### PR TITLE
Minor performance improvements

### DIFF
--- a/addons/hashes/fnc_hashSet.sqf
+++ b/addons/hashes/fnc_hashSet.sqf
@@ -30,12 +30,8 @@ if (isNil "_value") then { _value = nil};
 if (isNil "_key") exitWith {_hash};
 if (isNil "_hash") exitWith {_hash;};
 
-
-if (isNil "BIS_fnc_areEqual") then { LOG( "WARNING: BIS_fnc_areEqual is Nil") };
-
 // Work out whether the new value is the default value for this assoc.
-_isDefault = [if (isNil "_value") then { nil } else { _value },
-	_hash select HASH_DEFAULT_VALUE] call (uiNamespace getVariable "BIS_fnc_areEqual");
+_isDefault = if (isNil "_value") then { false } else { _value isEqualTo (_hash select HASH_DEFAULT_VALUE)};
 
 _index = (_hash select HASH_KEYS) find _key;
 if (_index >= 0) then

--- a/addons/network/fnc_publicVariable.sqf
+++ b/addons/network/fnc_publicVariable.sqf
@@ -4,7 +4,7 @@ Function: CBA_fnc_publicVariable
 Description:
 	CBA_fnc_publicVariable does only broadcast the new value if it doesn't exist in missionNamespace or the new value is different to the one in missionNamespace.
 	Checks also for different types. Nil as value gets always broadcasted.
-	
+
 	Should reduce network traffic.
 
 Parameters:
@@ -52,7 +52,7 @@ _s = if (typeName _value != typeName _var) then {
 			((_var && {_value}) || {(!_var && {!_value})})
 		};
 		case "ARRAY": {
-			([_var, _value] call (uiNamespace getVariable "BIS_fnc_areEqual"))
+			(_var isEqualTo _value)
 		};
 		case "CODE": {
 			false

--- a/addons/network/fnc_setVarNet.sqf
+++ b/addons/network/fnc_setVarNet.sqf
@@ -4,7 +4,7 @@ Function: CBA_fnc_setVarNet
 Description:
 	Same as setVariable ["name",var, true] but only broadcasts when the value of var is different to the one which is already saved in the variable space.
 	Checks also for different types. Nil as value gets always broadcasted.
-	
+
 	Should reduce network traffic.
 
 Parameters:
@@ -54,7 +54,7 @@ _s = if (typeName _value != typeName _var) then {
 			((_var && {_value}) || {(!_var && {!_value})})
 		};
 		case "ARRAY": {
-			([_var, _value] call (uiNamespace getVariable "BIS_fnc_areEqual"))
+			(_var isEqualTo _value)
 		};
 		case "CODE": {
 			false

--- a/addons/strings/fnc_strLen.sqf
+++ b/addons/strings/fnc_strLen.sqf
@@ -29,4 +29,4 @@ SCRIPT(strLen);
 
 // ----------------------------------------------------------------------------
 
-count (toArray (_this select 0)); // Return.
+count (_this select 0); // Return.


### PR DESCRIPTION
Switched out some BIS functions for script commands. Also updated strLen to make use of count directly, it's no longer required to make the string an array first.

Measurement:
21:24:53 "isEqualTo: true - 0"
21:24:53 "BIS_fnc_areEqual: true - 0.259995"

Tested using:
```sqf
call {
_testArray1 = [];
_testArray2 = [];

while {count _testArray1 < 1000} do {
    _testArray1 pushback [908509,539,"",9400];
    _testArray2 pushback [908509,539,"",9400];
};

_startTime = diag_tickTime;
_val = (_testArray1 isEqualTo _testArray2);
_endTime = diag_tickTime;


_startTime2 = diag_tickTime;
_val2 = [_testArray1, _testArray2] call BIS_fnc_areEqual;
_endTime2 = diag_tickTime;

diag_log format ["isEqualTo: %1 - %2", _val, _endTime - _startTime];
diag_log format ["BIS_fnc_areEqual: %1 - %2", _val2, _endTime2 - _startTime2];
};
```