### PR TITLE
fix CBA_fnc_findMin, improve CBA_fnc_findMax

### DIFF
--- a/addons/arrays/fnc_findMax.sqf
+++ b/addons/arrays/fnc_findMax.sqf
@@ -9,7 +9,7 @@ Parameters:
 
 Example:
     (begin example)
-    _result = [_array] call CBA_fnc_findMax
+    _result = [0,4,3,-2] call CBA_fnc_findMax
     (end)
 
 Returns:
@@ -18,24 +18,18 @@ Returns:
     nil on failure
 
 Author:
-    joko // Jonas
+    joko // Jonas, commy2
 
 ---------------------------------------------------------------------------- */
 #include "script_component.hpp"
 SCRIPT(findMax);
 
-private ["_index"];
+[_this] params [["_array", [], [[]]]];
 
-if (!IS_ARRAY(_this)) exitWith {nil};
-if (_this isEqualTo []) exitWith {nil};
+if !(_array isEqualTypeAll 0) exitWith {nil};
 
-params ["_max"];
-_index = 0;
+private _arraySorted = + _array;
+_arraySorted sort false; // false - descending
+_arraySorted params ["_min"];
 
-{
-    if (isNil "_x" || {(typeName _x) != (typeName 0)}) exitWith {_max = nil; _index = nil;};
-    if (_max < _x) then {_max = _x; _index = _forEachIndex};
-} forEach _this;
-
-if (isNil "_max") exitWith {nil};
-[_max, _index] // Return
+[_min, _array find _min]

--- a/addons/arrays/fnc_findMax.sqf
+++ b/addons/arrays/fnc_findMax.sqf
@@ -30,6 +30,6 @@ if !(_array isEqualTypeAll 0) exitWith {nil};
 
 private _arraySorted = + _array;
 _arraySorted sort false; // false - descending
-_arraySorted params ["_min"];
+_arraySorted params ["_max"];
 
-[_min, _array find _min]
+[_max, _array find _max]

--- a/addons/arrays/fnc_findMin.sqf
+++ b/addons/arrays/fnc_findMin.sqf
@@ -9,7 +9,7 @@ Parameters:
 
 Example:
     (begin example)
-    _result = [_array] call CBA_fnc_findMin
+    _result = [0,4,3,-2] call CBA_fnc_findMin
     (end)
 
 Returns:
@@ -18,24 +18,18 @@ Returns:
     nil on failure
 
 Author:
-    joko // Jonas
+    joko // Jonas, commy2
 
 ---------------------------------------------------------------------------- */
 #include "script_component.hpp"
 SCRIPT(findMin);
 
-private ["_index"];
+[_this] params [["_array", [], [[]]]];
 
-if (!IS_ARRAY(_this)) exitWith {nil};
-if (_this isEqualTo []) exitWith {nil};
+if !(_array isEqualTypeAll 0) exitWith {nil};
 
-params ["_min"];
-_index = 0;
+private _arraySorted = + _array;
+_arraySorted sort true; // true - ascending
+_arraySorted params ["_min"];
 
-{
-    if (isNil "_x" || {(typeName _x) != (typeName 0)}) exitWith {_max = nil; _index = nil;};
-    if (_min > _x) then {_min = _x; _index = _forEachIndex};
-} forEach _this;
-
-if (isNil "_max") exitWith {nil};
-[_min, _index] // Return
+[_min, _array find _min]


### PR DESCRIPTION
`[0,4,3,-2,1,5,2] call CBA_fnc_findMax`

old method: 0.121507 ms for (8238/10000) loops
new method: 0.0360001 ms for (10000/10000) loops

`CBA_fnc_findMin` was broken.