### PR TITLE
ERROR() - Example is wrong

### DIFF
--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -199,7 +199,7 @@ Parameters:
 
 Example:
     (begin example)
-        ERROR("Value not found","value of frog not found in config ...yada...yada...");
+        ERROR("value of frog not found in config ...yada...yada...");
     (end)
 
 Author:


### PR DESCRIPTION
The example for the "ERROR" macro is wrong.