### PR TITLE
Added LSTRING and CSTRING with External variants Macros

### DIFF
--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -953,7 +953,7 @@ Author:
     Jonpas
 ------------------------------------------- */
 #ifndef STRING_MACROS_GUARD
-    #def STRING_MACROS_GUARD
+#define STRING_MACROS_GUARD
     #define LSTRING(var1) QUOTE(TRIPLES(STR,ADDON,var1))
     #define LESTRING(var1,var2) QUOTE(TRIPLES(STR,DOUBLES(PREFIX,var1),var2))
     #define CSTRING(var1) QUOTE(TRIPLES($STR,ADDON,var1))

--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -952,19 +952,11 @@ Example:
 Author:
     Jonpas
 ------------------------------------------- */
-#ifndef LSTRING
+#ifndef STRING_MACROS_GUARD
+    #def STRING_MACROS_GUARD
     #define LSTRING(var1) QUOTE(TRIPLES(STR,ADDON,var1))
-#endif
-
-#ifndef LESTRING
     #define LESTRING(var1,var2) QUOTE(TRIPLES(STR,DOUBLES(PREFIX,var1),var2))
-#endif
-
-#ifndef CSTRING
     #define CSTRING(var1) QUOTE(TRIPLES($STR,ADDON,var1))
-#endif
-
-#ifndef ECSTRING
     #define ECSTRING(var1,var2) QUOTE(TRIPLES($STR,DOUBLES(PREFIX,var1),var2))
 #endif
 

--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -933,6 +933,41 @@ Author:
     private [#A,#B,#C,#D,#E,#F,#G,#H,#I]; \
     EXPLODE_9(ARRAY,A,B,C,D,E,F,G,H,I)
 
+/* -------------------------------------------
+Macro: xSTRING()
+    Get full string identifier from a stringtable owned by this component.
+
+Parameters:
+    VARIABLE - Partial name of global variable owned by this component [Any].
+
+Example:
+    ADDON is CBA_Balls.
+    (begin example)
+        // Localized String (localize command must still be used with it)
+        LSTRING(Example); // STR_CBA_Balls_Example;
+        // Config String (note the $)
+        CSTRING(Example); // $STR_CBA_Balls_Example;
+    (end)
+
+Author:
+    Jonpas
+------------------------------------------- */
+#ifndef LSTRING
+    #define LSTRING(var1) QUOTE(TRIPLES(STR,ADDON,var1))
+#endif
+
+#ifndef LESTRING
+    #define LESTRING(var1,var2) QUOTE(TRIPLES(STR,DOUBLES(PREFIX,var1),var2))
+#endif
+
+#ifndef CSTRING
+    #define CSTRING(var1) QUOTE(TRIPLES($STR,ADDON,var1))
+#endif
+
+#ifndef ECSTRING
+    #define ECSTRING(var1,var2) QUOTE(TRIPLES($STR,DOUBLES(PREFIX,var1),var2))
+#endif
+
 
 /* -------------------------------------------
 Group: Managing Function Parameters


### PR DESCRIPTION
As discussed with @ViperMaul this adds newly added Macros from ACE3 to CBA, with `#ifndef` for compatibility.

@ViperMaul should I be adding `#ifndef` on ACE3's side as well?