### PR TITLE
CBA UI - params support in code exec

### DIFF
--- a/addons/ui/flexiMenu/fnc_execute.sqf
+++ b/addons/ui/flexiMenu/fnc_execute.sqf
@@ -4,11 +4,14 @@
 //-----------------------------------------------------------------------------
 #include "\x\cba\addons\ui\script_component.hpp"
 
-private["_action", "_subMenu", "_multiReselect", "_useListBox", "_subMenuSource", "_params", "_pathName"];
+private["_arrayID", "_actionData", "_action", "_subMenu", "_multiReselect", "_useListBox", "_subMenuSource", "_params", "_pathName", "_actionCode", "_actionParams"];
 
-_action = _this select 0;
-_subMenu = _this select 1;
-_multiReselect = _this select 2;
+_arrayID = _this;
+_actionData = GVAR(menuActionData) select _arrayID;
+
+_action = _actionData select 0;
+_subMenu = _actionData select 1;
+_multiReselect = _actionData select 2;
 //-----------------------------------------------------------------------------
 // indicates an option/button was selected, (to allow menu to close upon release of interact key), except if _multiReselect enabled.
 if (_multiReselect == 0) then {
@@ -36,11 +39,21 @@ if (_useListBox == 0 && {_multiReselect == 0}) then { // if using embedded listB
 };
 //-----------------------------------------------------------------------------
 // execute main menu action (unless submenu)
-if (typeName _action == "CODE") then {
-    call _action
+if (typeName _action == typename []) then {
+    _actionParams = _action select 0;
+    _actionCode = _action select 1;
 } else {
-    if (_action != "") then {
-        call compile _action;
+    _actionParams = 1;
+    _actionCode = _action;
+};
+
+if (typeName _actionCode == typename {}) then {
+    _actionParams call _actionCode
+} else {
+    if (typename _actionCode == typename "") then {
+        if(_actionCode != "") then {
+            _actionParams call compile _actionCode;
+        };
     };
 };
 

--- a/addons/ui/flexiMenu/fnc_getMenuOption.sqf
+++ b/addons/ui/flexiMenu/fnc_getMenuOption.sqf
@@ -10,7 +10,7 @@
 private["_menuDefs0", "_menuDef", "_fastPartialResult",
     "_result", "_caption", "_action", "_actionOptions", "_icon", "_tooltip", "_subMenu", "_shortcut_DIK", "_visible", "_enabled",
     "_array", "_index", "_containCaret", "_asciiKey", "_iconFolder", "_multiReselect",
-    "_keyName", "_offset"];
+    "_keyName", "_offset", "_arrayID"];
 
 _menuDefs0 = _this select 0;
 _menuDef = _this select 1;
@@ -156,10 +156,12 @@ if (!_fastPartialResult && {_icon != ""}) then {
 };
 //-----------------------------------------------------------------------------
 if (_caption != "") then {
+    _arrayID = count GVAR(menuActionData);
     _actionOptions = [_action, _subMenu, _multiReselect];
+    GVAR(menuActionData) set [_arrayID, _actionOptions];
 
     // TODO: Consider changing _action array item from string to type code.
-    _action = format ["%1 call %2", _actionOptions, QUOTE(FUNC(execute))];
+    _action = format ["%1 call %2", _arrayID, QUOTE(FUNC(execute))];
 };
 //-----------------------------------------------------------------------------
 _result = [];

--- a/addons/ui/flexiMenu/fnc_menu.sqf
+++ b/addons/ui/flexiMenu/fnc_menu.sqf
@@ -158,6 +158,7 @@ if (GVAR(hotKeyColor) == "") then {
 };
 
 //-----------------------------------------------------------------------------
+GVAR(menuActionData) = [];
 _commitList = [];
 { // forEach
     if (count _x >= 2) then { // all essential array items exist


### PR DESCRIPTION
Support for params in cba ui with backwards compatibility

Example:
```
[
    ["Menu Caption", "flexiMenu resource dialog", "optional icon folder", menuStayOpenUponSelect],
    [
        [
            "caption",
            [name player, {hint format ["my name is %1", _this];}],
            "icon",
            "tooltip",
            {"submenu"|["menuName", "", {0/1}]},
            -1,
            {0|1/"0"|"1"/false|true},
            {-1|0|1/"-1"|"0"|"1"/false|true}]
    ]
]
```