### PR TITLE
Restore the CBA keybinding list in the briefing. Fixes #44

### DIFF
--- a/addons/help/XEH_postClientInit.sqf
+++ b/addons/help/XEH_postClientInit.sqf
@@ -20,10 +20,10 @@ _pkeynam = {
     _shift = if(_shift) then {42} else {0};
     _ctrl = if(_ctrl) then {56} else {0};
     _alt = if(_alt) then {29} else {0};
-    _keys = [_shift,_ctrl,_alt,_key];
+    _keys = [_shift,_ctrl,_alt,_dikKey];
     _keystrg = "^";
     {
-        _knaml = call compile format["format['%2',%1]",(keyName _x),"%1"];
+        _knaml = [cba_keybinding_dikDecToStringTable, format ["%1", _x]] call BIS_fnc_getFromPairs;
         _knaml = [_knaml, " "] call (uiNamespace getVariable "CBA_fnc_split");
         _knam = "^";
         {_k = _x; _knam = _knam + " " + _k} forEach _knaml;
@@ -57,12 +57,12 @@ _h = _pkeynam spawn {
                     _displayName = (_actionEntry select 0) select 0;
                 };
                 _keyBind = _actionEntry select 1;
-                _key = _keyBind select 0;
+                _dikKey = _keyBind select 0;
                 _mod = _keyBind select 1;
                 _shift = _mod select 0;
                 _ctrl = _mod select 1;
                 _alt = _mod select 2;
-                _keyn = [_key,_shift,_ctrl,_alt] call _this;
+                _keyn = call _this;
     
                 _text = _text + format ["    %1: <font color='#c48214'>%2</font><br/>", _displayName, _keyn];
             };

--- a/addons/help/XEH_postClientInit.sqf
+++ b/addons/help/XEH_postClientInit.sqf
@@ -64,7 +64,7 @@ _h = _pkeynam spawn {
                 _alt = _mod select 2;
                 _keyn = [_key,_shift,_ctrl,_alt] call _this;
     
-                _text = _text + format ["    %1: %2<br/>", _displayName, _keyn];
+                _text = _text + format ["    %1: <font color='#c48214'>%2</font><br/>", _displayName, _keyn];
             };
             _text = _text + "<br/>";
         };

--- a/addons/help/XEH_postClientInit.sqf
+++ b/addons/help/XEH_postClientInit.sqf
@@ -56,6 +56,9 @@ _h = _pkeynam spawn {
                 if (typeName _displayName == typeName []) then {
                     _displayName = (_actionEntry select 0) select 0;
                 };
+                // Escape < and >
+                _displayName = [_displayName, "<", "&lt;"] call (uiNamespace getVariable "CBA_fnc_replace");
+                _displayName = [_displayName, ">", "&gt;"] call (uiNamespace getVariable "CBA_fnc_replace");
                 _keyBind = _actionEntry select 1;
                 _dikKey = _keyBind select 0;
                 _mod = _keyBind select 1;

--- a/addons/help/XEH_postClientInit.sqf
+++ b/addons/help/XEH_postClientInit.sqf
@@ -28,10 +28,10 @@ _pkeynam = {
         _knam = "^";
         {_k = _x; _knam = _knam + " " + _k} forEach _knaml;
         _knam = [_knam, "^ ", ""] call (uiNamespace getVariable "CBA_fnc_replace");
-        _keystrg = _keystrg + "-" + _knam;
+        _keystrg = _keystrg + "+" + _knam;
     } forEach _keys;
     _keystrg = [_keystrg, "^ ", ""] call (uiNamespace getVariable "CBA_fnc_replace");
-    _keystrg = [_keystrg, "^-", ""] call (uiNamespace getVariable "CBA_fnc_replace");
+    _keystrg = [_keystrg, "^+", ""] call (uiNamespace getVariable "CBA_fnc_replace");
     _keystrg = [_keystrg, "^", "None"] call (uiNamespace getVariable "CBA_fnc_replace");
     _keystrg
 };

--- a/addons/help/XEH_postClientInit.sqf
+++ b/addons/help/XEH_postClientInit.sqf
@@ -11,6 +11,67 @@ TRACE_2("",GVAR(CREDITS_Info), GVAR(CREDITS_CfgPatches));
     if (isNil QGVAR(CREDITS_CfgPatches)) then { diag_log "CREDITS_CfgPatches is nil! CBA_fnc_hashGet must have failed"; TRACE_1("",CBA_fnc_hashGet)};
 #endif
 
+private ["_pkeynam", "_shift", "_ctrl", "_alt", "_keys", "_key", "_keystrg",
+ "_mod", "_knaml", "_knam", "_i", "_j", "_k", "_text",  "_names", "_handlers",
+ "_name", "_handler", "_actionNames", "_actionEntries", "_actionName",
+ "_displayName", "_keyn"];
+ 
+_pkeynam = {
+    _shift = if(_shift) then {42} else {0};
+    _ctrl = if(_ctrl) then {56} else {0};
+    _alt = if(_alt) then {29} else {0};
+    _keys = [_shift,_ctrl,_alt,_key];
+    _keystrg = "^";
+    {
+        _knaml = call compile format["format['%2',%1]",(keyName _x),"%1"];
+        _knaml = [_knaml, " "] call (uiNamespace getVariable "CBA_fnc_split");
+        _knam = "^";
+        {_k = _x; _knam = _knam + " " + _k} forEach _knaml;
+        _knam = [_knam, "^ ", ""] call (uiNamespace getVariable "CBA_fnc_replace");
+        _keystrg = _keystrg + "-" + _knam;
+    } forEach _keys;
+    _keystrg = [_keystrg, "^ ", ""] call (uiNamespace getVariable "CBA_fnc_replace");
+    _keystrg = [_keystrg, "^-", ""] call (uiNamespace getVariable "CBA_fnc_replace");
+    _keystrg = [_keystrg, "^", "None"] call (uiNamespace getVariable "CBA_fnc_replace");
+    _keystrg
+};
+
+_h = _pkeynam spawn {
+    _text = "";
+    _names = cba_keybinding_handlers select 0;
+    _handlers = cba_keybinding_handlers select 1;
+    for "_i" from 0 to (count _names) do {
+        _name = _names select _i;
+        _handler = _handlers select _i;
+        if (!isNil "_name") then {
+            _text = _text + format ["%1:<br/>", _name];
+            _actionNames = _handler select 0;
+            _actionEntries = _handler select 1;
+            
+            for "_j" from 0 to (count _actionNames - 1) do {
+                _actionName = _actionNames select _j;
+                _actionEntry = _actionEntries select _j;
+        
+                _displayName = _actionEntry select 0;
+                if (typeName _displayName == typeName []) then {
+                    _displayName = (_actionEntry select 0) select 0;
+                };
+                _keyBind = _actionEntry select 1;
+                _key = _keyBind select 0;
+                _mod = _keyBind select 1;
+                _shift = _mod select 0;
+                _ctrl = _mod select 1;
+                _alt = _mod select 2;
+                _keyn = [_key,_shift,_ctrl,_alt] call _this;
+    
+                _text = _text + format ["    %1: %2<br/>", _displayName, _keyn];
+            };
+            _text = _text + "<br/>";
+        };
+    };
+    player createDiaryRecord ["CBA_docs", [(localize "STR_DN_CBA_HELP_KEYS"), _text]];
+};
+
 player createDiarySubject ["CBA_docs", "CBA"];
 //player createDiaryRecord ["CBA_docs", [(localize "STR_DN_CBA_WEBSITE_WIKI"), "http://dev-heaven.net/projects/cca"]];
 if (!isNil QGVAR(CREDITS_CfgPatches)) then { player createDiaryRecord ["CBA_docs", [(localize "STR_DN_CBA_CREDITS_ADDONS"), GVAR(CREDITS_CfgPatches)]];};

--- a/addons/help/XEH_postClientInit.sqf
+++ b/addons/help/XEH_postClientInit.sqf
@@ -33,6 +33,9 @@ _pkeynam = {
     _keystrg = [_keystrg, "^ ", ""] call (uiNamespace getVariable "CBA_fnc_replace");
     _keystrg = [_keystrg, "^+", ""] call (uiNamespace getVariable "CBA_fnc_replace");
     _keystrg = [_keystrg, "^", "None"] call (uiNamespace getVariable "CBA_fnc_replace");
+    _keystrg = [_keystrg, "LAlt", "Alt"] call (uiNamespace getVariable "CBA_fnc_replace");
+    _keystrg = [_keystrg, "LCtrl", "Ctrl"] call (uiNamespace getVariable "CBA_fnc_replace");
+    _keystrg = [_keystrg, "LShift", "Shift"] call (uiNamespace getVariable "CBA_fnc_replace");
     _keystrg
 };
 

--- a/addons/help/config.cpp
+++ b/addons/help/config.cpp
@@ -4,7 +4,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = { "cba_common", "CBA_hashes","A3_UI_F"  };
+        requiredAddons[] = { "cba_common", "cba_hashes", "cba_keybinding", "A3_UI_F" };
         version = VERSION;
         author[] = {"alef", "Rocko", "Sickboy"};
         authorUrl = "http://dev-heaven.net/projects/cca";


### PR DESCRIPTION
This will display all key binds that use the CBA key binding system in the briefing, under the CBA->Keybindings diary record section.