### PR TITLE
Created optional addon to enable an automatic 'add XEH to addons that…

### DIFF
--- a/addons/xeh/fnc_support_monitor.sqf
+++ b/addons/xeh/fnc_support_monitor.sqf
@@ -28,14 +28,8 @@ if !(isClass _cfg) exitWith {
 _XEH = false;
 _init = _cfg >> "init";
 if (isText _init) then {
-    _initAr = toArray(getText(_init));
-    if (count _initAr > 11) then {
-        _ar = [];
-        for "_i" from 0 to 11 do {
-            PUSH(_ar,_initAr select _i);
-        };
-        _XEH = (toString(_ar) == "if(isNil'SLX");
-    };
+    _txt = getText(_init);
+    _XEH = _txt find "_this call SLX_XEH_EH_Init" > -1;
 };
 
 if (_XEH) then {

--- a/addons/xeh/init_post.sqf
+++ b/addons/xeh/init_post.sqf
@@ -69,8 +69,11 @@ if (!isDedicated && {!isNull player}) then { // isNull player check is for Main 
     };
 };
 
-// XEH for non XEH supported addons
-//SLX_XEH_STR spawn COMPILE_FILE2(\x\cba\addons\xeh\supportMonitor.sqf);
+// Optional: XEH for non XEH supported addons
+#define SUPMON configFile>>"CfgSettings">>"CBA">>"XEH">>"supportMonitor"
+if (isNumber(SUPMON) && getNumber(SUPMON) == 1) then {
+    SLX_XEH_STR spawn COMPILE_FILE2(\x\cba\addons\xeh\supportMonitor.sqf);
+};
 
 SLX_XEH_MACHINE set [8, true];
 

--- a/addons/xeh/supportMonitor.sqf
+++ b/addons/xeh/supportMonitor.sqf
@@ -42,4 +42,4 @@ _fnc = {
     };
 };
 
-[_fnc, 3, [(count vehicles), (count allUnits), vehicles, allUnits]] call cba_fnc_addPerFrameHandler;
+[_fnc, 3, [0, 0, [], []]] call CBA_fnc_addPerFrameHandler;

--- a/optional/README.TXT
+++ b/optional/README.TXT
@@ -4,6 +4,8 @@ CBA: Community Base Addons - OPTIONAL ADDONS
 cba_cache_disable.pbo                  => Dev Tool. Copy this to your cba\addons if you want to disable CBA's caching of functions.
 cba_diagnostic_disable_xeh_logging.pbo => Copy this to your cba\addons if you want to disable all the extra RPT logging.
 cba_diagnostic_enable_logging.pbo      => DEV Tool. Copy this to your cba\addons if you want to enable more logging.
+cba_enable_auto_xeh.pbo                => This will add extended event handler (XEH) functionality to units and vehicles that
+                                          are not XEH enabled. This may cause unforeseen side effects.
 
 
 Background on CBA Caching

--- a/optional/enable_auto_xeh/$PBOPREFIX$.TXT
+++ b/optional/enable_auto_xeh/$PBOPREFIX$.TXT
@@ -1,0 +1,1 @@
+x\cba\addons\enable_auto_xeh

--- a/optional/enable_auto_xeh/config.cpp
+++ b/optional/enable_auto_xeh/config.cpp
@@ -1,0 +1,26 @@
+#include "script_component.hpp"
+
+class CfgPatches
+{
+	class ADDON
+	{
+		units[] = {};
+		weapons[] = {};
+		requiredVersion = REQUIRED_VERSION;
+		requiredAddons[] = {"Extended_EventHandlers", "CBA_Main"};
+		version = VERSION;
+		author[] = {"CBA Team"};
+		authorUrl = "https://github.com/CBATeam/CBA_A3";
+	};
+};
+
+class CfgSettings
+{
+	class CBA
+	{
+		class XEH
+		{
+			supportMonitor = 1;
+		};
+	};
+};

--- a/optional/enable_auto_xeh/script_component.hpp
+++ b/optional/enable_auto_xeh/script_component.hpp
@@ -1,0 +1,7 @@
+#define COMPONENT enable_auto_xeh
+#include "\x\cba\addons\main\script_mod.hpp"
+
+#undef REQUIRED_VERSION
+#define REQUIRED_VERSION 1.00
+
+#include "\x\cba\addons\main\script_macros.hpp"


### PR DESCRIPTION
This lets users have the old, pre-RC7 behaviour back where XEH will add XEH event processing to units and vehicles that do not have it out of the box.