### PR TITLE
Fix XEH_ENABLED macro

### DIFF
--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -1407,7 +1407,7 @@ Author:
 // XEH Specific
 #define XEH_CLASS CBA_Extended_EventHandlers
 #define XEH_DISABLED class EventHandlers { class XEH_CLASS {}; }; SLX_XEH_DISABLED = 1
-#define XEH_ENABLED class EventHandlers { class XEH_CLASS { EXTENDED_EVENTHANDLERS }; }; delete SLX_XEH_DISABLED
+#define XEH_ENABLED class EventHandlers { class XEH_CLASS { EXTENDED_EVENTHANDLERS }; }; SLX_XEH_DISABLED = 0
 
 // TODO: These are actually outdated; _Once ?
 #define XEH_PRE_INIT QUOTE(call COMPILE_FILE(XEH_PreInit_Once))

--- a/addons/xeh/script_component.hpp
+++ b/addons/xeh/script_component.hpp
@@ -40,7 +40,7 @@
 #include "script_xeh.hpp"
 
 #undef XEH_ENABLED
-#define XEH_ENABLED class EventHandlers { class XEH_CLASS: XEH_CLASS {}; }; delete SLX_XEH_DISABLED
+#define XEH_ENABLED class EventHandlers { class XEH_CLASS: XEH_CLASS {}; }; SLX_XEH_DISABLED = 0
 
 #define XEH_EVENTS \
     "AnimChanged", \


### PR DESCRIPTION
Explosive triggers aren't working in ace, which are a vehicle that that inherits `XEH_DISABLED` from Thing.

XEH_ENABLED macro use of `delete` does not seem to have any effect.  I believe we need to zero out the number instead.

Without this:
```
    class ACE_Explosives_Place: Items_base_F {
        XEH_ENABLED;
```
`getNumber (configfile >> "CfgVehicles" >> "ACE_Explosives_Place" >> "SLX_XEH_DISABLED")` = 1