### PR TITLE
Remove unecessary entities call

### DIFF
--- a/addons/class_eventhandlers/fnc_init_loop.sqf
+++ b/addons/class_eventhandlers/fnc_init_loop.sqf
@@ -6,8 +6,8 @@ SCRIPT(init);
 GVAR(entities) = [];
 
 [{
-    if !(entities "" isEqualTo GVAR(entities)) then {
-        private _entities = entities "";
+    private _entities = entities "";
+    if !(_entities isEqualTo GVAR(entities)) then {
 
         GVAR(entities) = _entities;
 


### PR DESCRIPTION
No need to call `entities ""` twice.