### PR TITLE
Fix removing CfgGlasses items from cargo

### DIFF
--- a/addons/common/fnc_removeItemCargo.sqf
+++ b/addons/common/fnc_removeItemCargo.sqf
@@ -48,7 +48,7 @@ if (_item == "") exitWith {
     TRACE_2("Empty Item",_box,_item);
     false
 };
-if !(isClass (configFile >> "CfgWeapons" >> _item)) exitWith {
+if !(isClass (configFile >> "CfgWeapons" >> _item) || isClass (configFile >> "CfgGlasses" >> _item)) exitWith {
     TRACE_2("Item does not exist in the game config",_box,_item);
     false
 };

--- a/addons/common/fnc_removeItemCargoGlobal.sqf
+++ b/addons/common/fnc_removeItemCargoGlobal.sqf
@@ -48,7 +48,7 @@ if (_item == "") exitWith {
     TRACE_2("Empty Item",_box,_item);
     false
 };
-if !(isClass (configFile >> "CfgWeapons" >> _item)) exitWith {
+if !(isClass (configFile >> "CfgWeapons" >> _item) || isClass (configFile >> "CfgGlasses" >> _item)) exitWith {
     TRACE_2("Item does not exist in the game config",_box,_item);
     false
 };


### PR DESCRIPTION
`fnc_removeItemCargo` and `fnc_removeItemCargoGlobal` were not checking `CfgGlasses`, so those items could not be removed with them.