### PR TITLE
Fix split having extra separator at end

### DIFF
--- a/addons/strings/fnc_split.sqf
+++ b/addons/strings/fnc_split.sqf
@@ -45,7 +45,7 @@ if (_input == _separator) exitWith {["",""]};
 
 _lastWasSeperator = true;
 while {_index < _inputCount} do {
-    _find = (_input select [_index, (_inputCount - _index)]) find _separator;
+    _find = (_input select [_index]) find _separator;
     if (_find == 0) then {
         _index = _index + _separatorCount;
         if (_lastWasSeperator) then {_split pushBack "";};
@@ -53,7 +53,7 @@ while {_index < _inputCount} do {
     } else {
         _lastWasSeperator = false;
         if (_find == -1) then {
-            _split pushBack (_input select [_index, (_inputCount - _index)]);
+            _split pushBack (_input select [_index]);
             _index = _inputCount;
         } else {
             _split pushBack (_input select [_index, _find]);
@@ -62,7 +62,7 @@ while {_index < _inputCount} do {
     };
 };
 //Handle split at end:
-if ((_inputCount >= _separatorCount) && {(_input select [(_inputCount - _separatorCount), _separatorCount]) isEqualTo _separator}) then {
+if ((_inputCount >= _separatorCount) && _lastWasSeperator && {(_input select [(_inputCount - _separatorCount)]) isEqualTo _separator}) then {
     _split pushBack "";
 };
 _split

--- a/addons/strings/test_strings.sqf
+++ b/addons/strings/test_strings.sqf
@@ -77,6 +77,14 @@ _array = ["this\is\a\path\to\fnc_test.sqf","\fnc_"] call CBA_fnc_split;
 _expected = ["this\is\a\path\to", "test.sqf"];
 TEST_OP(str _array, ==, str _expected, _fn);
 
+_array = ["babab", "bab"] call CBA_fnc_split;
+_expected = ["", "ab"];
+TEST_OP(str _array, ==, str _expected, _fn);
+
+_array = ["BbabTabAbabbabababab", "bab"] call CBA_fnc_split;
+_expected = ["B","TabA","","a","ab"];
+TEST_OP(str _array, ==, str _expected, _fn);
+
 // ----------------------------------------------------------------------------
 // UNIT TESTS (stringReplace)
 _fn = "CBA_fnc_replace";


### PR DESCRIPTION
Fix #210
Also use `select [_index]` when selecting entire right side of a string.