### PR TITLE
Add removal of specific backpack and item from cargo functions

### DIFF
--- a/addons/common/CfgFunctions.hpp
+++ b/addons/common/CfgFunctions.hpp
@@ -372,25 +372,25 @@ class CfgFunctions
             // CBA_fnc_removeBackpackCargo
             class removeBackpackCargo
             {
-                description = "Function to remove specific backpacks from local cargo space.";
+                description = "Removes specific backpack(s) from local cargo space.";
                 file = "\x\cba\addons\common\fnc_removeBackpackCargo.sqf";
             };
             // CBA_fnc_removeBackpackCargoGlobal
             class removeBackpackCargoGlobal
             {
-                description = "Function to remove specific backpacks from global cargo space. MP synchronized.";
+                description = "Remove specific backpack(s) from global cargo space. MP synchronized.";
                 file = "\x\cba\addons\common\fnc_removeBackpackCargoGlobal.sqf";
             };
             // CBA_fnc_removeItemCargo
             class removeItemCargo
             {
-                description = "Function to remove specific items from local cargo space.";
+                description = "Removes specific item(s) from local cargo space.";
                 file = "\x\cba\addons\common\fnc_removeItemCargo.sqf";
             };
             // CBA_fnc_removeItemCargoGlobal
             class removeItemCargoGlobal
             {
-                description = "Function to remove specific items from global cargo space. MP synchronized.";
+                description = "Removes specific item(s) from global cargo space. MP synchronized.";
                 file = "\x\cba\addons\common\fnc_removeItemCargoGlobal.sqf";
             };
             // CBA_fnc_removeMagazine

--- a/addons/common/CfgFunctions.hpp
+++ b/addons/common/CfgFunctions.hpp
@@ -369,6 +369,30 @@ class CfgFunctions
                 description = "Real z coordinate of an object, for placing stuff on roofs, etc.";
                 file = "\x\cba\addons\common\fnc_realHeight.sqf";
             };
+            // CBA_fnc_removeBackpackCargo
+            class removeBackpackCargo
+            {
+                description = "Function to remove specific backpacks from local cargo space.";
+                file = "\x\cba\addons\common\fnc_removeBackpackCargo.sqf";
+            };
+            // CBA_fnc_removeBackpackCargoGlobal
+            class removeBackpackCargoGlobal
+            {
+                description = "Function to remove specific backpacks from global cargo space. MP synchronized.";
+                file = "\x\cba\addons\common\fnc_removeBackpackCargoGlobal.sqf";
+            };
+            // CBA_fnc_removeItemCargo
+            class removeItemCargo
+            {
+                description = "Function to remove specific items from local cargo space.";
+                file = "\x\cba\addons\common\fnc_removeItemCargo.sqf";
+            };
+            // CBA_fnc_removeItemCargoGlobal
+            class removeItemCargoGlobal
+            {
+                description = "Function to remove specific items from global cargo space. MP synchronized.";
+                file = "\x\cba\addons\common\fnc_removeItemCargoGlobal.sqf";
+            };
             // CBA_fnc_removeMagazine
             class removeMagazine
             {

--- a/addons/common/fnc_removeBackpackCargo.sqf
+++ b/addons/common/fnc_removeBackpackCargo.sqf
@@ -68,7 +68,7 @@ _count = round _count;
 // Returns array containing two arrays: [[type1, typeN, ...], [count1, countN, ...]]
 (getBackpackCargo _box) params ["_allItemsType", "_allItemsCount"];
 
-// Clear cargo space and readd the items as long its not the type in question
+// Clear cargo space and readd the items as long it's not the type in question
 local _returnVar = false;
 clearBackpackCargo _box;
 {

--- a/addons/common/fnc_removeBackpackCargo.sqf
+++ b/addons/common/fnc_removeBackpackCargo.sqf
@@ -1,0 +1,91 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_removeBackpackCargo
+
+Description:
+    Removes specific backpack(s) from local cargo space.
+
+    * Use <CBA_fnc_removeBackpackCargoGlobal> if you want to remove the backpack(s) in
+      global cargo space.
+
+Parameters:
+    _box - Object with cargo [Object]
+    _item - Classname of backpack(s) to remove [String]
+    _count - Number of backpack(s) to remove [Number] (Default: 1)
+
+Returns:
+    Success [Boolean]
+
+Examples:
+   (begin example)
+    // Remove 1 Kitbag Tan backpack locally from a box
+   _success = [myCoolBackpackBox, "B_Kitbag_cbr"] call CBA_fnc_removeBackpackCargo;
+
+   // Remove 2 Carryall Desert Camo backpacks locally from a box
+   _success = [myCoolBackpackBox, "B_Carryall_ocamo", 2] call CBA_fnc_removeBackpackCargo;
+   (end)
+
+Author:
+    Jonpas
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+SCRIPT(removeBackpackCargo);
+
+params ["_box", "_item", ["_count", 1]];
+
+if (typeName _box != "OBJECT") exitWith {
+    TRACE_2("Box not Object",_box,_item);
+    false
+};
+if (typeName _item != "STRING") exitWith {
+    TRACE_2("Item not String",_box,_item);
+    false
+};
+if (isNull _box) exitWith {
+    TRACE_2("Box isNull",_box,_item);
+    false
+};
+if (_item == "") exitWith {
+    TRACE_2("Empty Item",_box,_item);
+    false
+};
+if !(isClass (configFile >> "CfgVehicles" >> _item)) exitWith {
+    TRACE_2("Item does not exist in the game config",_box,_item);
+    false
+};
+if (typeName _count != "SCALAR") exitWith {
+    TRACE_3("Count is not a number",_box,_item,_count);
+    false
+};
+if (_count <= 0) exitWith {
+    TRACE_3("Count is not a positive number",_box,_item,_count);
+    false
+};
+
+// Ensure proper count
+_count = round _count;
+
+// Returns array containing two arrays: [[type1, typeN, ...], [count1, countN, ...]]
+(getBackpackCargo _box) params ["_allItemsType", "_allItemsCount"];
+
+// Clear cargo space and readd the items as long its not the type in question
+local _returnVar = false;
+clearBackpackCargo _box;
+{
+    local _itemCount = _allItemsCount select _forEachIndex;
+
+    if (_x == _item) then {
+        // Process removal
+        _returnVar = true;
+
+        _itemCount = _itemCount - _count;
+        if (_itemCount > 0) then {
+            // Add with new count
+            _box addBackpackCargo [_x, _itemCount];
+        };
+    } else {
+        // Readd only
+        _box addBackpackCargo [_x, _itemCount];
+    };
+} forEach _allItemsType;
+
+_returnVar

--- a/addons/common/fnc_removeBackpackCargo.sqf
+++ b/addons/common/fnc_removeBackpackCargo.sqf
@@ -3,6 +3,7 @@ Function: CBA_fnc_removeBackpackCargo
 
 Description:
     Removes specific backpack(s) from local cargo space.
+    Warning: Backpack's inventory information is lost.
 
     * Use <CBA_fnc_removeBackpackCargoGlobal> if you want to remove the backpack(s) in
       global cargo space.

--- a/addons/common/fnc_removeBackpackCargoGlobal.sqf
+++ b/addons/common/fnc_removeBackpackCargoGlobal.sqf
@@ -68,7 +68,7 @@ _count = round _count;
 // Returns array containing two arrays: [[type1, typeN, ...], [count1, countN, ...]]
 (getBackpackCargo _box) params ["_allItemsType", "_allItemsCount"];
 
-// Clear cargo space and readd the items as long its not the type in question
+// Clear cargo space and readd the items as long it's not the type in question
 local _returnVar = false;
 clearBackpackCargoGlobal _box;
 {

--- a/addons/common/fnc_removeBackpackCargoGlobal.sqf
+++ b/addons/common/fnc_removeBackpackCargoGlobal.sqf
@@ -3,6 +3,7 @@ Function: CBA_fnc_removeBackpackCargoGlobal
 
 Description:
     Removes specific backpack(s) from global cargo space. MP synchronized.
+    Warning: Backpack's inventory information is lost.
 
     * Use <CBA_fnc_removeBackpackCargo> if you want to remove the backpack(s) in
       local cargo space.

--- a/addons/common/fnc_removeBackpackCargoGlobal.sqf
+++ b/addons/common/fnc_removeBackpackCargoGlobal.sqf
@@ -1,0 +1,91 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_removeBackpackCargoGlobal
+
+Description:
+    Removes specific backpack(s) from global cargo space. MP synchronized.
+
+    * Use <CBA_fnc_removeBackpackCargo> if you want to remove the backpack(s) in
+      local cargo space.
+
+Parameters:
+    _box - Object with cargo [Object]
+    _item - Classname of backpack(s) to remove [String]
+    _count - Number of backpack(s) to remove [Number] (Default: 1)
+
+Returns:
+    Success [Boolean]
+
+Examples:
+   (begin example)
+    // Remove 1 Kitbag Tan backpack globally from a box
+   _success = [myCoolBackpackBox, "B_Kitbag_cbr"] call CBA_fnc_removeBackpackCargoGlobal;
+
+   // Remove 2 Carryall Desert Camo backpacks globally from a box
+   _success = [myCoolBackpackBox, "B_Carryall_ocamo", 2] call CBA_fnc_removeBackpackCargoGlobal;
+   (end)
+
+Author:
+    Jonpas
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+SCRIPT(removeBackpackCargoGlobal);
+
+params ["_box", "_item", ["_count", 1]];
+
+if (typeName _box != "OBJECT") exitWith {
+    TRACE_2("Box not Object",_box,_item);
+    false
+};
+if (typeName _item != "STRING") exitWith {
+    TRACE_2("Item not String",_box,_item);
+    false
+};
+if (isNull _box) exitWith {
+    TRACE_2("Box isNull",_box,_item);
+    false
+};
+if (_item == "") exitWith {
+    TRACE_2("Empty Item",_box,_item);
+    false
+};
+if !(isClass (configFile >> "CfgVehicles" >> _item)) exitWith {
+    TRACE_2("Item does not exist in the game config",_box,_item);
+    false
+};
+if (typeName _count != "SCALAR") exitWith {
+    TRACE_3("Count is not a number",_box,_item,_count);
+    false
+};
+if (_count <= 0) exitWith {
+    TRACE_3("Count is not a positive number",_box,_item,_count);
+    false
+};
+
+// Ensure proper count
+_count = round _count;
+
+// Returns array containing two arrays: [[type1, typeN, ...], [count1, countN, ...]]
+(getBackpackCargo _box) params ["_allItemsType", "_allItemsCount"];
+
+// Clear cargo space and readd the items as long its not the type in question
+local _returnVar = false;
+clearBackpackCargoGlobal _box;
+{
+    local _itemCount = _allItemsCount select _forEachIndex;
+
+    if (_x == _item) then {
+        // Process removal
+        _returnVar = true;
+
+        _itemCount = _itemCount - _count;
+        if (_itemCount > 0) then {
+            // Add with new count
+            _box addBackpackCargoGlobal [_x, _itemCount];
+        };
+    } else {
+        // Readd only
+        _box addBackpackCargoGlobal [_x, _itemCount];
+    };
+} forEach _allItemsType;
+
+_returnVar

--- a/addons/common/fnc_removeItemCargo.sqf
+++ b/addons/common/fnc_removeItemCargo.sqf
@@ -67,7 +67,7 @@ _count = round _count;
 // Returns array containing two arrays: [[type1, typeN, ...], [count1, countN, ...]]
 (getItemCargo _box) params ["_allItemsType", "_allItemsCount"];
 
-// Clear cargo space and readd the items as long its not the type in question
+// Clear cargo space and readd the items as long it's not the type in question
 local _returnVar = false;
 clearItemCargo _box;
 {

--- a/addons/common/fnc_removeItemCargo.sqf
+++ b/addons/common/fnc_removeItemCargo.sqf
@@ -1,0 +1,91 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_removeItemCargo
+
+Description:
+    Removes specific item(s) from local cargo space.
+
+    * Use <CBA_fnc_removeItemCargoGlobal> if you want to remove the item(s) in
+      global cargo space.
+
+Parameters:
+    _box - Object with cargo [Object]
+    _item - Classname of item(s) to remove [String]
+    _count - Number of item(s) to remove [Number] (Default: 1)
+
+Returns:
+    Success [Boolean]
+
+Examples:
+   (begin example)
+    // Remove 1 GPS locally from a box
+   _success = [myCoolItemBox, "ItemGPS"] call CBA_fnc_removeItemCargo;
+
+   // Remove 2 Compasses locally from a box
+   _success = [myCoolItemBox, "ItemCompass", 2] call CBA_fnc_removeItemCargo;
+   (end)
+
+Author:
+    Jonpas
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+SCRIPT(removeItemCargo);
+
+params ["_box", "_item", ["_count", 1]];
+
+if (typeName _box != "OBJECT") exitWith {
+    TRACE_2("Box not Object",_box,_item);
+    false
+};
+if (typeName _item != "STRING") exitWith {
+    TRACE_2("Item not String",_box,_item);
+    false
+};
+if (isNull _box) exitWith {
+    TRACE_2("Box isNull",_box,_item);
+    false
+};
+if (_item == "") exitWith {
+    TRACE_2("Empty Item",_box,_item);
+    false
+};
+if !(isClass (configFile >> "CfgWeapons" >> _item)) exitWith {
+    TRACE_2("Item does not exist in the game config",_box,_item);
+    false
+};
+if (typeName _count != "SCALAR") exitWith {
+    TRACE_3("Count is not a number",_box,_item,_count);
+    false
+};
+if (_count <= 0) exitWith {
+    TRACE_3("Count is not a positive number",_box,_item,_count);
+    false
+};
+
+// Ensure proper count
+_count = round _count;
+
+// Returns array containing two arrays: [[type1, typeN, ...], [count1, countN, ...]]
+(getItemCargo _box) params ["_allItemsType", "_allItemsCount"];
+
+// Clear cargo space and readd the items as long its not the type in question
+local _returnVar = false;
+clearItemCargo _box;
+{
+    local _itemCount = _allItemsCount select _forEachIndex;
+
+    if (_x == _item) then {
+        // Process removal
+        _returnVar = true;
+
+        _itemCount = _itemCount - _count;
+        if (_itemCount > 0) then {
+            // Add with new count
+            _box addItemCargo [_x, _itemCount];
+        };
+    } else {
+        // Readd only
+        _box addItemCargo [_x, _itemCount];
+    };
+} forEach _allItemsType;
+
+_returnVar

--- a/addons/common/fnc_removeItemCargoGlobal.sqf
+++ b/addons/common/fnc_removeItemCargoGlobal.sqf
@@ -1,0 +1,91 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_removeItemCargoGlobal
+
+Description:
+    Removes specific item(s) from global cargo space. MP synchronized.
+
+    * Use <CBA_fnc_removeItemCargo> if you want to remove the item(s) in
+      local cargo space.
+
+Parameters:
+    _box - Object with cargo [Object]
+    _item - Classname of item(s) to remove [String]
+    _count - Number of item(s) to remove [Number] (Default: 1)
+
+Returns:
+    Success [Boolean]
+
+Examples:
+   (begin example)
+    // Remove 1 GPS globally from a box
+   _success = [myCoolItemBox, "ItemGPS"] call CBA_fnc_removeItemCargoGlobal;
+
+   // Remove 2 Compasses globally from a box
+   _success = [myCoolItemBox, "ItemCompass", 2] call CBA_fnc_removeItemCargoGlobal;
+   (end)
+
+Author:
+    Jonpas
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+SCRIPT(removeItemCargoGlobal);
+
+params ["_box", "_item", ["_count", 1]];
+
+if (typeName _box != "OBJECT") exitWith {
+    TRACE_2("Box not Object",_box,_item);
+    false
+};
+if (typeName _item != "STRING") exitWith {
+    TRACE_2("Item not String",_box,_item);
+    false
+};
+if (isNull _box) exitWith {
+    TRACE_2("Box isNull",_box,_item);
+    false
+};
+if (_item == "") exitWith {
+    TRACE_2("Empty Item",_box,_item);
+    false
+};
+if !(isClass (configFile >> "CfgWeapons" >> _item)) exitWith {
+    TRACE_2("Item does not exist in the game config",_box,_item);
+    false
+};
+if (typeName _count != "SCALAR") exitWith {
+    TRACE_3("Count is not a number",_box,_item,_count);
+    false
+};
+if (_count <= 0) exitWith {
+    TRACE_3("Count is not a positive number",_box,_item,_count);
+    false
+};
+
+// Ensure proper count
+_count = round _count;
+
+// Returns array containing two arrays: [[type1, typeN, ...], [count1, countN, ...]]
+(getItemCargo _box) params ["_allItemsType", "_allItemsCount"];
+
+// Clear cargo space and readd the items as long its not the type in question
+local _returnVar = false;
+clearItemCargoGlobal _box;
+{
+    local _itemCount = _allItemsCount select _forEachIndex;
+
+    if (_x == _item) then {
+        // Process removal
+        _returnVar = true;
+
+        _itemCount = _itemCount - _count;
+        if (_itemCount > 0) then {
+            // Add with new count
+            _box addItemCargoGlobal [_x, _itemCount];
+        };
+    } else {
+        // Readd only
+        _box addItemCargoGlobal [_x, _itemCount];
+    };
+} forEach _allItemsType;
+
+_returnVar

--- a/addons/common/fnc_removeItemCargoGlobal.sqf
+++ b/addons/common/fnc_removeItemCargoGlobal.sqf
@@ -67,7 +67,7 @@ _count = round _count;
 // Returns array containing two arrays: [[type1, typeN, ...], [count1, countN, ...]]
 (getItemCargo _box) params ["_allItemsType", "_allItemsCount"];
 
-// Clear cargo space and readd the items as long its not the type in question
+// Clear cargo space and readd the items as long it's not the type in question
 local _returnVar = false;
 clearItemCargoGlobal _box;
 {


### PR DESCRIPTION
This PR adds 2 (4 including global variants) new functions:
- `removeBackpackCargo(Global)` - removes a specific type and number of backpack(s) from cargo space
- `removeItemCargo(Global)` - removes a specific type and number of item(s) from cargo space 

There are already `removeMagazineCargo(Global)` and `removeWeaponCargo(Global)` functions, I will be updating those with new commands as well in a separate PR.