### PR TITLE
Fix make.py version regex

### DIFF
--- a/tools/make.py
+++ b/tools/make.py
@@ -73,7 +73,7 @@ dssignfile = ""
 prefix = "cba"
 pbo_name_prefix = "cba_"
 signature_blacklist = []
-importantFiles = ["mod.cpp", "README.MD", "license.md", "logo_cba_ca.paa"]
+importantFiles = ["mod.cpp", "README.md", "LICENSE.md", "logo_cba_ca.paa"]
 versionFiles = ["mod.cpp"]
 
 ###############################################################################
@@ -750,11 +750,9 @@ def version_stamp_pboprefix(module,commitID):
         f.close()
 
         if configtext:
-            patchestext = re.search(r"version.*?=.*?$", configtext, re.DOTALL)
-            if patchestext:
+            if re.search(r"version=(.*?)$", configtext, re.DOTALL):
                 if configtext:
-                    patchestext = re.search(r"(version.*?=)(.*?)$", configtext, re.DOTALL).group(1)
-                    configtext = re.sub(r"version(.*?)=(.*?)$", "version = {}\n".format(commitID), configtext, flags=re.DOTALL)
+                    configtext = re.sub(r"version=(.*?)$", "version = {}\n".format(commitID), configtext, flags=re.DOTALL)
                     f = open(configpath, "w")
                     f.write(configtext)
                     f.close()
@@ -1433,7 +1431,7 @@ See the make.cfg file for additional build options.
             a3_path = cygwin_a3path
 
         print_yellow("Path from the registry => {}".format(a3_path))
-        a3_path = os.path.join(test_dir,"{}_DEV".format(project)) 
+        a3_path = os.path.join(test_dir,"{}_DEV".format(project))
 
         print_yellow("Copying build files to {}".format(a3_path))
 

--- a/tools/make.py
+++ b/tools/make.py
@@ -752,7 +752,7 @@ def version_stamp_pboprefix(module,commitID):
         if configtext:
             if re.search(r"version=(.*?)$", configtext, re.DOTALL):
                 if configtext:
-                    configtext = re.sub(r"version=(.*?)$", "version = {}\n".format(commitID), configtext, flags=re.DOTALL)
+                    configtext = re.sub(r"version=(.*?)$", "version={}\n".format(commitID), configtext, flags=re.DOTALL)
                     f = open(configpath, "w")
                     f.write(configtext)
                     f.close()


### PR DESCRIPTION
This fixes conflict with `cba_versioning.pbo` as @ViperMaul explains:
> It has to do with REGEX gets confused when it sees the line
prefix=x\cba\addons\versioning

> make.py converts that line into 
x\cba\addons\version=18d100a6

> When it should remove "x\cba\addons\" and leave that one line as 
version=18d100a6

This part of make.py has some black magic to it as well, all file opening should be changed to `with` statements and I see lots of potential optimizations, I'll see what I can do about it as time goes on, but not sure how much time I can spend on it, it works as it should at least. :banana: 