### PR TITLE
Restore XEH fired EH for Heli_Attack_01_base_F

### DIFF
--- a/addons/xeh_a3/CfgEventHandlers.hpp
+++ b/addons/xeh_a3/CfgEventHandlers.hpp
@@ -10,6 +10,9 @@ class Extended_firedBIS_Eventhandlers {
         {
                 SLX_BIS = "_this call (uinamespace getvariable 'BIS_fnc_effectFired')";
         };
+        class Helicopter_Base_F: Helicopter {
+        		SLX_BIS = "";
+        };
         class Heli_Attack_01_base_F /* : Helicopter_Base_F */ {
                 SLX_BIS = "_this call (uinamespace getvariable 'BIS_fnc_effectFired')";
         };

--- a/addons/xeh_a3/CfgVehicles.hpp
+++ b/addons/xeh_a3/CfgVehicles.hpp
@@ -69,10 +69,14 @@ class CfgVehicles {
 
     class Helicopter;
     class Helicopter_Base_F: Helicopter {
-        //  delete Eventhandlers;
+        class Eventhandlers: Eventhandlers {
+            DELETE_EVENTHANDLERS
+        };
     };
     class Heli_Attack_01_base_F: Helicopter_Base_F {
-        // delete Eventhandlers; // Eventhandlers
+        class Eventhandlers: Eventhandlers {
+            DELETE_EVENTHANDLERS
+        };
     };
     class Heli_Light_01_unarmed_base_F;
     class Heli_Light_01_civil_base_F: Heli_Light_01_unarmed_base_F {


### PR DESCRIPTION
Enable XEH for Helicopter_Base_F and disable its fired EH, just like the original config. Also, make sure the descendant Heli_Attack_01_base_F class has the stock BIS fired EH restored.