### PR TITLE
New CBA_fnc_randPosArea

### DIFF
--- a/addons/common/CfgFunctions.hpp
+++ b/addons/common/CfgFunctions.hpp
@@ -354,8 +354,14 @@ class CfgFunctions
             // CBA_fnc_randPos
             class randPos
             {
-                description = "A function used to randomize a position around a given center";
+                description = "A function used to randomize a position around a given center.";
                 file = "\x\cba\addons\common\fnc_randPos.sqf";
+            };
+            // CBA_fnc_randPosArea
+            class randPosArea
+            {
+                description = "A function used to randomize a position within a given zone.";
+                file = "\x\cba\addons\common\fnc_randPosArea.sqf";
             };
             // CBA_fnc_realHeight
             class realHeight

--- a/addons/common/fnc_randPosArea.sqf
+++ b/addons/common/fnc_randPosArea.sqf
@@ -43,8 +43,6 @@ switch (typeName _zRef) do {
     };
 };
 
-if (_zSize isEqualTo []) exitWith {[0,0,0]};
-
 private ["_x","_y","_a","_b","_rho","_phi","_x1","_x2","_y1","_y2"];
 if (_zRect) then {
     _x = _zSize select 0;

--- a/addons/common/fnc_randPosArea.sqf
+++ b/addons/common/fnc_randPosArea.sqf
@@ -30,7 +30,7 @@ _perimeter = if (count _this > 1) then {_this select 1} else {false};
 
 switch (typeName _zRef) do {
     case "STRING" : {
-        if !((markerShape _zRef) in ["RECTANGLE","ELLIPSE"]) then {
+        if ((markerShape _zRef) in ["RECTANGLE","ELLIPSE"]) then {
             _zSize = markerSize _zRef;
             _zDir = markerDir _zRef;
             _zRect = (markerShape _zRef) == "RECTANGLE";

--- a/addons/common/fnc_randPosArea.sqf
+++ b/addons/common/fnc_randPosArea.sqf
@@ -1,0 +1,77 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_randPosArea
+
+Description:
+    Find a random (uniformly distributed) position within the given area.
+
+    * You can <CBA_fnc_randPos> to find a position within a simple radius.
+
+Parameters:
+    _zone - The zone to find a position within [Marker or Trigger]
+    _perimeter - True to return only positions on the area perimeter [Boolean, defaults to false]
+
+Returns:
+    Position [Array]
+
+Examples:
+   (begin example)
+   _position = [marker, true] call CBA_fnc_randPosArea;
+
+   _position = [trigger] call CBA_fnc_randPosArea;
+   (end)
+
+Author:
+    SilentSpike 2015-07-06
+---------------------------------------------------------------------------- */
+
+private ["_zRef","_zSize","_zDir","_zRect","_zPos","_perimeter","_posVector"];
+_zRef = _this select 0;
+_perimeter = if (count _this > 1) then {_this select 1} else {false};
+
+switch (typeName _zRef) do {
+    case "STRING" : {
+        _zSize = markerSize _zRef;
+        _zDir = markerDir _zRef;
+        _zRect = (markerShape _zRef) == "RECTANGLE";
+        _zPos = markerPos _zRef;
+    };
+    case "OBJECT" : {
+        _zSize = triggerArea _zRef;
+        _zDir = _zSize select 2;
+        _zRect = _zSize select 3;
+        _zPos = getPos _zRef;
+    };
+};
+
+if (_zSize isEqualTo []) exitWith {[0,0,0]};
+
+private ["_x","_y","_a","_b","_rho","_phi","_x1","_x2","_y1","_y2"];
+if (_zRect) then {
+    _x = _zSize select 0;
+    _y = _zSize select 1;
+    _a = _x*2;
+    _b = _y*2;
+
+    if (_perimeter) then {
+        _rho = random (2*(_a + _b));
+
+        _x1 = (_rho min _a);
+        _y1 = ((_rho - _x1) min _b) max 0;
+        _x2 = ((_rho - _x1 - _y1) min _a) max 0;
+        _y2 = ((_rho - _x1 - _y1 - _x2) min _b) max 0;
+        _posVector = [(_x1 - _x2) - _x, (_y1 - _y2) - _y, 0];
+    } else {
+        _posVector = [random(_a) - _x, random(_b) - _y, 0];
+    };
+} else {
+    _rho = if (_perimeter) then {1} else {random 1};
+    _phi = random 360;
+    _x = sqrt(_rho) * cos(_phi);
+    _y = sqrt(_rho) * sin(_phi);
+
+    _posVector = [_x * (_zSize select 0), _y * (_zSize select 1), 0];
+};
+
+_posVector = [_posVector, -_zDir] call BIS_fnc_rotateVector2D;
+
+_zPos vectorAdd _posVector

--- a/addons/common/fnc_randPosArea.sqf
+++ b/addons/common/fnc_randPosArea.sqf
@@ -38,7 +38,7 @@ switch (typeName _zRef) do {
         };
     };
     case "OBJECT" : {
-        if ((triggerArea _zRef) isEqualTo []) then {
+        if !((triggerArea _zRef) isEqualTo []) then {
             _zSize = triggerArea _zRef;
             _zDir = _zSize select 2;
             _zRect = _zSize select 3;

--- a/addons/common/fnc_randPosArea.sqf
+++ b/addons/common/fnc_randPosArea.sqf
@@ -11,7 +11,7 @@ Parameters:
     _perimeter - True to return only positions on the area perimeter [Boolean, defaults to false]
 
 Returns:
-    Position [Array]
+    Position [Array] (Empty array if non-area object/marker was given)
 
 Examples:
    (begin example)
@@ -30,18 +30,24 @@ _perimeter = if (count _this > 1) then {_this select 1} else {false};
 
 switch (typeName _zRef) do {
     case "STRING" : {
-        _zSize = markerSize _zRef;
-        _zDir = markerDir _zRef;
-        _zRect = (markerShape _zRef) == "RECTANGLE";
-        _zPos = markerPos _zRef;
+        if !((markerShape _zRef) in ["RECTANGLE","ELLIPSE"]) then {
+            _zSize = markerSize _zRef;
+            _zDir = markerDir _zRef;
+            _zRect = (markerShape _zRef) == "RECTANGLE";
+            _zPos = markerPos _zRef;
+        };
     };
     case "OBJECT" : {
-        _zSize = triggerArea _zRef;
-        _zDir = _zSize select 2;
-        _zRect = _zSize select 3;
-        _zPos = getPos _zRef;
+        if ((triggerArea _zRef) isEqualTo []) then {
+            _zSize = triggerArea _zRef;
+            _zDir = _zSize select 2;
+            _zRect = _zSize select 3;
+            _zPos = getPos _zRef;
+        };
     };
 };
+
+if (isNil "_zSize") exitWith {[]};
 
 private ["_x","_y","_a","_b","_rho","_phi","_x1","_x2","_y1","_y2"];
 if (_zRect) then {


### PR DESCRIPTION
Adds a new function (CBA_fnc_randPosArea) to return a random position within a given marker/trigger:

- Supports ellipses and rectangles (and rotation)
- Distribution should be uniform
- Optional boolen parameter can be used to return only positions on the perimeter
- Returns empty array if non-area is passed in (either "ICON" marker or a non-trigger object)