### PR TITLE
Fix FormatNumber Decimals with Negative Numbers

### DIFF
--- a/addons/strings/fnc_formatNumber.sqf
+++ b/addons/strings/fnc_formatNumber.sqf
@@ -115,6 +115,9 @@ if (_number < 0) then {
 if (_decimalPlaces > 0) then {
     private ["_digit", "_multiplier", "_i"];
 
+    //Use abs to prevent extra `-` signs and so floor doesn't get wrong value
+    _number = abs _number;
+    
     _string = _string + _decimalPoint;
 
     _multiplier = 10;

--- a/addons/strings/test_strings.sqf
+++ b/addons/strings/test_strings.sqf
@@ -231,6 +231,12 @@ TEST_OP(_str,==,"012",_fn);
 _str = [-12] call CBA_fnc_formatNumber;
 TEST_OP(_str,==,"-12",_fn);
 
+_str = [-12.75] call CBA_fnc_formatNumber;
+TEST_OP(_str,==,"-13",_fn);
+
+_str = [-12.75,0,3] call CBA_fnc_formatNumber;
+TEST_OP(_str,==,"-12.750",_fn);
+
 // ----------------------------------------------------------------------------
 // UNIT TESTS (elaspsedTime)
 _fn = "CBA_fnc_formatElapsedTime";


### PR DESCRIPTION
Before:
`[-12.75,0,3] call CBA_fnc_formatNumber;` = "-12.-8-50"
`[-0.12345,1,5] call CBA_fnc_formatNumber;` = "-0.-2-3-4-5-5"
