### PR TITLE
Skip some unused compiles in XEH

### DIFF
--- a/addons/xeh/fnc_compileEventHandlers.sqf
+++ b/addons/xeh/fnc_compileEventHandlers.sqf
@@ -79,7 +79,7 @@ private _resultNames = [];
         _result pushBack ["", _eventName, _eventFunc];
         _resultNames pushBack _customName;
     } forEach configProperties [_baseConfig >> XEH_FORMAT_CONFIG_NAME(_eventName)];
-} forEach ["preStart", "preInit", "postInit"]; 
+} forEach ["preInit", "postInit"];
 
 // object events
 {

--- a/addons/xeh/fnc_postInit_unscheduled.sqf
+++ b/addons/xeh/fnc_postInit_unscheduled.sqf
@@ -26,7 +26,7 @@ if (CBA_missionTime == -1) then {
 // call PostInit events
 {
     if (_x select 1 == "postInit") then {
-        call (_x select 2);
+        [] call (_x select 2);
     };
 } forEach GVAR(allEventHandlers);
 

--- a/addons/xeh/fnc_preInit.sqf
+++ b/addons/xeh/fnc_preInit.sqf
@@ -89,7 +89,7 @@ GVAR(fallbackRunning) = false;
 {
     if (_x select 0 == "") then {
         if (_x select 1 == "preInit") then {
-            call (_x select 2);
+            [] call (_x select 2);
         };
     } else {
         _x params ["_className", "_eventName", "_eventFunc", "_allowInheritance", "_excludedClasses"];

--- a/addons/xeh/fnc_preStart.sqf
+++ b/addons/xeh/fnc_preStart.sqf
@@ -31,10 +31,24 @@ with uiNamespace do {
 
     // call PreStart events
     {
-        if (_x select 1 == "preStart") then {
-            call (_x select 2);
+        private _eventFunc = "";
+
+        if (isClass _x) then {
+            private _entry = _x >> "init";
+
+            if (isText _entry) then {
+                _eventFunc = _eventFunc + getText _entry + ";";
+            };
+        } else {
+            if (isText _x) then {
+                _eventFunc = getText _x + ";";
+            };
         };
-    } forEach (configFile call CBA_fnc_compileEventHandlers);
+
+        if !(_eventFunc isEqualTo "") then {
+            [] call compile _eventFunc;
+        };
+    } forEach configProperties [configFile >> XEH_FORMAT_CONFIG_NAME("preStart")];
 
     #ifdef DEBUG_MODE_FULL
         diag_log text format ["isScheduled = %1", call CBA_fnc_isScheduled];


### PR DESCRIPTION
- don't compile events handlers except preStart when starting the game. They are discarded anyway, so this needlesly slows down starting the game.

- don't compile preStart event handlers in missions. They are never used while the game is running.