### PR TITLE
Enable XEH for the BIS hatchback cars. Fixes #65

### DIFF
--- a/addons/xeh_a3/CfgVehicles.hpp
+++ b/addons/xeh_a3/CfgVehicles.hpp
@@ -238,11 +238,15 @@ class CfgVehicles {
 
     class Hatchback_01_base_F;
     class C_Hatchback_01_F: Hatchback_01_base_F {
-        //    delete Eventhandlers; // Eventhandlers
+        class Eventhandlers: Eventhandlers {
+            DELETE_EVENTHANDLERS
+        };
     };
     class Hatchback_01_sport_base_F;
     class C_Hatchback_01_sport_F: Hatchback_01_sport_base_F {
-        //    delete Eventhandlers; // Eventhandlers
+        class Eventhandlers: Eventhandlers {
+            DELETE_EVENTHANDLERS
+        };
     };
 
     class Offroad_01_armed_base_F;


### PR DESCRIPTION
Replace the BIS event handlers with the XEH ones in order to give the hatchbacks XEH abilities.
