### PR TITLE
Fix issues with PerFrameHandlers

### DIFF
--- a/addons/common/CfgFunctions.hpp
+++ b/addons/common/CfgFunctions.hpp
@@ -42,7 +42,7 @@ class CfgFunctions
             // CBA_fnc_addPerFrameHandler
             class addPerFrameHandler
             {
-                description = "Add a handler that will execute every frame, or every x number of seconds";
+                description = "Add a handler that will execute every frame, or every x number of seconds.";
                 file = "\x\cba\addons\common\fnc_addPerFrameHandler.sqf";
             };
             // CBA_fnc_addPlayerAction
@@ -438,7 +438,7 @@ class CfgFunctions
             // CBA_fnc_removePerFrameHandler
             class removePerFrameHandler
             {
-                description = "Remove a handler that you have added using CBA_fnc_addPerFrameHandler";
+                description = "Remove a handler that you have added using CBA_fnc_addPerFrameHandler.";
                 file = "\x\cba\addons\common\fnc_removePerFrameHandler.sqf";
             };
             // CBA_fnc_removePlayerAction

--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -33,8 +33,6 @@ LOG(MSG_INIT);
 ADDON = false;
 
 CBA_nil = [nil];
-GVAR(PFHhandles) = [];
-GVAR(nextPFHid) = -1;
 GVAR(centers) = [];
 CBA_actionHelper = QUOTE(PATHTO(actionHelper));
 GVAR(delayless) = QUOTE(PATHTOF(delayless.fsm));

--- a/addons/common/fnc_addPerFrameHandler.sqf
+++ b/addons/common/fnc_addPerFrameHandler.sqf
@@ -28,18 +28,15 @@ if (_function isEqualTo {}) exitWith {-1};
 
 if (isNil QGVAR(PFHhandles)) then {
     GVAR(PFHhandles) = [];
-    GVAR(lastPFHid) = -1;
 };
 
-GVAR(lastPFHid) = GVAR(lastPFHid) + 1;
-
-if (GVAR(lastPFHid) >= 999999) exitWith {
+if (count GVAR(PFHhandles) >= 999999) exitWith {
     WARNING("Maximum amount of per frame handlers reached!");
     diag_log _function;
     -1
 };
 
-private _handle = GVAR(PFHhandles) pushBack GVAR(lastPFHid);
+private _handle = GVAR(PFHhandles) pushBack count GVAR(perFrameHandlerArray);
 
 GVAR(perFrameHandlerArray) pushBack [_function, _delay, 0, diag_tickTime, _args, _handle];
 

--- a/addons/common/fnc_addPerFrameHandler.sqf
+++ b/addons/common/fnc_addPerFrameHandler.sqf
@@ -2,41 +2,45 @@
 Function: CBA_fnc_addPerFrameHandler
 
 Description:
-    Add a handler that will execute every frame, or every x number of seconds
+    Add a handler that will execute every frame, or every x number of seconds.
 
 Parameters:
-    _func - The function you wish to execute
-    _delay - The amount of time in seconds (can be less than 0) between executions, 0 for everyframe.
-    _params - Parameters passed to the function executing. This will be the same array every execution.
+    _function - The function you wish to execute. <CODE>
+    _delay    - The amount of time in seconds between executions, 0 for every frame. [optional] (default: 0) <NUMBER>
+    _args     - Parameters passed to the function executing. This will be the same array every execution. [optional] <ANY>
 
 Returns:
-    _handle - a number representing the handle of the function. Use this to remove the handler.
+    _handle - a number representing the handle of the function. Use this to remove the handler. <NUMBER>
 
 Examples:
     (begin example)
-        [{player sideChat format["every frame! _this: %1", _this];}, 0, ["some","params",1,2,3]] call CBA_fnc_addPerFrameHandler;
+        _handle = [{player sideChat format ["every frame! _this: %1", _this];}, 0, ["some","params",1,2,3]] call CBA_fnc_addPerFrameHandler;
     (end)
 
 Author:
-    Nou & Jaynus, donated from ACRE project code for use by the community.
-
+    Nou & Jaynus, donated from ACRE project code for use by the community; commy2
 ---------------------------------------------------------------------------- */
 #include "script_component.hpp"
 
-private ["_handle", "_data", "_publicHandle"];
-params ["_func","_delay", ["_params",[]]];
+params [["_function", {}, [{}]], ["_delay", 0, [0]], ["_args", []]];
 
-if (!isNil "_func") then {
-    _handle = if (GVAR(nextPFHid) == -1) then {
-        GVAR(nextPFHid) = count GVAR(perFrameHandlerArray);
-        GVAR(nextPFHid)
-    } else {
-        GVAR(nextPFHid) = GVAR(nextPFHid) + 1;
-        GVAR(nextPFHid)
-    };
+if (_function isEqualTo {}) exitWith {-1};
 
-    _publicHandle = GVAR(PFHhandles) pushback _handle;
-    _data = [_func, _delay, 0, diag_tickTime, _params, _publicHandle];
-    GVAR(perFrameHandlerArray) pushBack _data;
+if (isNil QGVAR(PFHhandles)) then {
+    GVAR(PFHhandles) = [];
+    GVAR(lastPFHid) = -1;
 };
-_publicHandle
+
+GVAR(lastPFHid) = GVAR(lastPFHid) + 1;
+
+if (GVAR(lastPFHid) >= 999999) exitWith {
+    WARNING("Maximum amount of per frame handlers reached!");
+    diag_log _function;
+    -1
+};
+
+private _handle = GVAR(PFHhandles) pushBack GVAR(lastPFHid);
+
+GVAR(perFrameHandlerArray) pushBack [_function, _delay, 0, diag_tickTime, _args, _handle];
+
+_handle

--- a/addons/common/fnc_addPerFrameHandler.sqf
+++ b/addons/common/fnc_addPerFrameHandler.sqf
@@ -38,6 +38,6 @@ if (count GVAR(PFHhandles) >= 999999) exitWith {
 
 private _handle = GVAR(PFHhandles) pushBack count GVAR(perFrameHandlerArray);
 
-GVAR(perFrameHandlerArray) pushBack [_function, _delay, 0, diag_tickTime, _args, _handle];
+GVAR(perFrameHandlerArray) pushBack [_function, _delay, diag_tickTime, diag_tickTime, _args, _handle];
 
 _handle

--- a/addons/common/fnc_removePerFrameHandler.sqf
+++ b/addons/common/fnc_removePerFrameHandler.sqf
@@ -24,7 +24,7 @@ Author:
 
 params [["_handle", -1, [0]]];
 
-if (_handle < 0 || {_handle > GVAR(lastPFHid)}) exitWith {};
+if (_handle < 0 || {_handle >= count GVAR(PFHhandles)}) exitWith {};
 
 [{
     params ["_handle"];

--- a/addons/common/fnc_removePerFrameHandler.sqf
+++ b/addons/common/fnc_removePerFrameHandler.sqf
@@ -2,10 +2,10 @@
 Function: CBA_fnc_removePerFrameHandler
 
 Description:
-    Remove a handler that you have added using CBA_fnc_addPerFrameHandler
+    Remove a handler that you have added using CBA_fnc_addPerFrameHandler.
 
 Parameters:
-    _handle - The function handle you wish to remove
+    _handle - The function handle you wish to remove. <NUMBER>
 
 Returns:
     None
@@ -18,34 +18,24 @@ Examples:
     (end)
 
 Author:
-    Nou & Jaynus, donated from ACRE project code for use by the community.
-
+    Nou & Jaynus, donated from ACRE project code for use by the community; commy2
 ---------------------------------------------------------------------------- */
-
 #include "script_component.hpp"
 
-params ["_publicHandle"];
+params [["_handle", -1, [0]]];
 
-if (isNil "_publicHandle" || {_publicHandle < 0} || {(count GVAR(PFHhandles)) <= _publicHandle}) exitWith {// Nil/no handle or handle is out of bounds of Public Handle Array
-    WARNING("Invalid or not existing PFH ID.");
-};
+if (_handle < 0 || {_handle > GVAR(lastPFHid)}) exitWith {};
 
-private "_handle";
-_handle = GVAR(PFHhandles) select _publicHandle;
-if (isNil "_handle") exitWith {}; // Nil handle, nil action
-GVAR(PFHhandles) set [_publicHandle, nil];
-GVAR(perFrameHandlerArray) set [_handle, nil];
-_newArray = [];
+[{
+    params ["_handle"];
 
-GVAR(nextPFHid) = ({
-    private ["_newHandle", "_return"];
-    _return = false;
-    if !(isNil "_x") then {
-        _x params ["", "", "", "", "", "_publicH"];
-        _newHandle = _newArray pushBack _x;
-        GVAR(PFHhandles) set [_publicH, _newHandle];
-        _return = true;
-    };
-    _return
-} count GVAR(perFrameHandlerArray)) - 1;
-GVAR(perFrameHandlerArray) = _newArray;
+    GVAR(perFrameHandlerArray) deleteAt (GVAR(PFHhandles) select _handle);
+    GVAR(PFHhandles) set [_handle, nil];
+
+    {
+        _x params ["", "", "", "", "", "_handle"];
+        GVAR(PFHhandles) set [_handle, _forEachIndex];
+    } forEach GVAR(perFrameHandlerArray);
+}, _handle] call CBA_fnc_directCall;
+
+nil

--- a/addons/common/init_perFrameHandler.sqf
+++ b/addons/common/init_perFrameHandler.sqf
@@ -133,7 +133,7 @@ FUNC(onFrame) = {
         _x params ["_function", "_delay", "_delta", "", "_args", "_handle"];
 
         if (diag_tickTime > _delta) then {
-            _x set [2, diag_tickTime + _delay];
+            _x set [2, _delta + _delay];
             [_args, _handle] call _function;
             false
         };

--- a/addons/common/init_perFrameHandler.sqf
+++ b/addons/common/init_perFrameHandler.sqf
@@ -9,6 +9,7 @@ GVAR(perFrameHandlerArray) = [];
 GVAR(fpsCount) = 0;
 GVAR(lastCount) = -1;
 GVAR(lastFrameRender) = 0;
+GVAR(lastTickTime) = 0;
 
 PREP(perFrameEngine);
 
@@ -128,6 +129,7 @@ FUNC(monitorFrameRender) = {
 FUNC(onFrame) = {
     TRACE_1("Executing onFrame",nil);
     GVAR(lastFrameRender) = diag_frameNo;
+    GVAR(lastTickTime) = diag_tickTime;
 
     {
         _x params ["_function", "_delay", "_delta", "", "_args", "_handle"];
@@ -139,3 +141,10 @@ FUNC(onFrame) = {
         };
     } count GVAR(perFrameHandlerArray);
 };
+
+// fix for save games. subtract last tickTime from ETA of all PFHs after mission was loaded
+addMissionEventHandler ["Loaded", {
+    {
+        _x set [2, (_x select 2) - GVAR(lastTickTime) + diag_tickTime];
+    } forEach GVAR(perFrameHandlerArray);
+}];

--- a/addons/common/init_perFrameHandler.sqf
+++ b/addons/common/init_perFrameHandler.sqf
@@ -128,25 +128,14 @@ FUNC(monitorFrameRender) = {
 FUNC(onFrame) = {
     TRACE_1("Executing onFrame",nil);
     GVAR(lastFrameRender) = diag_frameNo;
-    // if(GVAR(lastCount) > (GVAR(fpsCount)-1)) then {
-        // hint "FUCK UP IN SEQUENCE!";
-    // };
-    // player sideChat format["fps: %1 %2 %3", (GVAR(fpsCount)/diag_fps), diag_fps, GVAR(fpsCount)];
-    // GVAR(lastCount) = GVAR(fpsCount);
-    // GVAR(fpsCount) = GVAR(fpsCount) + 1;
-    // player sideChat format["c: %1", GVAR(perFrameHandlerArray)];
-    {
 
-        if !(isNil "_x") then {
-            _handlerData = _x;
-            if (_handlerData params ["_func", "_delay", "_delta", "", "_args", "_idPFH"]) then {
-                if (diag_tickTime > _delta) then {
-                    [_args, _idPFH] call _func;
-                    _delta = diag_tickTime + _delay;
-                    //TRACE_1("data", _data);
-                    _handlerData set [2, _delta];
-                };
-            };
+    {
+        _x params ["_function", "_delay", "_delta", "", "_args", "_handle"];
+
+        if (diag_tickTime > _delta) then {
+            _x set [2, diag_tickTime + _delay];
+            [_args, _handle] call _function;
+            false
         };
     } count GVAR(perFrameHandlerArray);
 };


### PR DESCRIPTION
ref: #229, #230 

- makes CBA_fnc_addPerFrameHandler and CBA_fnc_removePerFrameHandler safe to be used in scheduled environment.
- moves stuff around in `FUNC(onFrame)` to reduce overhead
- adds debug log when more than 1kk PFHs were added per mission.
- adds PFH save game compatibility

I'm currently on 1.55 dev and there seems to be no array size limit, so I can't really test #229.