### PR TITLE
don't execute preInit when returning to 3den

### DIFF
--- a/addons/xeh/CfgEventHandlers.hpp
+++ b/addons/xeh/CfgEventHandlers.hpp
@@ -75,5 +75,9 @@ class Extended_WeaponAssembled_EventHandlers {};
 class Extended_WeaponDisassembled_EventHandlers {};
 
 // display xeh
-class Extended_DisplayLoad_EventHandlers {};
+class Extended_DisplayLoad_EventHandlers {
+    class RscDisplayInterrupt {
+        GVAR(3denFix) = QUOTE(call COMPILE_FILE(XEH_interruptDisplayLoad));
+    };
+};
 class Extended_DisplayUnload_EventHandlers {};

--- a/addons/xeh/XEH_interruptDisplayLoad.sqf
+++ b/addons/xeh/XEH_interruptDisplayLoad.sqf
@@ -1,0 +1,11 @@
+#include "script_component.hpp"
+
+disableSerialization;
+
+params ["_display"];
+
+private _ctrl = _display displayCtrl 104;
+
+if (ctrlText _ctrl == localize "STR_3DEN_RscDisplayInterrupt_ButtonAbort_3DEN_text") then {
+    _ctrl ctrlAddEventHandler ["buttonClick", {uiNamespace setVariable [QGVAR(3denFix), true]}];
+};

--- a/addons/xeh/fnc_preInit.sqf
+++ b/addons/xeh/fnc_preInit.sqf
@@ -16,6 +16,12 @@ Author:
 ---------------------------------------------------------------------------- */
 #include "script_component.hpp"
 
+// hack to fix 3den executing preInit unnecessarily when returning from a preview
+if (uiNamespace getVariable [QGVAR(3denFix), false]) exitWith {
+    uiNamespace setVariable [QGVAR(3denFix), false];
+    diag_log text "[XEH]: 3den preview detected. Abort preInit.";
+};
+
 SLX_XEH_DisableLogging = uiNamespace getVariable ["SLX_XEH_DisableLogging", false]; // get from preStart
 
 XEH_LOG("XEH: PreInit started. v" + getText (configFile >> "CfgPatches" >> "cba_common" >> "version") + ". " + PFORMAT_7("MISSIONINIT",missionName,worldName,isMultiplayer,isServer,isDedicated,hasInterface,didJIP));


### PR DESCRIPTION
This is a extremly hackish work around for 3den calling all preInit = 1 functions when returning from a preview. Adds a variable to the return button.

This has one major flaw though. Should BI fix the problem and preInit does not occur anymore when returning from preview in 3den, this fix will prevent XEH preInit from being executed, which means we would have to patch.

It slightly reduces load times in 3den when returning from a preview (can add up to a few seconds with ACE) and fixes bugs like this: https://github.com/CBATeam/CBA_A3/issues/282