### PR TITLE
Restore XEH init EH for the BLUFOR FIA units.

### DIFF
--- a/addons/xeh_a3/CfgVehicles.hpp
+++ b/addons/xeh_a3/CfgVehicles.hpp
@@ -211,6 +211,12 @@ class CfgVehicles {
             DELETE_EVENTHANDLERS
         };
     };
+    class SoldierGB;
+    class I_G_Soldier_base_F: SoldierGB {
+        class Eventhandlers: Eventhandlers {
+            DELETE_EVENTHANDLERS
+        };
+    };
 
     class LandVehicle;
     class Car: LandVehicle {


### PR DESCRIPTION
The west FIA units were missing the XEH init event handler. This caused problems such as missing self-interaction functionality in combination with ACE.  