### PR TITLE
fix SLX_XEH_DISABLED is not meant to disable extended event handlers

### DIFF
--- a/addons/xeh/fnc_addClassEventHandler.sqf
+++ b/addons/xeh/fnc_addClassEventHandler.sqf
@@ -69,7 +69,7 @@ private _entities = entities "" + allUnits;
 private _eventVarName = format [QGVAR(%1), _eventName];
 
 {
-    if (_x isKindOf _className && {getNumber (_config >> "SLX_XEH_DISABLED") != 1}) then {
+    if (_x isKindOf _className) then {
         private _unit = _x;
 
         if (ISKINDOF(_unit,_className,_allowInheritance,_excludedClasses)) then {

--- a/addons/xeh/fnc_initEvents.sqf
+++ b/addons/xeh/fnc_initEvents.sqf
@@ -28,8 +28,6 @@ if !(ISPROCESSED(_unit)) then {
 
     private _class = configFile >> "CfgVehicles" >> typeOf _unit;
 
-    if (getNumber (_class >> "SLX_XEH_DISABLED") == 1) exitWith {};
-
     // add events to XEH incompatible units
     if (!isClass (_class >> "EventHandlers" >> QUOTE(XEH_CLASS))) then {
         {

--- a/addons/xeh/fnc_startFallbackLoop.sqf
+++ b/addons/xeh/fnc_startFallbackLoop.sqf
@@ -42,7 +42,7 @@ GVAR(entities) = [];
             if !(ISPROCESSED(_x)) then {
                 _x call CBA_fnc_initEvents;
 
-                if (!ISINITIALIZED(_x) && {getNumber (configFile >> "CfgVehicles" >> typeOf _x >> "SLX_XEH_DISABLED") != 1}) then {
+                if !(ISINITIALIZED(_x)) then {
                     _x call CBA_fnc_init;
                 };
             };

--- a/addons/xeh/fnc_supportMonitor.sqf
+++ b/addons/xeh/fnc_supportMonitor.sqf
@@ -29,7 +29,7 @@ private _notSupportingClasses = [];
 
 {
     if (_classFilter == "" || {configName _x isKindOf _classFilter}) then {
-        if (!isClass (_x >> "EventHandlers" >> QUOTE(XEH_CLASS))) then {
+        if (configProperties [_x >> "EventHandlers" >> QUOTE(XEH_CLASS)] isEqualTo []) then {
             // don't list duplicates
             if (!_includeDuplicates && {{configName _x == "EventHandlers"} count configProperties [_x, "isClass _x", false] == 0}) exitWith {};
 

--- a/addons/xeh/script_xeh.hpp
+++ b/addons/xeh/script_xeh.hpp
@@ -55,41 +55,41 @@ weaponRested = "{_this call _x} forEach ((_this select 0) getVariable ""cba_xeh_
     Removes all event handlers.
 */
 
-#define DELETE_EVENTHANDLERS delete init; \
-delete fired; \
-delete animChanged; \
-delete animDone; \
-delete animStateChanged; \
-delete containerClosed; \
-delete containerOpened; \
-delete controlsShifted; \
-delete dammaged; \
-delete engine; \
-delete epeContact; \
-delete epeContactEnd; \
-delete epeContactStart; \
-delete explosion; \
-delete firedNear; \
-delete fuel; \
-delete gear; \
-delete getIn; \
-delete getOut; \
-delete handleHeal; \
-delete hit; \
-delete hitPart; \
-delete incomingMissile; \
-delete inventoryClosed; \
-delete inventoryOpened; \
-delete killed; \
-delete landedTouchDown; \
-delete landedStopped; \
-delete local; \
-delete respawn; \
-delete put; \
-delete take; \
-delete seatSwitched; \
-delete soundPlayed; \
-delete weaponAssembled; \
-delete weaponDisassembled; \
-delete weaponDeployed; \
-delete weaponRested;
+#define DELETE_EVENTHANDLERS init = ""; \
+fired = ""; \
+animChanged = ""; \
+animDone = ""; \
+animStateChanged = ""; \
+containerClosed = ""; \
+containerOpened = ""; \
+controlsShifted = ""; \
+dammaged = ""; \
+engine = ""; \
+epeContact = ""; \
+epeContactEnd = ""; \
+epeContactStart = ""; \
+explosion = ""; \
+firedNear = ""; \
+fuel = ""; \
+gear = ""; \
+getIn = ""; \
+getOut = ""; \
+handleHeal = ""; \
+hit = ""; \
+hitPart = ""; \
+incomingMissile = ""; \
+inventoryClosed = ""; \
+inventoryOpened = ""; \
+killed = ""; \
+landedTouchDown = ""; \
+landedStopped = ""; \
+local = ""; \
+respawn = ""; \
+put = ""; \
+take = ""; \
+seatSwitched = ""; \
+soundPlayed = ""; \
+weaponAssembled = ""; \
+weaponDisassembled = ""; \
+weaponDeployed = ""; \
+weaponRested = "";


### PR DESCRIPTION
`SLX_XEH_DISABLED` was never meant to disable extended event handlers. It's was only used in the old support monitor script.

https://github.com/CBATeam/CBA_A3/pull/241 already fixes all occurrences in ACE 3, but some addon out there that is no longer supported might still have the old entry.

This PR removes the `SLX_XEH_DISABLED` check where appropriate.

It also improves `[false, false, true] call CBA_fnc_supportMonitor` to report classes where XEH is explicitly disabled instead of only reporting those who disable it by not inheriting `EventHandlers` (and having `SLX_XEH_DISABLED = 1;`).