### PR TITLE
fixes the typo named in #175

### DIFF
--- a/addons/ai/fnc_taskPatrol.sqf
+++ b/addons/ai/fnc_taskPatrol.sqf
@@ -35,11 +35,9 @@ Author:
 
 #include "script_component.hpp"
 
-#define NULL    "$null$"
-
 params ["_group", ["_position",[]], ["_radius",100], ["_count",3]];
 
-_group = [_group] call CBA_fnc_getGroup;
+_group = _group call CBA_fnc_getGroup;
 if !(local _group) exitWith {}; // Don't create waypoints on each machine
 
 _position = [_position,_group] select (_position isEqualTo []);


### PR DESCRIPTION
and removes obsolete `#define NULL    "$null$"`