### PR TITLE
add keyhandlers to zeus interface, fix #33

### DIFF
--- a/addons/events/XEH_preClientInit.sqf
+++ b/addons/events/XEH_preClientInit.sqf
@@ -66,6 +66,13 @@ FUNC(attach_handler) = {
 ["KeyUp", QUOTE(UP call FUNC(keyHandler))] call (uiNamespace getVariable "CBA_fnc_addDisplayHandler");
 ["KeyDown", QUOTE(DOWN call FUNC(keyHandler))] call (uiNamespace getVariable "CBA_fnc_addDisplayHandler");
 
+// add keyhandlers to zeus interface
+["CBA_curatorOpened", {
+    params ["_display"];
+    _display displayAddEventHandler ["KeyUp", {UP call FUNC(keyHandler)}];
+    _display displayAddEventHandler ["KeyDown", {DOWN call FUNC(keyHandler)}];
+}] call CBA_fnc_addEventHandler;
+
 SLX_XEH_STR spawn {
     waitUntil { !isNull (findDisplay 46) };
     // Workaround for Single Player, mission editor, or mission, preview/continue, whatever, adding double handlers

--- a/addons/keybinding/gui/gui.hpp
+++ b/addons/keybinding/gui/gui.hpp
@@ -174,3 +174,8 @@ class RscDisplayConfigure {
         };
     };
 };
+
+class RscDisplayCurator {
+    onLoad = "['CBA_curatorOpened', _this] call CBA_fnc_localEvent; [""onLoad"",_this,""RscDisplayCurator"",'CuratorDisplays'] call (uinamespace getvariable 'BIS_fnc_initDisplay')";
+    onUnload = "['CBA_curatorClosed', _this] call CBA_fnc_localEvent; [""onUnload"",_this,""RscDisplayCurator"",'CuratorDisplays'] call (uinamespace getvariable 'BIS_fnc_initDisplay')";
+};


### PR DESCRIPTION
fixes: https://github.com/CBATeam/CBA_A3/issues/33

- current display (#46 or #312) is passed to the custom keyDown script as `params ["_display"];`
- also adds "CBA_curatorOpened" and "CBA_curatorClosed" events which probably could be usefull in other places or for mission makers