### PR TITLE
add Extended_PreStart_Eventhandlers

### DIFF
--- a/addons/xeh/CfgEventHandlers.hpp
+++ b/addons/xeh/CfgEventHandlers.hpp
@@ -6,6 +6,10 @@ class Extended_EventHandlers
 };
 
 
+// The PreStart handlers run once when the game is started
+// this could be used to precompile functions.
+class Extended_PreStart_EventHandlers {};
+
 // Class for "pre-init", run-once event handlers. Code in here runs before any
 // Extended_Init_Eventhandlers code.
 class Extended_PreInit_EventHandlers {};

--- a/addons/xeh/CfgFunctions.hpp
+++ b/addons/xeh/CfgFunctions.hpp
@@ -9,7 +9,11 @@ class CfgFunctions
                 preInit = 1;
                 file = "\x\cba\addons\xeh\init_pre.sqf";
             };
+            class preStartXEH
+            {
+                preStart = 1;
+                file = "\x\cba\addons\xeh\init_preStart.sqf";
+            };
         };
     };
 };
-

--- a/addons/xeh/init_preStart.sqf
+++ b/addons/xeh/init_preStart.sqf
@@ -1,0 +1,18 @@
+// #define DEBUG_MODE_FULL
+#include "script_component.hpp"
+SCRIPT(init_preStart);
+
+// No _this in preStart, also fixes call to init_compile
+private "_this";
+_this = nil;
+
+// Always compile cache function once
+call compile preProcessFileLineNumbers 'x\cba\addons\xeh\init_compile.sqf';
+
+PREP(init_once);
+
+with uiNamespace do {
+    (configFile/"Extended_PreStart_EventHandlers") call FUNC(init_once);
+};
+
+XEH_LOG("XEH: PreStart Finished.");


### PR DESCRIPTION
Similar to `Extended_PreInit_Eventhandlers` and `Extended_PostInit_Eventhandlers`, but executed once during game start.

This could be used to:
- precompile functions  
-- faster first mission start when empty main menu mission is selected (-world="empty")  
-- security against namespace attacks  
- log errors (e.g. addon1 requires addon1_comp_addon2 when addon2 is loaded aswell)