### PR TITLE
Fix missing \ in sample include

### DIFF
--- a/addons/main/script_macros_mission.hpp
+++ b/addons/main/script_macros_mission.hpp
@@ -21,7 +21,7 @@
 
     Usage:
         Define PREFIX and COMPONENT, then include this file:
-            #include "x\cba\addons\main\script_macros_mission.hpp"
+            #include "\x\cba\addons\main\script_macros_mission.hpp"
 */
 
 // TODO: Alternate COMPILE_FILE macros that add e.g "mission\"


### PR DESCRIPTION
The `script_macros_mission.hpp` file is in an addon and to find it, the path to the file needs a `\` in front.