### PR TITLE
[COMMON - XEH_preInit.sqf] - Utilize IS_NILS macro

### DIFF
--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -67,7 +67,7 @@ FUNC(log) = {
 };
 
 // Nil check
-if (isNil "CBA_NIL_CHECKED") then { CBA_NIL_CHECKED = false };
+ISNILS(CBA_NIL_CHECKED,false);
 
 // Prepare all functions
 DEPRECATE(fAddMagazine,fnc_addMagazine);


### PR DESCRIPTION
Changed "isNil" check to use "ISNILS" macro