### PR TITLE
Restore equivalent position handling in taskDefend

### DIFF
--- a/addons/ai/fnc_taskDefend.sqf
+++ b/addons/ai/fnc_taskDefend.sqf
@@ -32,6 +32,7 @@ _group = [_group] call CBA_fnc_getGroup;
 if !(local _group) exitWith {}; // Don't create waypoints on each machine
 
 _position = [_position,_group] select (_position isEqualTo []);
+_position = _position call CBA_fnc_getPos;
 
 _group enableattack false;
 


### PR DESCRIPTION
Previously if no position was given the position of the group was used instead.

When I updated the function to use `params` and then retroactively check if the default position value was used I forget to make the `_position` variable use the *position* of the group rather than just the group itself.