### PR TITLE
Fix XEH EventHandler inheritance for chickens

### DIFF
--- a/addons/xeh_a3/CfgVehicles.hpp
+++ b/addons/xeh_a3/CfgVehicles.hpp
@@ -38,7 +38,12 @@ class CfgVehicles {
     };
     class Fowl_Base_F;
     class Cock_random_F: Fowl_Base_F {
-        delete Eventhandlers; // Eventhandlers
+        class Eventhandlers: Eventhandlers {
+            DELETE_EVENTHANDLERS
+        };
+    };
+    class Cock_white_F: Cock_random_F {
+        delete Eventhandlers; // Eventhandlers;
     };
 
     class FlagCarrierCore;


### PR DESCRIPTION
RPT: Cannot delete class EventHandlers, it is referenced somewhere (used
as a base class probably).