### PR TITLE
Add the ability to disable fnc_globalExecute

### DIFF
--- a/addons/network/XEH_preInit.sqf
+++ b/addons/network/XEH_preInit.sqf
@@ -94,10 +94,10 @@ if (SLX_XEH_MACHINE select 3) then {
 };
 
 // CBA_fnc_globalExecute is normally enabled
-_disableGE = false;
+private _disableGE = false;
 
 // Check the CfgSettings >> "CBA" >> "network" >> "disableGlobalExecute" value
-_entry = (CFGSETTINGSS(CBA,COMPONENT) >> "disableGlobalExecute");
+private _entry = (CFGSETTINGSS(CBA,COMPONENT) >> "disableGlobalExecute");
 if (isNumber _entry) then {
     _disableGE = (getNumber _entry == 1);
 } else {
@@ -107,7 +107,7 @@ if (isNumber _entry) then {
 };
 
 // Check the mission configuration
-_dGE = getMissionConfigValue ["CBA_disableGlobalExecute", -1];
+private _dGE = getMissionConfigValue ["CBA_disableGlobalExecute", -1];
 if (_dGE isEqualType 0) then {
     if (_dGE in [0, 1]) then {
         _disableGE = (_dGE == 1);

--- a/addons/network/XEH_preInit.sqf
+++ b/addons/network/XEH_preInit.sqf
@@ -46,8 +46,6 @@ ADDON = false;
 ISNIL(timeSync_Disabled,true); // deprecated
 ISNIL(weatherSync_Disabled,true);
 
-PREP(exec);
-
 DEPRECATE(fnc_remoteExecute,fnc_globalExecute);
 DEPRECATE(fnc_remoteSay,fnc_globalSay);
 
@@ -95,8 +93,38 @@ if (SLX_XEH_MACHINE select 3) then {
     };
 };
 
+// CBA_fnc_globalExecute is normally enabled
+_disableGE = false;
 
-[QUOTE(GVAR(cmd)), { if (GVAR(init)) then { _this spawn FUNC(exec) } }] call (uiNamespace getVariable "CBA_fnc_addEventHandler");
+// Check the CfgSettings >> "CBA" >> "network" >> "disableGlobalExecute" value
+_entry = (CFGSETTINGSS(CBA,COMPONENT) >> "disableGlobalExecute");
+if (isNumber _entry) then {
+    _disableGE = (getNumber _entry == 1);
+} else {
+    if (isText _entry) then {
+        _disableGE = (getText _entry == "true");
+    };
+};
+
+// Check the mission configuration
+_dGE = getMissionConfigValue ["CBA_disableGlobalExecute", -1];
+if (_dGE isEqualType 0) then {
+    if (_dGE in [0, 1]) then {
+        _disableGE = (_dGE == 1);
+    };
+} else {
+    if (_dGE isEqualType "") then {
+        _disableGE = (_dGE == "true");
+    };
+};
+
+if (_disableGE) then {
+    uiNamespace setVariable [QGVAR(exec), compileFinal ""];
+    missionNamespace setVariable [QGVAR(exec), compileFinal ""];
+} else {
+    PREP(exec);
+    [QUOTE(GVAR(cmd)), { if (GVAR(init)) then { _this spawn FUNC(exec) } }] call (uiNamespace getVariable "CBA_fnc_addEventHandler");
+};
 [QUOTE(GVAR(say)), { private "_say"; _say = _this; _objects = _say select 0; if (typeName _objects != "ARRAY") then { _objects = [_objects] }; { _x say (_say select 1) } forEach _objects }] call (uiNamespace getVariable "CBA_fnc_addEventHandler");
 [QUOTE(GVAR(say3d)), { private "_say"; _say = _this; if (count _this > 2) then { if ((positionCameraToWorld [0,0,0]) distance (_say select 0) <= (_say select 2)) then { (_say select 0) say3d (_say select 1) } } else { (_say select 0) say3d (_say select 1) } }] call (uiNamespace getVariable "CBA_fnc_addEventHandler");
 [QUOTE(GVAR(date)), { private "_date"; _date = _this; setDate _date }] call (uiNamespace getVariable "CBA_fnc_addEventHandler");

--- a/addons/network/XEH_preInit.sqf
+++ b/addons/network/XEH_preInit.sqf
@@ -119,8 +119,7 @@ if (_dGE isEqualType 0) then {
 };
 
 if (_disableGE) then {
-    uiNamespace setVariable [QGVAR(exec), compileFinal ""];
-    missionNamespace setVariable [QGVAR(exec), compileFinal ""];
+    missionNamespace setVariable [QUOTE(FUNC(exec)), compileFinal ""];
 } else {
     PREP(exec);
     [QUOTE(GVAR(cmd)), { if (GVAR(init)) then { _this spawn FUNC(exec) } }] call (uiNamespace getVariable "CBA_fnc_addEventHandler");

--- a/addons/network/config.cpp
+++ b/addons/network/config.cpp
@@ -11,7 +11,12 @@ class CfgPatches
         authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };
+class CfgSettings {
+    class CBA {
+        class COMPONENT {
+            disableGlobalExecute = 0;
+        };
+    };
+};
 #include "CfgEventHandlers.hpp"
 #include "CfgFunctions.hpp"
-
-

--- a/optionals/disable_globalexec/config.cpp
+++ b/optionals/disable_globalexec/config.cpp
@@ -1,0 +1,24 @@
+/*
+    Disable network code execution
+    
+    This is an optional addon that can be used to disable the network
+    execution function "CBA_fnc_globalExecute" from running code on
+    other machines.
+*/
+
+class CfgPatches {
+    class CBA_Disable_GlobalExec {
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = 0.1;
+        requiredAddons[] = {"cba_network"};
+    };
+};
+
+class CfgSettings {
+    class CBA {
+        class Network {
+            disableGlobalExecute = 1;
+        };
+    };
+};


### PR DESCRIPTION
Mission makers and/or server managers can disable the use of
CBA_fnc_globalExecute either by using a mission setting or
an optional addon. When disabled, calling fnc_globalExecute
does nothing. Fixes #269