### PR TITLE
Remove XEH Caching

### DIFF
--- a/addons/xeh/fnc_compileEventHandlers.sqf
+++ b/addons/xeh/fnc_compileEventHandlers.sqf
@@ -64,11 +64,8 @@ private _resultNames = [];
             };
         };
 
-        // only add event on machines where it exists
-        if !(_eventFunc isEqualTo "") then {
-            _result pushBack ["", _eventName, compile _eventFunc];
-            _resultNames pushBack _customName;
-        };
+        _result pushBack ["", _eventName, compile _eventFunc];
+        _resultNames pushBack _customName;
     } forEach configProperties [_baseConfig >> XEH_FORMAT_CONFIG_NAME(_eventName)];
 } forEach ["preStart", "preInit", "postInit"]; 
 
@@ -170,11 +167,25 @@ private _resultNames = [];
 
             // only add event on machines where it exists
             if !(_eventFunc isEqualTo _eventFuncBase) then {
-                _result pushBack [_className, _eventName, compile _eventFunc, _allowInheritance, _excludedClasses];
-                _resultNames pushBack _customName;
+                _eventFunc = compile _eventFunc;
+            } else {
+                _eventFunc = {};
             };
+
+            _result pushBack [_className, _eventName, _eventFunc, _allowInheritance, _excludedClasses];
+            _resultNames pushBack _customName;
         } forEach configProperties [_x];
     } forEach configProperties [_baseConfig >> XEH_FORMAT_CONFIG_NAME(_eventName), "isClass _x"];
 } forEach [XEH_EVENTS];
 
-_result
+//_result select {!((_x select 2) isEqualTo {})} @todo 1.55 dev, delete everything below
+
+private _return = [];
+
+{
+    if !((_x select 2) isEqualTo {}) then {
+        _return pushBack _x;
+    };
+} forEach _result;
+
+_return

--- a/addons/xeh/fnc_compileEventHandlers.sqf
+++ b/addons/xeh/fnc_compileEventHandlers.sqf
@@ -45,17 +45,21 @@ private _resultNames = [];
             };
 
             // client only events
-            private _entryClient = _x >> "clientInit";
+            if (!isDedicated) then {
+                _entry = _x >> "clientInit";
 
-            if (!isDedicated && {isText _entryClient}) then {
-                _eventFunc = _eventFunc + getText _entryClient + ";";
+                if (isText _entry) then {
+                    _eventFunc = _eventFunc + getText _entry + ";";
+                };
             };
 
             // server only events
-            private _entryServer = _x >> "serverInit";
+            if (isServer) then {
+                _entry = _x >> "serverInit";
 
-            if (isServer && {isText _entryServer}) then {
-                _eventFunc = _eventFunc + getText _entryServer + ";";
+                if (isText _entry) then {
+                    _eventFunc = _eventFunc + getText _entry + ";";
+                };
             };
         } else {
             // global events
@@ -64,7 +68,15 @@ private _resultNames = [];
             };
         };
 
-        _result pushBack ["", _eventName, compile _eventFunc];
+        if !(_eventFunc isEqualTo "") then {
+            _eventFunc = compile _eventFunc;
+            TRACE_2("does something",_customName,_eventName);
+        } else {
+            _eventFunc = {};
+            TRACE_2("does NOT do something",_customName,_eventName);
+        };
+
+        _result pushBack ["", _eventName, _eventFunc];
         _resultNames pushBack _customName;
     } forEach configProperties [_baseConfig >> XEH_FORMAT_CONFIG_NAME(_eventName)];
 } forEach ["preStart", "preInit", "postInit"]; 
@@ -123,17 +135,21 @@ private _resultNames = [];
                 };
 
                 // client only events
-                private _entryClient = _x >> format ["client%1", _entryName];
+                if (!isDedicated) then {
+                    _entry = _x >> format ["client%1", _entryName];
 
-                if (!isDedicated && {isText _entryClient}) then {
-                    _eventFunc = _eventFunc + getText _entryClient + ";";
+                    if (isText _entry) then {
+                        _eventFunc = _eventFunc + getText _entry + ";";
+                    };
                 };
 
                 // server only events
-                private _entryServer = _x >> format ["server%1", _entryName];
+                if (isServer) then {
+                    _entry = _x >> format ["server%1", _entryName];
 
-                if (isServer && {isText _entryServer}) then {
-                    _eventFunc = _eventFunc + getText _entryServer + ";";
+                    if (isText _entry) then {
+                        _eventFunc = _eventFunc + getText _entry + ";";
+                    };
                 };
 
                 // init event handlers that should run on respawn again, onRespawn = 1
@@ -168,8 +184,10 @@ private _resultNames = [];
             // only add event on machines where it exists
             if !(_eventFunc isEqualTo _eventFuncBase) then {
                 _eventFunc = compile _eventFunc;
+                TRACE_3("does something",_customName,_className,_eventName);
             } else {
                 _eventFunc = {};
+                TRACE_3("does NOT do something",_customName,_className,_eventName);
             };
 
             _result pushBack [_className, _eventName, _eventFunc, _allowInheritance, _excludedClasses];

--- a/addons/xeh/fnc_compileEventHandlers.sqf
+++ b/addons/xeh/fnc_compileEventHandlers.sqf
@@ -47,14 +47,14 @@ private _resultNames = [];
             // client only events
             private _entryClient = _x >> "clientInit";
 
-            if ((!isDedicated) && {isText _entryClient}) then {
+            if (!isDedicated && {isText _entryClient}) then {
                 _eventFunc = _eventFunc + getText _entryClient + ";";
             };
 
             // server only events
             private _entryServer = _x >> "serverInit";
 
-            if ((isServer) && {isText _entryServer}) then {
+            if (isServer && {isText _entryServer}) then {
                 _eventFunc = _eventFunc + getText _entryServer + ";";
             };
         } else {
@@ -64,8 +64,11 @@ private _resultNames = [];
             };
         };
 
-        _result pushBack ["", _eventName, compile _eventFunc];
-        _resultNames pushBack _customName;
+        // only add event on machines where it exists
+        if !(_eventFunc isEqualTo "") then {
+            _result pushBack ["", _eventName, compile _eventFunc];
+            _resultNames pushBack _customName;
+        };
     } forEach configProperties [_baseConfig >> XEH_FORMAT_CONFIG_NAME(_eventName)];
 } forEach ["preStart", "preInit", "postInit"]; 
 
@@ -168,9 +171,8 @@ private _resultNames = [];
             // only add event on machines where it exists
             if !(_eventFunc isEqualTo _eventFuncBase) then {
                 _result pushBack [_className, _eventName, compile _eventFunc, _allowInheritance, _excludedClasses];
+                _resultNames pushBack _customName;
             };
-
-            _resultNames pushBack _customName;
         } forEach configProperties [_x];
     } forEach configProperties [_baseConfig >> XEH_FORMAT_CONFIG_NAME(_eventName), "isClass _x"];
 } forEach [XEH_EVENTS];

--- a/addons/xeh/fnc_compileEventHandlers.sqf
+++ b/addons/xeh/fnc_compileEventHandlers.sqf
@@ -95,7 +95,6 @@ private _resultNames = [];
             private _customName = configName _x;
             private _allowInheritance = true;
             private _excludedClasses = [];
-            private _doesSomething = false;
 
             if (isClass _x) then {
                 // allow inheritance of this event?
@@ -121,23 +120,20 @@ private _resultNames = [];
 
                 if (isText _entry) then {
                     _eventFunc = _eventFunc + getText _entry + ";";
-                    _doesSomething = true;
                 };
 
                 // client only events
                 private _entryClient = _x >> format ["client%1", _entryName];
 
-                if ((!isDedicated) && {isText _entryClient}) then {
+                if (!isDedicated && {isText _entryClient}) then {
                     _eventFunc = _eventFunc + getText _entryClient + ";";
-                    _doesSomething = true;
                 };
 
                 // server only events
                 private _entryServer = _x >> format ["server%1", _entryName];
 
-                if ((isServer) && {isText _entryServer}) then {
+                if (isServer && {isText _entryServer}) then {
                     _eventFunc = _eventFunc + getText _entryServer + ";";
-                    _doesSomething = true;
                 };
 
                 // init event handlers that should run on respawn again, onRespawn = 1
@@ -148,12 +144,7 @@ private _resultNames = [];
                 // global events
                 if (isText _x) then {
                     _eventFunc = getText _x + ";";
-                    _doesSomething = true;
                 };
-            };
-            
-            if ((!_doesSomething) && {!isMultiplayer}) then { //Print error warning for XEH with no actual code
-                diag_log text format ["[XEH]: No functions found for [%1] in [%2] from config [%3] (check event name)", _eventName, _customName, _x];
             };
 
             // emulate oo-like inheritance by adding classnames that would redefine an event by using the same custom event name to the excluded classes
@@ -174,7 +165,11 @@ private _resultNames = [];
                 };
             } forEach _resultNames;
 
-            _result pushBack [_className, _eventName, compile _eventFunc, _allowInheritance, _excludedClasses, _doesSomething];
+            // only add event on machines where it exists
+            if !(_eventFunc isEqualTo _eventFuncBase) then {
+                _result pushBack [_className, _eventName, compile _eventFunc, _allowInheritance, _excludedClasses];
+            };
+
             _resultNames pushBack _customName;
         } forEach configProperties [_x];
     } forEach configProperties [_baseConfig >> XEH_FORMAT_CONFIG_NAME(_eventName), "isClass _x"];

--- a/addons/xeh/fnc_preInit.sqf
+++ b/addons/xeh/fnc_preInit.sqf
@@ -61,15 +61,12 @@ GVAR(EventsLowercase) = [];
     };
 } forEach ([false, true] call CBA_fnc_supportMonitor);
 
-// recompile extended event handlers when enabled
-if (["xeh"] call CBA_fnc_isRecompileEnabled) then {
-    GVAR(allEventHandlers) = configFile call CBA_fnc_compileEventHandlers; // from addon config
-} else {
-    GVAR(allEventHandlers) = call (uiNamespace getVariable QGVAR(fnc_getAllEventHandlers));
-};
-
+// always recompile extended event handlers
+// XEH_LOG("XEH: Compiling XEH START");
+GVAR(allEventHandlers) = configFile call CBA_fnc_compileEventHandlers; // from addon config
 GVAR(allEventHandlers) append (missionConfigFile call CBA_fnc_compileEventHandlers); // from mission config
 GVAR(allEventHandlers) append (campaignConfigFile call CBA_fnc_compileEventHandlers); // from campaign config
+// XEH_LOG("XEH: Compiling XEH END");
 
 // add extended event handlers to classes
 GVAR(fallbackRunning) = false;
@@ -81,18 +78,19 @@ GVAR(fallbackRunning) = false;
             call (_x select 2);
         };
     } else {
-        _x params ["_className", "_eventName", "_eventFunc", "_allowInheritance", "_excludedClasses"];
+        _x params ["_className", "_eventName", "_eventFunc", "_allowInheritance", "_excludedClasses", "_doesSomething"];
 
         // backwards comp, args in _this are already switched
         if (_eventName == "firedBis") then {
             _eventName = "fired";
         };
 
-        private _success = [_className, _eventName, _eventFunc, _allowInheritance, _excludedClasses] call CBA_fnc_addClassEventHandler;
-
-        #ifdef DEBUG_MODE_FULL
-            diag_log text format ["%1:%2=%3", _className, _eventName, _success];
-        #endif
+        if (_doesSomething) then {
+            private _success = [_className, _eventName, _eventFunc, _allowInheritance, _excludedClasses] call CBA_fnc_addClassEventHandler;
+            TRACE_3("does something",_className,_eventName,_success);
+        } else {
+            TRACE_2("does NOT do something",_className,_eventName);
+        };
     };
 } forEach GVAR(allEventHandlers);
 

--- a/addons/xeh/fnc_preInit.sqf
+++ b/addons/xeh/fnc_preInit.sqf
@@ -62,11 +62,19 @@ GVAR(EventsLowercase) = [];
 } forEach ([false, true] call CBA_fnc_supportMonitor);
 
 // always recompile extended event handlers
-// XEH_LOG("XEH: Compiling XEH START");
-GVAR(allEventHandlers) = configFile call CBA_fnc_compileEventHandlers; // from addon config
-GVAR(allEventHandlers) append (missionConfigFile call CBA_fnc_compileEventHandlers); // from mission config
-GVAR(allEventHandlers) append (campaignConfigFile call CBA_fnc_compileEventHandlers); // from campaign config
-// XEH_LOG("XEH: Compiling XEH END");
+#ifdef DEBUG_MODE_FULL
+    XEH_LOG("XEH: Compiling XEH START");
+#endif
+
+GVAR(allEventHandlers) = [];
+
+{
+    GVAR(allEventHandlers) append (_x call CBA_fnc_compileEventHandlers);
+} forEach [configFile, campaignConfigFile, missionConfigFile];
+
+#ifdef DEBUG_MODE_FULL
+    XEH_LOG("XEH: Compiling XEH END");
+#endif
 
 // add extended event handlers to classes
 GVAR(fallbackRunning) = false;
@@ -78,19 +86,15 @@ GVAR(fallbackRunning) = false;
             call (_x select 2);
         };
     } else {
-        _x params ["_className", "_eventName", "_eventFunc", "_allowInheritance", "_excludedClasses", "_doesSomething"];
+        _x params ["_className", "_eventName", "_eventFunc", "_allowInheritance", "_excludedClasses"];
 
         // backwards comp, args in _this are already switched
         if (_eventName == "firedBis") then {
             _eventName = "fired";
         };
 
-        if (_doesSomething) then {
-            private _success = [_className, _eventName, _eventFunc, _allowInheritance, _excludedClasses] call CBA_fnc_addClassEventHandler;
-            TRACE_3("does something",_className,_eventName,_success);
-        } else {
-            TRACE_2("does NOT do something",_className,_eventName);
-        };
+        private _success = [_className, _eventName, _eventFunc, _allowInheritance, _excludedClasses] call CBA_fnc_addClassEventHandler;
+        TRACE_3("addClassEventHandler",_className,_eventName,_success);
     };
 } forEach GVAR(allEventHandlers);
 

--- a/addons/xeh/fnc_preStart.sqf
+++ b/addons/xeh/fnc_preStart.sqf
@@ -23,16 +23,12 @@ with uiNamespace do {
 
     XEH_LOG("XEH: PreStart started.");
 
-    // pre compile PreInit and PostInit config event handlers
-    // stored in function to prevent these from being overwritten
-    GVAR(fnc_getAllEventHandlers) = compileFinal str (configFile call CBA_fnc_compileEventHandlers);
-
     // call PreStart events
     {
         if (_x select 1 == "preStart") then {
             call (_x select 2);
         };
-    } forEach (call FUNC(getAllEventHandlers));
+    } forEach (configFile call CBA_fnc_compileEventHandlers);
 
     #ifdef DEBUG_MODE_FULL
         diag_log text format ["isScheduled = %1", call CBA_fnc_isScheduled];


### PR DESCRIPTION
With the new XEH overhaul, we were baking the `isServer` checks into the XEH code for server events. 

By eliminating the cache and building the code at runtime, we can add only valid XEH based on the machine type.
With CBA/ACE, compiling configFile's XEH takes less than a 1/4 second on my machine, with a full modset, it's less than 1/2 a second, so we weren't gaining much by caching.

Performance gains are **very** minimal, but `isServer` `!isDedicated` and the `forEach` iteration all take some time. I think it's better to spend a little more time at mission load than during gameplay.

I've also added a rpt warning for Composite XEH that don't have any matching text (ace's cargo was doing this).

Example:
```
class Extended_Killed_EventHandlers {
    class All {
        class test0 { killed = "diag_log text format ['test0 %1', _this];"; };
        class test1 { serverKilled = "diag_log text format ['test1 %1', _this];"; };
        class test2 { clientKilled = "diag_log text format ['test2 %1', _this];"; };
        class test3 { init = "diag_log text format ['test3 %1', _this];"; }; //text does not match event, this won't do anything
    };
};
```
Checking `cursorTarget getVariable "cba_xeh_killed"`
```
[ //Before:
{_this call ace_attach_fnc_handleKilled;},
{call ace_cargo_fnc_handleDestroyed;},
{diag_log text format ['test0 %1', _this];;},
{if (isServer) then {diag_log text format ['test1 %1', _this];};},
{if (!isDedicated) then {diag_log text format ['test2 %1', _this];};},
{}
]

[ //After:
{_this call ace_attach_fnc_handleKilled;},
{call ace_cargo_fnc_handleDestroyed;},
{diag_log text format ['test0 %1', _this];;},
{diag_log text format ['test1 %1', _this];;},
{diag_log text format ['test2 %1', _this];;}
]
```

And on dedicated we don't add clientXEH and clients don't add serverXEH.