### PR TITLE
add CBA_fnc_createNamespace and CBA_fnc_deleteNamespace

### DIFF
--- a/addons/common/CfgFunctions.hpp
+++ b/addons/common/CfgFunctions.hpp
@@ -87,6 +87,12 @@ class CfgFunctions
                 description = "Creates a marker all at once.";
                 file = "\x\cba\addons\common\fnc_createMarker.sqf";
             };
+            // CBA_fnc_createNamespace
+            class createNamespace
+            {
+                description = "Creates a namespace. Used to store and read variables via setVariable and getVariable.";
+                file = "\x\cba\addons\common\fnc_createNamespace.sqf";
+            };
             // CBA_fnc_createTrigger
             class createTrigger
             {
@@ -104,6 +110,12 @@ class CfgFunctions
             {
                 description = "A function used to delete entities";
                 file = "\x\cba\addons\common\fnc_deleteEntity.sqf";
+            };
+            // CBA_fnc_deleteNamespace
+            class deleteNamespace
+            {
+                description = "Deletes a namespace created with CBA_fnc_createNamespace.";
+                file = "\x\cba\addons\common\fnc_deleteNamespace.sqf";
             };
             // CBA_fnc_determineMuzzles
             class determineMuzzles

--- a/addons/common/CfgLocationTypes.hpp
+++ b/addons/common/CfgLocationTypes.hpp
@@ -1,0 +1,13 @@
+
+class CfgLocationTypes {
+    class CBA_NamespaceDummy {
+        name = "";
+        drawStyle = "name";
+        texture = "";
+        color[] = {0,0,0,0};
+        size = 0;
+        textSize = 0;
+        shadow = 0;
+        font = "PuristaMedium";
+    };
+};

--- a/addons/common/config.cpp
+++ b/addons/common/config.cpp
@@ -16,6 +16,7 @@ class CfgPatches {
 #include "CfgFunctions.hpp"
 #include "CfgPerFrame.hpp"
 #include "CfgRemoteExec.hpp"
+#include "CfgLocationTypes.hpp"
 
 class CBA_DirectCall {
     class dummy;

--- a/addons/common/fnc_createNamespace.sqf
+++ b/addons/common/fnc_createNamespace.sqf
@@ -20,5 +20,6 @@ Author:
     commy2
 ---------------------------------------------------------------------------- */
 #include "script_component.hpp"
+SCRIPT(createNamespace);
 
 createLocation ["CBA_NamespaceDummy", [-1000, -1000, 0], 0, 0]

--- a/addons/common/fnc_createNamespace.sqf
+++ b/addons/common/fnc_createNamespace.sqf
@@ -1,0 +1,24 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_createNamespace
+
+Description:
+    Creates a namespace. Used to store and read variables via setVariable and getVariable.
+    The Namespace is destroyed after the mission ends. getVariable ARRAY is not supported.
+
+Parameters:
+    None
+
+Returns:
+    _namespace - a namespace <LOCATION>
+
+Examples:
+    (begin example)
+        _namespace = call CBA_fnc_createNamespace;
+    (end)
+
+Author:
+    commy2
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+
+createLocation ["CBA_NamespaceDummy", [-1000, -1000, 0], 0, 0]

--- a/addons/common/fnc_deleteNamespace.sqf
+++ b/addons/common/fnc_deleteNamespace.sqf
@@ -19,6 +19,7 @@ Author:
     commy2
 ---------------------------------------------------------------------------- */
 #include "script_component.hpp"
+SCRIPT(deleteNamespace);
 
 params [["_namespace", locationNull, [locationNull]]];
 

--- a/addons/common/fnc_deleteNamespace.sqf
+++ b/addons/common/fnc_deleteNamespace.sqf
@@ -1,0 +1,25 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_deleteNamespace
+
+Description:
+    Deletes a namespace created with CBA_fnc_createNamespace.
+
+Parameters:
+    _namespace - a namespace <LOCATION>
+
+Returns:
+    None
+
+Examples:
+    (begin example)
+        _namespace call CBA_fnc_deleteNamespace;
+    (end)
+
+Author:
+    commy2
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+
+params [["_namespace", locationNull, [locationNull]]];
+
+deleteLocation _namespace;


### PR DESCRIPTION
This is a faster alternative to creating pseudo-namespaces compared to `createVehicleLocal` with `Logic` or similar. It also never runs into any limitations regarding group count and is strictly local.
It is based on creating a location outside of the map which is used as container for variables.

Perf test:
`call CBA_fnc_createNamespace;`
0.0207031 ms
(10000/10000)

`"Logic" createVehicleLocal [-1000,-1000,0];`
0.138744 ms
(6649/10000)

Usage:
```
test_namespace = call CBA_fnc_createNamespace;
test_namespace setVariable ["test_value", 123];
```
```
test_namespace getVariable "test_value"
-> 123
```
```
allVariables test_namespace
["test_value"]
```
```
test_namespace call CBA_fnc_deleteNamespace;
```

Only downside is, that the `getVariable ARRAY` syntax does not work it.