### PR TITLE
Make isRecompileEnabled generic, warn FiredBIS

### DIFF
--- a/addons/common/init_functionsModule.sqf
+++ b/addons/common/init_functionsModule.sqf
@@ -10,6 +10,7 @@ scriptName "CBA\common\init_functionsModule";
 private ["_recompile"];
 _recompile = (count _this) > 0;
 
+if (isNil "CBA_FUNC_RECOMPILE") then { CBA_FUNC_RECOMPILE = ["functions"] call CBA_fnc_isRecompileEnabled; };
 if (CBA_FUNC_RECOMPILE) then { _recompile = true };
 
 

--- a/addons/xeh/fnc_addClassEventHandler.sqf
+++ b/addons/xeh/fnc_addClassEventHandler.sqf
@@ -58,6 +58,10 @@ if (_eventName == "getOutMan" && {isNil QGVAR(getOutManAdded)}) then {
 _eventName = toLower _eventName;
 
 // no such event
+if (_eventName == "FiredBIS") exitWith {
+    WARNING("Cannot add 'FiredBIS' - Use 'Fired' instead");
+    false
+};
 if !(_eventName in GVAR(EventsLowercase)) exitWith {false};
 
 // add events to already existing objects

--- a/addons/xeh/fnc_compileFunction.sqf
+++ b/addons/xeh/fnc_compileFunction.sqf
@@ -30,7 +30,7 @@ if (isNil "_cachedFunc") then {
     uiNamespace setVariable [_funcName, compileFinal preprocessFileLineNumbers _funcFile];
     missionNamespace setVariable [_funcName, uiNamespace getVariable _funcName];
 } else {
-    if (call CBA_fnc_isRecompileEnabled) then {
+    if (["compile"] call CBA_fnc_isRecompileEnabled) then {
         missionNamespace setVariable [_funcName, compileFinal preprocessFileLineNumbers _funcFile];
     } else {
         missionNamespace setVariable [_funcName, _cachedFunc];

--- a/addons/xeh/fnc_preInit.sqf
+++ b/addons/xeh/fnc_preInit.sqf
@@ -62,7 +62,7 @@ GVAR(EventsLowercase) = [];
 } forEach ([false, true] call CBA_fnc_supportMonitor);
 
 // recompile extended event handlers when enabled
-if (call CBA_fnc_isRecompileEnabled) then {
+if (["xeh"] call CBA_fnc_isRecompileEnabled) then {
     GVAR(allEventHandlers) = configFile call CBA_fnc_compileEventHandlers; // from addon config
 } else {
     GVAR(allEventHandlers) = call (uiNamespace getVariable QGVAR(fnc_getAllEventHandlers));


### PR DESCRIPTION
 - Make isRecompileEnabled generic (works on `xeh`, `compile` and `functions`)

 - `["CAManBase", "firedBis", {diag_log text format ["FiredBIS %1", _this];}] call CBA_fnc_addClassEventHandler;` returned true, but had no effect.  I see this as being a possible source of confustion as it takes `fired` and returns the normal (addEventHandler) `fired` params, but converting from XEH, you might expect the event name to be `firedBIS`,