### PR TITLE
fix CBA_fnc_selectWeapon, add CBA_fnc_isPerson and CBA_fnc_canUseWeapon

### DIFF
--- a/addons/common/CfgFunctions.hpp
+++ b/addons/common/CfgFunctions.hpp
@@ -69,6 +69,12 @@ class CfgFunctions
                 description = "Add weapon(s) to vehicle cargo. MP synchronized.";
                 file = "\x\cba\addons\common\fnc_addWeaponCargoGlobal.sqf";
             };
+            // CBA_fnc_canUseWeapon
+            class canUseWeapon
+            {
+                description = "Checks if the unit can currently use a weapon.";
+                file = "\x\cba\addons\common\fnc_canUseWeapon.sqf";
+            };
             // CBA_fnc_createCenter
             class createCenter
             {
@@ -279,6 +285,12 @@ class CfgFunctions
                 description = "A function used to find out if the group or object is alive.";
                 file = "\x\cba\addons\common\fnc_isAlive.sqf";
             };
+            // CBA_fnc_isPerson
+            class isPerson
+            {
+                description = "Checks if an object is a person - soldier or civilian.";
+                file = "\x\cba\addons\common\fnc_isPerson.sqf";
+            };
             // CBA_fnc_isTurnedOut
             class isTurnedOut
             {
@@ -450,7 +462,7 @@ class CfgFunctions
             // CBA_fnc_selectWeapon
             class selectWeapon
             {
-                description = "Selects weapon, if the player has the weapon, including correctly selecting a muzzle, if any.";
+                description = "Selects a weapon including correctly selecting a weapon mode of specified.";
                 file = "\x\cba\addons\common\fnc_selectWeapon.sqf";
             };
             // CBA_fnc_setHeight

--- a/addons/common/fnc_canUseWeapon.sqf
+++ b/addons/common/fnc_canUseWeapon.sqf
@@ -1,0 +1,30 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_canUseWeapon
+
+Description:
+    Checks if the unit can currently use a weapon.
+
+Parameters:
+    _unit - A unit <OBJECT>
+
+Returns:
+    True if the unit is not in a vehicle or in a FFV position <BOOLEAN>
+
+Examples:
+    (begin example)
+    _result = player call CBA_fnc_canUseWeapon;
+    (end)
+
+Author:
+    commy2
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+SCRIPT(canUseWeapon);
+
+params [["_unit", objNull, [objNull]]];
+
+if (_unit == vehicle _unit) exitWith {true};
+
+private _config = configFile >> "CfgMovesMaleSdr" >> "States" >> animationState _unit;
+
+isClass _config && {getNumber (_config >> "canPullTrigger") == 1}

--- a/addons/common/fnc_isPerson.sqf
+++ b/addons/common/fnc_isPerson.sqf
@@ -1,0 +1,42 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_isPerson
+
+Description:
+    Checks if an object is a person - soldier or civilian.
+
+Parameters:
+    _unit - A unit or classname <OBJECT, STRING>
+
+Returns:
+    True if object is a person, otherwise false <BOOLEAN>
+
+Examples:
+    (begin example)
+    player call CBA_fnc_isPerson;
+    -> true
+
+    "CAManBase" call CBA_fnc_isPerson;
+    -> true
+
+    (vehicle player) call CBA_fnc_isPerson;
+    -> false
+
+    _projectile call CBA_fnc_isPerson;
+    -> false
+    (end)
+
+Author:
+    commy2
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+SCRIPT(isPerson);
+
+params [["_unit", "", [objNull, ""]]];
+
+if (_unit isEqualType objNull) then {
+    _unit = typeOf _unit;
+};
+
+private _config = configFile >> "CfgVehicles" >> _unit;
+
+isClass _config && {getNumber (_config >> "isMan") == 1}

--- a/addons/common/fnc_selectWeapon.sqf
+++ b/addons/common/fnc_selectWeapon.sqf
@@ -2,37 +2,50 @@
 Function: CBA_fnc_selectWeapon
 
 Description:
-    Selects weapon, if the player has the weapon, including correctly selecting a muzzle, if any.
+    Selects a weapon including correctly selecting a weapon mode of specified.
+    Has to be executed on the machine where the unit is local.
 
 Parameters:
-    _unit - Unit object to perform function on [Object]
-    _weap - Weapon to select [String]
+    _unit   - Unit object to perform function on. <OBJECT>
+    _weapon - Weapon or muzzle to select <STRING>
+    _mode   - Weapon mode to switch to [optional] <STRING> (default: "")
 
 Returns:
-    Success or Failed [Boolean]
+    Success or Failed <BOOLEAN>
 
 Examples:
     (begin example)
-    _result = [player, secondaryWeapon player] call CBA_fnc_selectWeapon
+    _result = [player, secondaryWeapon player] call CBA_fnc_selectWeapon;
+    _result = [player, currentWeapon player, "FullAuto"] call CBA_fnc_selectWeapon;
+    _result = [player, "LMG_M200_body"] call CBA_fnc_selectWeapon;
     (end)
 
 Author:
-    Sickboy
+    Sickboy, commy2
 ---------------------------------------------------------------------------- */
-
 #include "script_component.hpp"
 SCRIPT(selectWeapon);
 
-private ["_cfg", "_muz", "_ar"];
-params ["_unit","_weap"];
-_cfg = (configFile >> "CfgWeapons" >> _weap >> "muzzles");
-if (isArray _cfg) then {
-    _ar = getArray _cfg;
-    _muz = _ar select 0;
-    if (_muz == "this") then { _muz = _weap };
+#define MAXIMUM_TRIES 100
+
+params [["_unit", objNull, [objNull]], ["_weapon", "", [""]], ["_mode", "", [""]]];
+
+if (!local _unit) exitWith {false};
+
+private _vehicle = [vehicle _unit, _unit] select (_unit call CBA_fnc_canUseWeapon);
+
+private _index = 0;
+
+if (_mode isEqualTo "") then {
+    while {_index < MAXIMUM_TRIES && {currentMuzzle _unit != _weapon}} do {
+        _unit action ["SwitchWeapon", _vehicle, _unit, _index];
+        _index = _index + 1;
+    };
 } else {
-    _muz = _weap;
+    while {_index < MAXIMUM_TRIES && {currentMuzzle _unit != _weapon || {currentWeaponMode _unit != _mode}}} do {
+        _unit action ["SwitchWeapon", _vehicle, _unit, _index];
+        _index = _index + 1;
+    };
 };
 
-if (vehicle player != player) exitWith { false };
-if (player hasWeapon _weap) then { _unit selectWeapon _muz; true } else { false };
+_index < MAXIMUM_TRIES // return


### PR DESCRIPTION
fixes:
- `CBA_fnc_selectWeapon` doesn't work when the unit is in a firing from vehicles slot.
- `CBA_fnc_selectWeapon` doesn't work when the local player has not the same weapon as the unit.

adds:
- `CBA_fnc_selectWeapon` can now select vehicle weapons.
- `CBA_fnc_selectWeapon` has an optional paramter to select a specific weapon mode.
- `CBA_fnc_isPerson` which checks if an object is a person (soldier, civilian etc.).
- `CBA_fnc_canUseWeapon` which checks if a unit can currently use it's rifle, pistol or launcher. (Basically true on foot and in FFV slots, proved itself very usefull in ACE)
