### PR TITLE
Move the XEH initialization out of the init event handler.

### DIFF
--- a/addons/xeh/CfgFunctions.hpp
+++ b/addons/xeh/CfgFunctions.hpp
@@ -1,0 +1,15 @@
+class CfgFunctions
+{
+    class CBA
+    {
+        class XEH
+        {
+            class initXEH
+            {
+                preInit = 1;
+                file = "\x\cba\addons\xeh\init_pre.sqf";
+            };
+        };
+    };
+};
+

--- a/addons/xeh/config.cpp
+++ b/addons/xeh/config.cpp
@@ -5,4 +5,5 @@
 
 #include "CfgPatches.hpp"
 #include "CfgEventHandlers.hpp"
+#include "CfgFunctions.hpp"
 #include "CfgVehicles.hpp"

--- a/addons/xeh/script_xeh.hpp
+++ b/addons/xeh/script_xeh.hpp
@@ -2,7 +2,7 @@
 // MACRO: EXTENDED_EVENTHANDLERS
 // XEH uses all existing event handlers
 /////////////////////////////////////////////////////////////////////////////////
-#define EXTENDED_EVENTHANDLERS init = QUOTE(if(isNil'SLX_XEH_MACHINE')then{call compile preProcessFileLineNumbers '\x\cba\addons\xeh\init_pre.sqf'};_this call SLX_XEH_EH_Init); \
+#define EXTENDED_EVENTHANDLERS init = "_this call SLX_XEH_EH_Init"; \
 fired              = "_this call SLX_XEH_EH_Fired"; \
 animChanged        = "_this call SLX_XEH_EH_AnimChanged"; \
 animDone           = "_this call SLX_XEH_EH_AnimDone"; \


### PR DESCRIPTION
We can use the BIS CfgFunctions system to initialize XEH. That way, there's no need to have a conditional expression in the XEH init event handler.