### PR TITLE
add a designated CBA_Extended_EventHandlers base class

### DIFF
--- a/addons/xeh/CfgEventHandlers.hpp
+++ b/addons/xeh/CfgEventHandlers.hpp
@@ -1,10 +1,12 @@
 
-class XEH_CLASS {
+class DOUBLES(XEH_CLASS,base) {
     EXTENDED_EVENTHANDLERS
 };
 
+class XEH_CLASS: DOUBLES(XEH_CLASS,base) {}; // bwc
+
 class DefaultEventhandlers {
-    class XEH_CLASS: XEH_CLASS {};
+    class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
 };
 
 // The PreStart handlers run once when the game is started


### PR DESCRIPTION
This is an issue @bux encountered when trying to reenable XEH on some static / building objects.
Usually those have XEH disabled, which is done by clearing the `CBA_Extended_EventHandlers`.

When setting up inheritance of the `EventHandlers` class, you actually carry over the references to all sub classes defined in that class.

![http://i.imgur.com/wgAVHKI.jpg](http://i.imgur.com/wgAVHKI.jpg)

`SignAd_Sponsor` 's `EventHandlers` is from `Thing`. `Thing` has an empty `CBA_Extended_EventHandlers` class to disable XEH on random map objects.
But bux was trying to inherit the actual root class which is also called `CBA_Extended_EventHandlers` and since Arma can only reference base classes by their name, the empty one from `Thing` was selected instead of the full one on root config.
The only work around currently is to discard the `EventHandlers` class, which is not ideal.

This can be avoided by adding a differently named base class.   `CBA_Extended_EventHandlers_base`. `CBA_Extended_EventHandlers` has to stay for backwards compatibility...