### PR TITLE
default_param: Gracefully handle nil array

### DIFF
--- a/addons/common/fnc_defaultParam.sqf
+++ b/addons/common/fnc_defaultParam.sqf
@@ -32,4 +32,6 @@ SCRIPT(defaultParam);
 // -----------------------------------------------------------------------------
 PARAMS_3(_params,_index,_defaultValue);
 
+ISNILS(_params,[]);
+
 _params param [_index,_defaultValue]

--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -1023,8 +1023,9 @@ Author:
     Spooner
 ------------------------------------------- */
 #define DEFAULT_PARAM(INDEX,NAME,DEF_VALUE) \
-    private #NAME; \
-    NAME = RETNIL(_this) param [INDEX, DEF_VALUE]; \
+    private [#NAME,"_this"]; \
+    ISNILS(_this,[]); \
+    NAME = _this param [INDEX, DEF_VALUE]; \
     TRACE_3("DEFAULT_PARAM",INDEX,NAME,DEF_VALUE)
 
 /* -------------------------------------------


### PR DESCRIPTION
Turns out the new parameter commands don't play nice when the input array is nil. This updates the default_param macro to correctly handle nil values again (and the function).