### PR TITLE
Split returns wrong value for long separator strings

### DIFF
--- a/addons/strings/fnc_split.sqf
+++ b/addons/strings/fnc_split.sqf
@@ -32,14 +32,14 @@ SCRIPT(split);
 // ----------------------------------------------------------------------------
 
 private ["_split", "_index", "_inputCount", "_separatorCount", "_find", "_lastWasSeperator"];
-params ["_input", ["_separator",""]];
+params [["_input",""], ["_separator",""]];
 _split = [];
 _index = 0;
 _inputCount = count _input;
 _separatorCount = count _separator;
 //Return array if split count > input count (Match default behavior):
-if (_separatorCount > _inputCount) exitWith {toArray _input};
-if (_separatorCount > 0) then {
+if (_separatorCount > _inputCount) exitWith {[_input]};
+if (_separatorCount > 1) then {
     _lastWasSeperator = true;
     while {_index < _inputCount} do {
         _find = (_input select [_index, (_inputCount - _index)]) find _separator;
@@ -63,8 +63,6 @@ if (_separatorCount > 0) then {
         _split pushBack "";
     };
 } else {
-    for "_index" from 0 to (_inputCount - 1) do {
-        _split pushBack (_input select [_index, 1]);
-    };
+    _split = _input splitString _separator;
 };
 _split

--- a/addons/strings/test_strings.sqf
+++ b/addons/strings/test_strings.sqf
@@ -41,6 +41,10 @@ _array = ["", "\"] call CBA_fnc_split;
 _expected = [];
 TEST_OP(str _array, ==, str _expected, _fn);
 
+_array = ["", ""] call CBA_fnc_split;
+_expected = [];
+TEST_OP(str _array, ==, str _expected, _fn);
+
 _array = ["\", "\"] call CBA_fnc_split;
 _expected = ["", ""];
 TEST_OP(str _array, ==, str _expected, _fn);
@@ -59,6 +63,18 @@ TEST_OP(str _array, ==, str _expected, _fn);
 
 _array = ["peas", ""] call CBA_fnc_split;
 _expected = ["p", "e", "a", "s"];
+TEST_OP(str _array, ==, str _expected, _fn);
+
+_array = ["abc", "abc"] call CBA_fnc_split;
+_expected = ["", ""];
+TEST_OP(str _array, ==, str _expected, _fn);
+
+_array = ["abc", "long"] call CBA_fnc_split;
+_expected = ["abc"];
+TEST_OP(str _array, ==, str _expected, _fn);
+
+_array = ["this\is\a\path\to\fnc_test.sqf","\fnc_"] call CBA_fnc_split;
+_expected = ["this\is\a\path\to", "test.sqf"];
 TEST_OP(str _array, ==, str _expected, _fn);
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
If CBA_fnc_split is asked to split an input string with a separator
string longer than the source string, the function will return an
array of ASCII values of the input string. The correct behavior
is to return the input string. Fixes #133.

Added a few more useful test cases for CBA_fnc_split.