### PR TITLE
add CBA_missionTime

### DIFF
--- a/addons/xeh/fnc_postInit_unscheduled.sqf
+++ b/addons/xeh/fnc_postInit_unscheduled.sqf
@@ -18,6 +18,11 @@ Author:
 
 XEH_LOG("XEH: PostInit started.");
 
+// fix CBA_missionTime being -1 on (non-JIP) clients at mission start.
+if (CBA_missionTime == -1) then {
+    CBA_missionTime = 0;
+};
+
 // call PostInit events
 {
     if (_x select 1 == "postInit") then {


### PR DESCRIPTION
BI seems to be unable to make a proper time command that is synched in MP and is correctly resumed in save games, JIP and all that.

This PR adds the `CBA_missionTime` variable.

pros:

- based on tickTime
- set every frame
- synched in MP/JIP
- resumes correct value when loading save games
- multiplied by accTime (SP only)
- paused when game is paused (ESC menu, SP only)

cons:

- -1 on clients during preInit (correct value on and after postInit)
- not linked to ingame day time (faster)
- ignores `skipTime`, `setDate`, `timeMultiplier` etc. (ingame day time)

Test:
https://gist.github.com/commy2/c01e4885b8961363ef7e
https://gist.github.com/commy2/06de40913799965ba8e5

`0 = 0 spawn {waitUntil {diag_log CBA_missionTime; systemChat str CBA_missionTime; false}};`

I ran it for 2hrs and the values didn't diverge. (Although it was two game instances on the same machine)