### PR TITLE
Triggers - Create locally only.

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -62,7 +62,7 @@ FUNC(initPerFrameHandlers) = {
 
     GVAR(lastFrameRender) = diag_frameNo;
     // Use a trigger, runs every 0.5s, unscheduled execution
-    GVAR(perFrameTrigger) = createTrigger["EmptyDetector", [0,0,0]];
+    GVAR(perFrameTrigger) = createTrigger["EmptyDetector", [0,0,0], false];
     GVAR(perFrameTrigger) setTriggerStatements[QUOTE(call FUNC(monitorFrameRender)), "", ""];
 };
 

--- a/addons/common/init_delayLess.sqf
+++ b/addons/common/init_delayLess.sqf
@@ -12,7 +12,7 @@ FUNC(addTriggerHandler) = {
 
     // Create the trigger, only on first use
     if (isNil QGVAR(d_trigger)) then {
-        GVAR(d_trigger) = createTrigger["EmptyDetector", [0,0]];
+        GVAR(d_trigger) = createTrigger["EmptyDetector", [0,0], false];
         GVAR(d_trigger) setTriggerActivation ["ANY", "PRESENT", true];
         GVAR(d_trigger) setTriggerStatements["{ if (count _x == 2) then { (_x select 0) call (_x select 1) } } forEach cba_common_d", "", ""];
     };

--- a/addons/events/XEH_preClientInit.sqf
+++ b/addons/events/XEH_preClientInit.sqf
@@ -80,7 +80,7 @@ SLX_XEH_STR spawn {
     // Once the last registered keypress is longer than TIMEOUT seconds ago, re-attach the handler.
     if (isServer) then { // isServer = SP or MP server-client
         // Use a trigger, runs every 0.5s, unscheduled execution
-        GVAR(keyTrigger) = createTrigger["EmptyDetector", [0,0,0]];
+        GVAR(keyTrigger) = createTrigger["EmptyDetector", [0,0,0], false];
         GVAR(keyTrigger) setTriggerStatements[QUOTE(if ((GVAR(keypressed) + TIMEOUT) < time) then { call FUNC(attach_handler) }), "", ""];
     } else { // dedicatedClient
         // TODO: Find better dummy class to use


### PR DESCRIPTION
As of Arma 3 v1.43, Triggers now support being created locally rather than globally. This will create less trigger objects on clients and lower initial network activity. The setTriggerStatement/setTriggerActivation functions all only have local effects, so nothing should change.

Reference: https://community.bistudio.com/wiki/createTrigger

Summary: Minor optimization.