### PR TITLE
Added XEH support for SeatSwitched event handlers. Fixes #107

### DIFF
--- a/addons/xeh/CfgEventHandlers.hpp
+++ b/addons/xeh/CfgEventHandlers.hpp
@@ -57,6 +57,7 @@ class Extended_MPRespawn_EventHandlers {};
 */
 class Extended_Put_EventHandlers {};
 class Extended_Take_EventHandlers {};
+class Extended_SeatSwitched_EventHandlers {};
 class Extended_SoundPlayed_EventHandlers {};
 class Extended_WeaponAssembled_EventHandlers {};
 class Extended_WeaponDisassembled_EventHandlers {};

--- a/addons/xeh/init_eh.sqf
+++ b/addons/xeh/init_eh.sqf
@@ -67,6 +67,7 @@ XEH_FUNC(Local);
 //XEH_FUNC(MPRespawn);
 XEH_FUNC(Put);
 XEH_FUNC(Respawn);
+XEH_FUNC(SeatSwitched);
 XEH_FUNC(Take);
 XEH_FUNC(WeaponAssembled);
 XEH_FUNC(WeaponDisassembled);

--- a/addons/xeh/script_component.hpp
+++ b/addons/xeh/script_component.hpp
@@ -20,8 +20,8 @@
     /* "HandleDamage", */ "HandleHeal", "Hit", "HitPart", "IncomingMissile", \
     "InventoryClosed", "InventoryOpened", \
     "Killed", "LandedTouchDown", "LandedStopped", "Local", /* "MPHit", */ \
-    /* "MPKilled", "MPRespawn", */ "Respawn", "Put", "Take", "SoundPlayed", \
-    "WeaponAssembled", "WeaponDisassembled"
+    /* "MPKilled", "MPRespawn", */ "Respawn", "Put", "Take", "SeatSwitched", \
+    "SoundPlayed", "WeaponAssembled", "WeaponDisassembled"
 #define XEH_CUSTOM_EVENTS "GetInMan", "GetOutMan", "FiredBis"
 
 

--- a/addons/xeh/script_xeh.hpp
+++ b/addons/xeh/script_xeh.hpp
@@ -40,6 +40,7 @@ local              = "_this call SLX_XEH_EH_Local"; \
 respawn            = "_this call SLX_XEH_EH_Respawn"; \
 put                = "_this call SLX_XEH_EH_Put"; \
 take               = "_this call SLX_XEH_EH_Take"; \
+seatSwitched       = "_this call SLX_XEH_EH_SeatSwitched"; \
 soundPlayed        = "_this call SLX_XEH_EH_SoundPlayed"; \
 weaponAssembled    = "_this call SLX_XEH_EH_WeaponAssembled"; \
 weaponDisAssembled = "_this call SLX_XEH_EH_WeaponDisassembled";
@@ -103,6 +104,7 @@ delete local;  \
 delete respawn;  \
 delete put;  \
 delete take; \
+delete seatSwitched; \
 delete soundPlayed; \
 delete weaponAssembled; \
 delete weaponDisAssembled;


### PR DESCRIPTION
[SeatSwitched](https://community.bistudio.com/wiki/Arma_3:_Event_Handlers#SeatSwitched)

The event will be available in A3 1.50. This changeset is compatible with A3 1.48.