### PR TITLE
Added locality check to fnc_taskPatrol. Fixes #158

### DIFF
--- a/addons/ai/fnc_taskPatrol.sqf
+++ b/addons/ai/fnc_taskPatrol.sqf
@@ -39,6 +39,8 @@ Author:
 
 params ["_group", ["_position",[]], ["_radius",100], ["_count",3]];
 
+if (!local _group) exitWith {};
+
 _position = [_position,_group] select (_position isEqualTo []);
 
 _this =+ _this;


### PR DESCRIPTION
Only create waypoints where the affected group is local.