### PR TITLE
add meta.cpp file

### DIFF
--- a/meta.cpp
+++ b/meta.cpp
@@ -1,0 +1,2 @@
+protocol = 1;
+publishedid = 450814997;

--- a/tools/make.py
+++ b/tools/make.py
@@ -73,7 +73,7 @@ dssignfile = ""
 prefix = "cba"
 pbo_name_prefix = "cba_"
 signature_blacklist = []
-importantFiles = ["mod.cpp", "README.md", "LICENSE.md", "logo_cba_ca.paa"]
+importantFiles = ["mod.cpp", "README.md", "LICENSE.md", "logo_cba_ca.paa", "meta.cpp"]
 versionFiles = ["mod.cpp"]
 
 ###############################################################################


### PR DESCRIPTION
With Arma 3 1.56 the new Server Browser inside of the Launcher is able
to pull mods used on a server directly from the steam workshop. Server
admins need to add a special file to each mod to ensure, that the mod is
found in the workshop.

This pull request add this file according to https://community.bistudio.com/wiki/How_to_enable_Steam_Workshop_support_in_Server_Browser

Link to CBA's workshop entry: https://steamcommunity.com/sharedfiles/filedetails/?id=450814997

[This has already been added to ACE3](https://github.com/acemod/ACE3/blob/master/meta.cpp).