### PR TITLE
Added team color synchronization

### DIFF
--- a/addons/common/CfgFunctions.hpp
+++ b/addons/common/CfgFunctions.hpp
@@ -450,7 +450,7 @@ class CfgFunctions
             // CBA_fnc_synchTeamColors
             class synchTeamColors
             {
-                description = "Synchs the team colors per frame.";
+                description = "Synchs the team colors every second.";
                 file = "\x\cba\addons\common\fnc_synchTeamColors.sqf";
             };
             // CBA_fnc_systemChat

--- a/addons/common/CfgFunctions.hpp
+++ b/addons/common/CfgFunctions.hpp
@@ -339,6 +339,12 @@ class CfgFunctions
                 description = "Creates a ""random"" number 0-9 based on an object's velocity";
                 file = "\x\cba\addons\common\fnc_objectRandom.sqf";
             };
+            // CBA_fnc_onTeamColorChanged
+            class onTeamColorChanged
+            {
+                description = "Assigns the units team color if it changed on another machine.";
+                file = "\x\cba\addons\common\fnc_onTeamColorChanged.sqf";
+            };
             // CBA_fnc_parseYAML
             class parseYAML
             {
@@ -440,6 +446,12 @@ class CfgFunctions
             {
                 description = "Switch player to another unit.";
                 file = "\x\cba\addons\common\fnc_switchPlayer.sqf";
+            };
+            // CBA_fnc_synchTeamColors
+            class synchTeamColors
+            {
+                description = "Synchs the team colors per frame.";
+                file = "\x\cba\addons\common\fnc_synchTeamColors.sqf";
             };
             // CBA_fnc_systemChat
             class systemChat

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -121,7 +121,7 @@ if !(isDedicated) then {
 
 ["CBA_teamColorChanged", CBA_fnc_onTeamColorChanged] call CBA_fnc_addEventHandler;
 if (hasInterface) then {
-    [CBA_fnc_synchTeamColors, 0, []] call CBA_fnc_addPerFrameHandler;
+    [CBA_fnc_synchTeamColors, 1, []] call CBA_fnc_addPerFrameHandler;
     if (didJIP) then {
         private "_team";
         {

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -120,6 +120,6 @@ if !(isDedicated) then {
 */
 
 if (hasInterface) then {
-    ["CBA_teamColorChanged", FUNC(onTeamColorChanged)] call FUNC(addEventHandler);
-    [FUNC(synchTeamColors), 0, []] call FUNC(addPerFrameHandler);
+    ["CBA_teamColorChanged", CBA_fnc_onTeamColorChanged] call CBA_fnc_addEventHandler;
+    [CBA_fnc_synchTeamColors, 0, []] call CBA_fnc_addPerFrameHandler;
 };

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -118,3 +118,8 @@ if !(isDedicated) then {
     activateAddons _addons;
 };
 */
+
+if (hasInterface) then {
+    ["CBA_teamColorChanged", FUNC(onTeamColorChanged)] call FUNC(addEventHandler);
+    [FUNC(synchTeamColors), 0, []] call FUNC(addPerFrameHandler);
+};

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -119,7 +119,17 @@ if !(isDedicated) then {
 };
 */
 
+["CBA_teamColorChanged", CBA_fnc_onTeamColorChanged] call CBA_fnc_addEventHandler;
 if (hasInterface) then {
-    ["CBA_teamColorChanged", CBA_fnc_onTeamColorChanged] call CBA_fnc_addEventHandler;
     [CBA_fnc_synchTeamColors, 0, []] call CBA_fnc_addPerFrameHandler;
+    if (didJIP) then {
+        private "_team";
+        {
+            _team = _x getVariable [QGVAR(synchedTeam), ""];
+            if (_team != "") then {
+                _x assignTeam _team;
+            };
+            true
+        } count allUnits;
+    };
 };

--- a/addons/common/fnc_onTeamColorChanged.sqf
+++ b/addons/common/fnc_onTeamColorChanged.sqf
@@ -1,0 +1,22 @@
+/* ----------------------------------------------------------------------------
+Internal Function: CBA_fnc_onTeamColorChanged
+
+Description:
+    Assigns the units team color if it changed on another machine.
+
+Parameters:
+    _unit - unit [OBJECT]
+    _team - team the unit got assigned to [STRING]
+
+Returns:
+    Nothing
+
+Author:
+    BaerMitUmlaut
+---------------------------------------------------------------------------- */
+
+#include "script_component.hpp"
+params ["_unit", "_team"];
+
+_unit assignTeam _team;
+_unit setVariable [QGVAR(synchedTeam), _team];

--- a/addons/common/fnc_onTeamColorChanged.sqf
+++ b/addons/common/fnc_onTeamColorChanged.sqf
@@ -2,7 +2,7 @@
 Internal Function: CBA_fnc_onTeamColorChanged
 
 Description:
-    Assigns the units team color if it changed on another machine.
+    Assigns the units team color if it changed on the squad leaders machine.
 
 Parameters:
     _unit - unit [OBJECT]

--- a/addons/common/fnc_onTeamColorChanged.sqf
+++ b/addons/common/fnc_onTeamColorChanged.sqf
@@ -19,6 +19,6 @@ Author:
 params ["_unit", "_team"];
 
 _unit assignTeam _team;
-if (isServer) then {
+if (local (leader _unit)) then {
     _unit setVariable [QGVAR(synchedTeam), _team, true];
 };

--- a/addons/common/fnc_onTeamColorChanged.sqf
+++ b/addons/common/fnc_onTeamColorChanged.sqf
@@ -19,4 +19,6 @@ Author:
 params ["_unit", "_team"];
 
 _unit assignTeam _team;
-_unit setVariable [QGVAR(synchedTeam), _team];
+if (isServer) then {
+    _unit setVariable [QGVAR(synchedTeam), _team, true];
+};

--- a/addons/common/fnc_synchTeamColors.sqf
+++ b/addons/common/fnc_synchTeamColors.sqf
@@ -2,7 +2,7 @@
 Internal Function: CBA_fnc_synchTeamColors
 
 Description:
-    Synchs the team colors every second. Does not need to be called manually.
+    Synchs the team colors. Does not need to be called manually.
 
 Parameters:
     None

--- a/addons/common/fnc_synchTeamColors.sqf
+++ b/addons/common/fnc_synchTeamColors.sqf
@@ -21,8 +21,9 @@ if (leader player == player) then {
     {
         if ((assignedTeam _x) != (_x getVariable [QGVAR(synchedTeam), "MAIN"])) then {
             //Local team != currently synched team, so we need to synchronize them again
-            ["CBA_teamColorChanged", [_x, assignedTeam _x]] call FUNC(remoteEvent);
+            ["CBA_teamColorChanged", [_x, assignedTeam _x]] call CBA_fnc_remoteEvent;
             _x setVariable [QGVAR(synchedTeam), assignedTeam _x];
         };
-    } forEach units player;
+        true
+    } count units player;
 };

--- a/addons/common/fnc_synchTeamColors.sqf
+++ b/addons/common/fnc_synchTeamColors.sqf
@@ -1,0 +1,28 @@
+/* ----------------------------------------------------------------------------
+Internal Function: CBA_fnc_synchTeamColors
+
+Description:
+    Synchs the team colors per frame. Does not need to be called manually and
+    is executed every frame.
+
+Parameters:
+    None
+
+Returns:
+    Nothing
+
+Author:
+    BaerMitUmlaut
+---------------------------------------------------------------------------- */
+
+#include "script_component.hpp"
+
+if (leader player == player) then {
+    {
+        if ((assignedTeam _x) != (_x getVariable [QGVAR(synchedTeam), "MAIN"])) then {
+            //Local team != currently synched team, so we need to synchronize them again
+            ["CBA_teamColorChanged", [_x, assignedTeam _x]] call FUNC(remoteEvent);
+            _x setVariable [QGVAR(synchedTeam), assignedTeam _x];
+        };
+    } forEach units player;
+};

--- a/addons/common/fnc_synchTeamColors.sqf
+++ b/addons/common/fnc_synchTeamColors.sqf
@@ -22,7 +22,6 @@ if (leader player == player) then {
         if ((assignedTeam _x) != (_x getVariable [QGVAR(synchedTeam), "MAIN"])) then {
             //Local team != currently synched team, so we need to synchronize them again
             ["CBA_teamColorChanged", [_x, assignedTeam _x]] call CBA_fnc_remoteEvent;
-            _x setVariable [QGVAR(synchedTeam), assignedTeam _x];
         };
         true
     } count units player;

--- a/addons/common/fnc_synchTeamColors.sqf
+++ b/addons/common/fnc_synchTeamColors.sqf
@@ -21,7 +21,7 @@ if (leader player == player) then {
     {
         if ((assignedTeam _x) != (_x getVariable [QGVAR(synchedTeam), "MAIN"])) then {
             //Local team != currently synched team, so we need to synchronize them again
-            ["CBA_teamColorChanged", [_x, assignedTeam _x]] call CBA_fnc_remoteEvent;
+            ["CBA_teamColorChanged", [_x, assignedTeam _x]] call CBA_fnc_globalEvent;
         };
         true
     } count units player;

--- a/addons/common/fnc_synchTeamColors.sqf
+++ b/addons/common/fnc_synchTeamColors.sqf
@@ -2,8 +2,7 @@
 Internal Function: CBA_fnc_synchTeamColors
 
 Description:
-    Synchs the team colors per frame. Does not need to be called manually and
-    is executed every frame.
+    Synchs the team colors every second. Does not need to be called manually.
 
 Parameters:
     None


### PR DESCRIPTION
This synchronizes fireteam colors across the network. Other addons can either call the `"CBA_teamColorChanged"` event or indirectly trigger that event by remote calling `assignTeam` on the squad leaders machine.

See issue #94.