### PR TITLE
Port ACE delayed execution functions to CBA

### DIFF
--- a/addons/common/CfgFunctions.hpp
+++ b/addons/common/CfgFunctions.hpp
@@ -141,6 +141,12 @@ class CfgFunctions
                 description = "Drops a weapon.";
                 file = "\x\cba\addons\common\fnc_dropWeapon.sqf";
             };
+            // CBA_fnc_execNextFrame
+            class execNextFrame
+            {
+                description = "Add piece of code that will execute once on the next frame.";
+                file = "\x\cba\addons\common\fnc_execNextFrame.sqf";
+            };
             // CBA_fnc_findEntity
             class findEntity
             {
@@ -512,6 +518,18 @@ class CfgFunctions
             {
                 description = "Display a message in the global chat channel.";
                 file = "\x\cba\addons\common\fnc_systemChat.sqf";
+            };
+            // CBA_fnc_waitAndExecute
+            class waitAndExecute
+            {
+                description = "Add piece of code that will execute after a certain delay in seconds.";
+                file = "\x\cba\addons\common\fnc_waitAndExecute.sqf";
+            };
+            // CBA_fnc_waitUntilAndExecute
+            class waitUntilAndExecute
+            {
+                description = "Add a condition and statement code. The condition will every frame until it's true, and then the statement will execute once. Both execute in non sched environment";
+                file = "\x\cba\addons\common\fnc_waitUntilAndExecute.sqf";
             };
         };
     };

--- a/addons/common/fnc_execNextFrame.sqf
+++ b/addons/common/fnc_execNextFrame.sqf
@@ -1,0 +1,30 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_execNextFrame
+
+Description:
+    Executes a code once in non sched environment on the next frame.
+
+Parameters:
+    _function - The function to run. <CODE>
+    _args     - Parameters passed to the function executing. This will be the same array every execution. [optional] <ANY>
+
+Returns:
+    Nothing
+
+Examples:
+    (begin example)
+        [{player sideChat format ["This is frame %1, not %2", diag_frameno, _this select 0];}, [diag_frameno]] call CBA_fnc_execNextFrame;
+    (end)
+
+Author:
+    esteldunedain and PabstMirror, donated from ACE3
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+
+params [["_function", {}, [{}]], ["_args", []]];
+
+if (diag_frameno != GVAR(nextFrameNo)) then {
+    GVAR(nextFrameBufferA) pushBack [_args, _function];
+} else {
+    GVAR(nextFrameBufferB) pushBack [_args, _function];
+};

--- a/addons/common/fnc_waitAndExecute.sqf
+++ b/addons/common/fnc_waitAndExecute.sqf
@@ -1,0 +1,28 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_waitAndExecute
+
+Description:
+    Executes a code once in non sched environment with a given game time delay.
+
+Parameters:
+    _function - The function you wish to execute. <CODE>
+    _args     - Parameters passed to the function executing. This will be the same array every execution. [optional] <ANY>
+    _delay    - The amount of time in seconds between executions, 0 for every frame. [optional] (default: 0) <NUMBER>
+
+Returns:
+    Nothing
+
+Examples:
+    (begin example)
+        [{player sideChat format ["5s later! _this: %1", _this];}, ["some","params",1,2,3], 5] call CBA_fnc_waitAndExecute;
+    (end)
+
+Author:
+    esteldunedain and PabstMirror, donated from ACE3
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+
+params [["_function", {}, [{}]], ["_args", []], ["_delay", 0, [0]]];
+
+GVAR(waitAndExecArray) pushBack [CBA_missionTime + _delay, _function, _args];
+GVAR(waitAndExecArrayIsSorted) = false;

--- a/addons/common/fnc_waitUntilAndExecute.sqf
+++ b/addons/common/fnc_waitUntilAndExecute.sqf
@@ -1,0 +1,27 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_waitUntilAndExecute
+
+Description:
+    Executes a code once in non sched environment after a condition is true.
+
+Parameters:
+    _conditionFunction - The function to evaluate as condition. <CODE>
+    _statementFunction - The function to run once the condition is true. <CODE>
+    _args     - Parameters passed to the function executing. This will be the same array every execution. [optional] <ANY>
+
+Returns:
+    Nothing
+
+Examples:
+    (begin example)
+        [{(_this select 0) == vehicle (_this select 0)}, {(_this select 0) setDamage 1;}, [player]] call CBA_fnc_waitUntilAndExecute;
+    (end)
+
+Author:
+    joko // Jonas, donated from ACE3
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+
+params [["_conditionFunction", {}, [{}]], ["_statementFunction", {}, [{}]], ["_args", []]];
+
+GVAR(waitUntilAndExecArray) pushBack [_conditionFunction, _statementFunction, _args];


### PR DESCRIPTION
This PR ports the following functions from ACE, with some optimizations. All of them run in non sched environment and are handled by the onFrame loop that handles PFH.

- `CBA_fnc_waitAndExecute`: Executes a code once in non sched environment with a given game time delay. It' based on a queue, so only the bare minimum of elements are evaluated each frame. This is a very efficient way of delaying execution, certainly much more than a PFH, specially for long delays. It's savegame compatible due to the use of `CBA_missionTime`.

- `CBA_fnc_execNextFrame`: A specialized version of `CBA_fnc_waitAndExecute` that delays execution a single frame.

- `CBA_fnc_waitUntilAndExecute`: Evaluates a condition code on each frame, and finally launches a sepparate statement code once when the condition returns true. This behaves like BIS `waitUntil`, but in non sched environment. Due to all condition being evaluated each frame, this function should be used only when necessary.

All of this are heavily used in ACE. We'll certainly switch to CBA's versions if this is merged.
