### PR TITLE
add addon and path to debug when deprecated fired XEH is used

### DIFF
--- a/addons/xeh/fnc_compileEventHandlers.sqf
+++ b/addons/xeh/fnc_compileEventHandlers.sqf
@@ -99,7 +99,7 @@ private _resultNames = [];
         if (_eventName == "fired") then {
             // generate backwards compatible format of _this
             _eventFuncBase = "private _this = [_this select 0, _this select 1, _this select 2, _this select 3, _this select 4, _this select 6, _this select 5];";
-            diag_log text format ["[XEH]: Usage of deprecated Extended Eventhandler ""fired"". Use ""firedBis"" instead. Path: %1\%2\%3\%4.", configSourceMod _x, _baseConfig, XEH_FORMAT_CONFIG_NAME(_eventName), _className];
+            diag_log text format ["[XEH]: Usage of deprecated Extended Event Handler ""fired"". Use ""firedBIS"" instead. Path: %1\%2\%3\%4.", configSourceMod _x, _baseConfig, XEH_FORMAT_CONFIG_NAME(_eventName), _className];
         };
 
         {

--- a/addons/xeh/fnc_compileEventHandlers.sqf
+++ b/addons/xeh/fnc_compileEventHandlers.sqf
@@ -99,7 +99,7 @@ private _resultNames = [];
         if (_eventName == "fired") then {
             // generate backwards compatible format of _this
             _eventFuncBase = "private _this = [_this select 0, _this select 1, _this select 2, _this select 3, _this select 4, _this select 6, _this select 5];";
-            diag_log text "[XEH]: Usage of deprecated Extended Eventhandler ""fired"". Use ""firedBis"" instead.";
+            diag_log text format ["[XEH]: Usage of deprecated Extended Eventhandler ""fired"". Use ""firedBis"" instead. Path: %1\%2\%3\%4.", configSourceMod _x, _baseConfig, XEH_FORMAT_CONFIG_NAME(_eventName), _className];
         };
 
         {


### PR DESCRIPTION
Used in addon:
`21:33:13 [XEH]: Usage of deprecated Extended Eventhandler "fired". Use "firedBis" instead. Path: CBA_A3\bin\config.bin\Extended_Fired_EventHandlers\CAManBase.`

Used in (unpacked) mission:
`21:33:13 [XEH]: Usage of deprecated Extended Eventhandler "fired". Use "firedBis" instead. Path: \C:\Users\admin\Documents\Arma 3 - Other Profiles\Gefr%2e%20commy2\missions\$The_Test$.VR\description.ext\Extended_Fired_EventHandlers\CAManBase.`