### PR TITLE
Fix include file name capitalizations

### DIFF
--- a/addons/diagnostic/config.cpp
+++ b/addons/diagnostic/config.cpp
@@ -13,6 +13,6 @@ class CfgPatches
 };
 
 #include "CfgFunctions.hpp"
-#include "CfgEventhandlers.hpp"
+#include "CfgEventHandlers.hpp"
 
 

--- a/addons/events/config.cpp
+++ b/addons/events/config.cpp
@@ -11,7 +11,7 @@ class CfgPatches
         authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };
-#include "CfgEventhandlers.hpp"
+#include "CfgEventHandlers.hpp"
 #include "CfgFunctions.hpp"
 
 

--- a/addons/network/config.cpp
+++ b/addons/network/config.cpp
@@ -11,7 +11,7 @@ class CfgPatches
         authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };
-#include "CfgEventhandlers.hpp"
+#include "CfgEventHandlers.hpp"
 #include "CfgFunctions.hpp"
 
 


### PR DESCRIPTION
The on-disk filenames for the event handler definition
header files is "CfgEventHandlers.hpp". The include statement
needs to specify exactly that for builds in Linux to work.
(Unix file systems have case-significant file names)