### PR TITLE
change 3den debug console keybind to ctrl+d

### DIFF
--- a/addons/diagnostic/CfgDisplay3DEN.hpp
+++ b/addons/diagnostic/CfgDisplay3DEN.hpp
@@ -8,6 +8,12 @@ class Display3DEN {
                 class DebugConsole {
                     shortcuts[] = {INPUT_CTRL_OFFSET + DIK_D};
                 };
+                class FunctionsViewer {
+                    shortcuts[] = {INPUT_ALT_OFFSET + DIK_F};
+                };
+                class ConfigViewer {
+                    shortcuts[] = {INPUT_CTRL_OFFSET + DIK_G};
+                };
             };
         };
     };

--- a/addons/diagnostic/CfgDisplay3DEN.hpp
+++ b/addons/diagnostic/CfgDisplay3DEN.hpp
@@ -1,0 +1,14 @@
+
+class ctrlMenuStrip;
+
+class Display3DEN {
+    class Controls {
+        class MenuStrip: ctrlMenuStrip {
+            class Items {
+                class DebugConsole {
+                    shortcuts[] = {INPUT_CTRL_OFFSET + DIK_D};
+                };
+            };
+        };
+    };
+};

--- a/addons/diagnostic/config.cpp
+++ b/addons/diagnostic/config.cpp
@@ -1,13 +1,12 @@
 #include "script_component.hpp"
-class CfgPatches
-{
-    class ADDON
-    {
+
+class CfgPatches {
+    class ADDON {
         units[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = { "CBA_common", "CBA_events" };
+        requiredAddons[] = {"CBA_common","CBA_events","3DEN"};
         version = VERSION;
-        author[] = {"Spooner", "Sickboy"};
+        author[] = {"Spooner","Sickboy"};
         authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };
@@ -15,4 +14,4 @@ class CfgPatches
 #include "CfgFunctions.hpp"
 #include "CfgEventHandlers.hpp"
 
-
+#include "CfgDisplay3DEN.hpp"

--- a/addons/diagnostic/script_component.hpp
+++ b/addons/diagnostic/script_component.hpp
@@ -10,3 +10,5 @@
 #endif
 
 #include "\x\cba\addons\main\script_macros.hpp"
+
+#include "\a3\ui_f\hpp\defineDIKCodes.inc"


### PR DESCRIPTION
^ circumflex is a horrible keybind for the debug console, because it will add an additional "^" once you start typing. This PR changes that keybind to ctrl+D (, which was used in the 2D editor too).
I tried to add the keybind with +=, so circumflex still works, but apparently 3den only accepts the first bind, even though this is an array.
 
Also adds alt+f hotkey for functions viewer and ctrl+g for config viewer.

ctrl+f and ctrl+shift+f were already used by search functions.

