### PR TITLE
fix addClassEventHandlers not working for units that spawn inside vehicles

### DIFF
--- a/addons/class_eventhandlers/fnc_init_loop.sqf
+++ b/addons/class_eventhandlers/fnc_init_loop.sqf
@@ -6,9 +6,8 @@ SCRIPT(init);
 GVAR(entities) = [];
 
 [{
-    private _entities = entities "";
+    private _entities = entities "" + allUnits;
     if !(_entities isEqualTo GVAR(entities)) then {
-
         GVAR(entities) = _entities;
 
         // iterate through all objects and add eventhandlers to all new ones


### PR DESCRIPTION
Apparently, `entities ""` does not include units inside vehicles, so we have to add allUnits.