### PR TITLE
add CBA_fnc_directCall

### DIFF
--- a/addons/common/CfgFunctions.hpp
+++ b/addons/common/CfgFunctions.hpp
@@ -111,6 +111,12 @@ class CfgFunctions
                 description = "Gets the list of possible muzzles for a weapon.";
                 file = "\x\cba\addons\common\fnc_determineMuzzles.sqf";
             };
+            // CBA_fnc_directCall
+            class directCall
+            {
+                description = "Executes a piece of code in unscheduled environment.";
+                file = "\x\cba\addons\common\fnc_directCall.sqf";
+            };
             // CBA_fnc_dropMagazine
             class dropMagazine
             {

--- a/addons/common/config.cpp
+++ b/addons/common/config.cpp
@@ -1,21 +1,22 @@
 #include "script_component.hpp"
-class CfgPatches
-{
-    class ADDON
-    {
+
+class CfgPatches {
+    class ADDON {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = { "A3_BaseConfig_F" };
+        requiredAddons[] = {"A3_BaseConfig_F"};
         version = VERSION;
-        author[] = {"Spooner", "Sickboy", "Rocko"};
+        author[] = {"Spooner","Sickboy","Rocko"};
         authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };
+
 #include "CfgEventHandlers.hpp"
-
 #include "CfgFunctions.hpp"
-
 #include "CfgPerFrame.hpp"
-
 #include "CfgRemoteExec.hpp"
+
+class CBA_DirectCall {
+    class dummy;
+};

--- a/addons/common/fnc_directCall.sqf
+++ b/addons/common/fnc_directCall.sqf
@@ -1,0 +1,37 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_directCall
+
+Description:
+    Executes a piece of code in unscheduled environment.
+
+Parameters:
+    _code      - Code to execute <CODE>
+    _arguments - Parameters to call the code with. [optional] <ANY>
+
+Returns:
+    None
+
+Examples:
+    (begin example)
+        0 spawn {{systemChat str (call CBA_fnc_isScheduled)} call CBA_fnc_directCall}
+    (end)
+
+Author:
+    commy2
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+
+params [["_code", {}, [{}]], ["_arguments", []]];
+
+if (isNil QGVAR(directCallStack)) then {
+    GVAR(directCallStack) = [];
+};
+
+private _id = GVAR(directCallStack) pushBack [_arguments, _code];
+
+(format [
+    QUOTE((GVAR(directCallStack) select %1 select 0) call (GVAR(directCallStack) select %1 select 1); GVAR(directCallStack) set [ARR_2(%1, nil)]; if ({!isNil QUOTE("_x")} count GVAR(directCallStack) == 0) then {GVAR(directCallStack) = [];}; false),
+    _id
+]) configClasses (configFile >> "CBA_DirectCall");
+
+nil

--- a/addons/common/fnc_directCall.sqf
+++ b/addons/common/fnc_directCall.sqf
@@ -23,15 +23,6 @@ Author:
 
 params [["_code", {}, [{}]], ["_arguments", []]];
 
-if (isNil QGVAR(directCallStack)) then {
-    GVAR(directCallStack) = [];
-};
-
-private _id = GVAR(directCallStack) pushBack [_arguments, _code];
-
-(format [
-    QUOTE((GVAR(directCallStack) select %1 select 0) call (GVAR(directCallStack) select %1 select 1); GVAR(directCallStack) set [ARR_2(%1, nil)]; if ({!isNil QUOTE("_x")} count GVAR(directCallStack) == 0) then {GVAR(directCallStack) = [];}; false),
-    _id
-]) configClasses (configFile >> "CBA_DirectCall");
+"_arguments call _code; false" configClasses (configFile >> "CBA_DirectCall");
 
 nil

--- a/addons/common/fnc_directCall.sqf
+++ b/addons/common/fnc_directCall.sqf
@@ -25,6 +25,6 @@ params [["_code", {}, [{}]], ["_arguments", []]];
 
 private "_return";
 
-"_return = _arguments call _code; false" configClasses (configFile >> "CBA_DirectCall");
+"_return = _arguments call _code" configClasses (configFile >> "CBA_DirectCall");
 
 if (!isNil "_return") then {_return};

--- a/addons/common/fnc_directCall.sqf
+++ b/addons/common/fnc_directCall.sqf
@@ -9,7 +9,7 @@ Parameters:
     _arguments - Parameters to call the code with. [optional] <ANY>
 
 Returns:
-    None
+    _return - Return value of the function <ANY>
 
 Examples:
     (begin example)
@@ -23,6 +23,8 @@ Author:
 
 params [["_code", {}, [{}]], ["_arguments", []]];
 
-"_arguments call _code; false" configClasses (configFile >> "CBA_DirectCall");
+private "_return";
 
-nil
+"_return = _arguments call _code; false" configClasses (configFile >> "CBA_DirectCall");
+
+if (!isNil "_return") then {_return};

--- a/addons/xeh/CfgVehicles.hpp
+++ b/addons/xeh/CfgVehicles.hpp
@@ -142,13 +142,4 @@ class CfgVehicles {
         scope = 1;
         displayName = "XEH Initialization Logic";
     };
-
-    // spawned in BI's scheduled postInit to run unscheduled XEH postInit
-    class CBA_PostInit_Helper: Logic {
-        scope = 1;
-        displayName = "XEH PostInit Helper";
-        class EventHandlers {
-            init = "[] call CBA_fnc_postInit_unscheduled; deleteVehicle (_this select 0);";
-        };
-    };
 };

--- a/addons/xeh/fnc_postInit.sqf
+++ b/addons/xeh/fnc_postInit.sqf
@@ -16,5 +16,4 @@ Author:
 ---------------------------------------------------------------------------- */
 #include "script_component.hpp"
 
-// this runs in scheduled. we don't like scheduled. spawn a game logic with init event handler instead.
-"CBA_PostInit_Helper" createVehicleLocal [0,0,0];
+CBA_fnc_postInit_unscheduled call CBA_fnc_directCall;

--- a/addons/xeh/script_component.hpp
+++ b/addons/xeh/script_component.hpp
@@ -2,7 +2,7 @@
 
 #include "\x\cba\addons\main\script_mod.hpp"
 
-//#define DEBUG_ENABLED_XEH
+#define DEBUG_ENABLED_XEH
 
 #ifdef DEBUG_ENABLED_XEH
     #define DEBUG_MODE_FULL

--- a/addons/xeh/script_component.hpp
+++ b/addons/xeh/script_component.hpp
@@ -2,7 +2,7 @@
 
 #include "\x\cba\addons\main\script_mod.hpp"
 
-#define DEBUG_ENABLED_XEH
+//#define DEBUG_ENABLED_XEH
 
 #ifdef DEBUG_ENABLED_XEH
     #define DEBUG_MODE_FULL


### PR DESCRIPTION
This is the best I can come up with.

required for #230 

~~Makes the call atomic by reducing it to a `pushBack`.~~

can be confirmed working with:
```
TEST = {systemChat str (call CBA_fnc_isScheduled)};

call TEST;
0 spawn {
    call TEST;
    TEST call CBA_fnc_directCall;
};

-> false
-> true
-> false
```
Name does not conflict, because the old one is named `CBA_common_fnc_directCall`
