### PR TITLE
fix dropWeapon, dropMagazine, add dropItem, weaponComponents

### DIFF
--- a/addons/common/CfgFunctions.hpp
+++ b/addons/common/CfgFunctions.hpp
@@ -63,6 +63,10 @@ class CfgFunctions {
             F_FILEPATH(removeWeapon);
             F_FILEPATH(removeMagazine);
             F_FILEPATH(removeItem);
+            F_FILEPATH(weaponComponents);
+            F_FILEPATH(dropWeapon);
+            F_FILEPATH(dropMagazine);
+            F_FILEPATH(dropItem);
         };
 
         class Cargo {
@@ -119,8 +123,6 @@ class CfgFunctions {
 
         class Broken {
             F_FILEPATH(actionArgument);
-            F_FILEPATH(dropMagazine);
-            F_FILEPATH(dropWeapon);
         };
     };
 };

--- a/addons/common/fnc_dropItem.sqf
+++ b/addons/common/fnc_dropItem.sqf
@@ -27,7 +27,7 @@ SCRIPT(dropItem);
 
 params [["_unit", objNull, [objNull]], ["_item", "", [""]]];
 
-private _return = [_unit, _item, _ammo] call CBA_fnc_removeItem;
+private _return = [_unit, _item] call CBA_fnc_removeItem;
 
 if (_return) then {
     _unit switchMove "ainvpknlmstpslaywrfldnon_1";

--- a/addons/common/fnc_dropItem.sqf
+++ b/addons/common/fnc_dropItem.sqf
@@ -1,0 +1,45 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_dropItem
+
+Description:
+    Drops an item.
+
+    Function which verifies existence of _item and _unit, returns false in case
+    of trouble, or when able to remove _item from _unit true in case of success
+
+Parameters:
+    _unit - the unit that should drop the item <OBJECT>
+    _item - class name of the item to drop <STRING>
+
+Returns:
+    true if successful, false otherwise <BOOLEAN>
+
+Examples:
+    (begin example)
+        _result = [player, "FirstAidKit"] call CBA_fnc_dropItem
+    (end)
+
+Author:
+    commy2
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+SCRIPT(dropItem);
+
+params [["_unit", objNull, [objNull]], ["_item", "", [""]]];
+
+private _return = [_unit, _item, _ammo] call CBA_fnc_removeItem;
+
+if (_return) then {
+    _unit switchMove "ainvpknlmstpslaywrfldnon_1";
+
+    private _weaponHolder = nearestObject [_unit, "WeaponHolder"];
+
+    if (isNull _weaponHolder || {_unit distance _weaponHolder > 2}) then {
+        _weaponHolder = createVehicle ["GroundWeaponHolder", [0,0,0], [], 0, "NONE"];
+        _weaponHolder setPosASL getPosASL _unit;
+    };
+
+    _weaponHolder addItemCargoGlobal [_item, 1];
+};
+
+_return

--- a/addons/common/fnc_dropMagazine.sqf
+++ b/addons/common/fnc_dropMagazine.sqf
@@ -2,76 +2,56 @@
 Function: CBA_fnc_dropMagazine
 
 Description:
-    Drop a magazine.
+    Drops a magazine.
 
     Function which verifies existence of _item and _unit, returns false in case
     of trouble, or when able to remove _item from _unit true in case of success.
 
 Parameters:
-    _unit   - the unit that should drop a magazine [Object]
-    _item   - class name of the magazine to drop [String]
+    _unit - the unit that should drop a magazine <OBJECT>
+    _item - class name of the magazine to drop <STRING>
+    _ammo - ammo count <NUMBER>
 
 Returns:
-    true if successful, false otherwise
+    true if successful, false otherwise <BOOLEAN>
 
 Examples:
     (begin example)
-    _result = [player, "SmokeShell"] call CBA_fnc_dropMagazine
+        _result = [player, "SmokeShell"] call CBA_fnc_dropMagazine
     (end)
 
 Author:
-
+    ?, commy2
 ---------------------------------------------------------------------------- */
-
 #include "script_component.hpp"
 SCRIPT(dropMagazine);
 
-#define __scriptname fnc_dropMagazine
+params [["_unit", objNull, [objNull]], ["_item", "", [""]], ["_ammo", -1, [0]]];
 
-#define __cfg (configFile >> "CfgMagazines")
-#define __action "DROPMAGAZINE"
-#define __ar (magazines _unit)
+// random mag mode
+if (_ammo < 0) then {
+    _ammo = (selectRandom (magazinesAmmoFull _unit select {_x select 0 == _item && {toLower (_x select 4) in ["uniform","vest","backpack"]}})) param [1, "null"];
+};
 
-private ["_item", "_holder"];
-params ["_unit"];
-if (typeName _unit != "OBJECT") exitWith {
-    TRACE_2("Unit not Object",_unit,_item);
-    false
-};
-_item = _this select 1;
-if (typeName _item != "STRING") exitWith {
-    TRACE_2("Item not String",_unit,_item);
-    false
-};
-if (isNull _unit) exitWith {
-    TRACE_2("Unit isNull",_unit,_item);
-    false
-};
-if (_item == "") exitWith {
-    TRACE_2("Empty Item",_unit,_item);
-    false
-};
-if !(isClass (__cfg >> _item)) exitWith {
-    TRACE_2("Item not exist in Config",_unit,_item);
-    false
-};
-if !(_item in __ar) exitWith {
+// no mag of this type in units inventory
+if (_ammo isEqualTo "null") exitWith {
     TRACE_2("Item not available on Unit",_unit,_item);
     false
 };
-_holder = if (count _this > 2) then {
-    _this select 2
-} else {
-    _unit
+
+private _return = [_unit, _item, _ammo] call CBA_fnc_removeMagazine;
+
+if (_return) then {
+    _unit switchMove "ainvpknlmstpslaywrfldnon_1";
+
+    private _weaponHolder = nearestObject [_unit, "WeaponHolder"];
+
+    if (isNull _weaponHolder || {_unit distance _weaponHolder > 2}) then {
+        _weaponHolder = createVehicle ["GroundWeaponHolder", [0,0,0], [], 0, "NONE"];
+        _weaponHolder setPosASL getPosASL _unit;
+    };
+
+    _weaponHolder addMagazineAmmoCargo [_item, 1, _ammo];
 };
-if (typeName _holder != "OBJECT") exitWith {
-    TRACE_3("Holder not object",_unit,_item,_holder);
-    false
-};
-if (isNull _holder) exitWith {
-    TRACE_3("Holder isNull",_unit,_item,_holder);
-    false
-};
-_unit action [__action, _holder, _item];
-TRACE_3("Holder: %3 - Success",_unit,_item,_holder);
-true
+
+_return

--- a/addons/common/fnc_dropMagazine.sqf
+++ b/addons/common/fnc_dropMagazine.sqf
@@ -10,7 +10,7 @@ Description:
 Parameters:
     _unit - the unit that should drop a magazine <OBJECT>
     _item - class name of the magazine to drop <STRING>
-    _ammo - ammo count <NUMBER>
+    _ammo - ammo count (optional). If not specified a random magazine is chosen <NUMBER>
 
 Returns:
     true if successful, false otherwise <BOOLEAN>
@@ -30,7 +30,7 @@ params [["_unit", objNull, [objNull]], ["_item", "", [""]], ["_ammo", -1, [0]]];
 
 // random mag mode
 if (_ammo < 0) then {
-    _ammo = (selectRandom (magazinesAmmoFull _unit select {_x select 0 == _item && {toLower (_x select 4) in ["uniform","vest","backpack"]}})) param [1, "null"];
+    _ammo = ((magazinesAmmoFull _unit select {_x select 0 == _item && {toLower (_x select 4) in ["uniform","vest","backpack"]}}) call BIS_fnc_selectRandom) param [1, "null"];
 };
 
 // no mag of this type in units inventory

--- a/addons/common/fnc_dropWeapon.sqf
+++ b/addons/common/fnc_dropWeapon.sqf
@@ -8,70 +8,63 @@ Description:
     of trouble, or when able to remove _item from _unit true in case of success
 
 Parameters:
-    _unit   - the unit that should drop a magazine [Object]
-    _item   - class name of the weapon to drop [String]
+    _unit - the unit that should drop a weapon <OBJECT>
+    _item - class name of the weapon to drop <STRING>
 
 Returns:
-    true if successful, false otherwise
+    true if successful, false otherwise <BOOLEAN>
+
 Examples:
     (begin example)
-    _result = [player, primaryWeapon player] call CBA_fnc_dropWeapon
+        _result = [player, primaryWeapon player] call CBA_fnc_dropWeapon
     (end)
 
 Author:
-
+    ?, commy2
 ---------------------------------------------------------------------------- */
-
 #include "script_component.hpp"
 SCRIPT(dropWeapon);
 
-#define __scriptname fDropWeapon
+params [["_unit", objNull, [objNull]], ["_item", "", [""]]];
 
-#define __cfg (configFile >> "CfgWeapons")
-#define __action "DROPWEAPON"
-#define __ar (weapons _unit)
+private _weaponInfo = (weaponsItems _unit select {_x select 0 == _item}) param [0, []];
+private _return = [_unit, _item] call CBA_fnc_removeWeapon;
 
-private ["_unit", "_item", "_holder"];
-params ["_unit"];
-if (typeName _unit != "OBJECT") exitWith {
-    TRACE_2("Unit not Object",_unit,_item);
-    false
-};
-_item = _this select 1;
-if (typeName _item != "STRING") exitWith {
-    TRACE_2("Item not String",_unit,_item);
-    false
-};
-if (isNull _unit) exitWith {
-    TRACE_2("Unit isNull",_unit,_item);
-    false
-};
-if (_item == "") exitWith {
-    TRACE_2("Empty Item",_unit,_item);
-    false
-};
-if !(isClass (__cfg >> _item)) exitWith {
-    TRACE_2("Item not exist in Config",_unit,_item);
-    false
-};
-if !(_item in __ar) exitWith {
-    TRACE_2("Item not available on Unit",_unit,_item);
-    false
-};
-_holder = if (count _this > 2) then {
-    _this select 2
-} else {
-    _unit
-};
-if (typeName _holder != "OBJECT") exitWith {
-    TRACE_3("Holder: %3 - Holder not object",_unit,_item,_holder);
-    false
-};
-if (isNull _holder) exitWith {
-    TRACE_3("Holder: %3 - Holder isNull",_unit,_item,_holder);
-    false
+if (_return) then {
+    private _baseWeapon = _item call CBA_fnc_weaponComponents param [0, _item];
+
+    private _items = _weaponInfo;
+    _items deleteAt 0; // delete the weapon
+
+    private _magazines = [];
+
+    {
+        if (_x isEqualType []) then {
+            _magazines pushBack _x;
+            _items set [_forEachIndex, ""];
+        };
+    } forEach _items;
+
+    _items = _items - [""];
+
+    _unit switchMove "ainvpknlmstpslaywrfldnon_1";
+
+    private _weaponHolder = nearestObject [_unit, "WeaponHolder"];
+
+    if (isNull _weaponHolder || {_unit distance _weaponHolder > 2}) then {
+        _weaponHolder = createVehicle ["GroundWeaponHolder", [0,0,0], [], 0, "NONE"];
+        _weaponHolder setPosASL getPosASL _unit;
+    };
+
+    _weaponHolder addWeaponCargoGlobal [_baseWeapon, 1];
+
+    {
+        _weaponHolder addItemCargoGlobal [_x, 1];
+    } forEach _items;
+
+    {
+        _weaponHolder addMagazineAmmoCargo [_x select 0, 1, _x select 1];
+    } forEach _magazines;
 };
 
-_unit action [__action, _holder, _item];
-TRACE_3("Holder: %3 - Success",_unit,_item,_holder);
-true
+_return

--- a/addons/common/fnc_weaponComponents.sqf
+++ b/addons/common/fnc_weaponComponents.sqf
@@ -1,0 +1,64 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_weaponComponents
+
+Description:
+    Reports class name of base weapon without attachments and all attachments belonging to a pre equipped weapon.
+    Base weapon and attachments are reported in lower case capitalization.
+    Fixed version of BIS_fnc_weaponComponents.
+
+Parameters:
+    _weapon - a weapons class name with attachments build in <STRING>
+
+Returns:
+    _components - class names of base weapon + attachments. <ARRAY>
+        attachments are in random order, but weapon is always at first position
+        empty array if weapon does not exist in config
+
+Examples:
+    (begin example)
+        _components = (primaryWeapon player) call CBA_fnc_weaponComponents;
+    (end)
+
+Author:
+    commy2, based on BIS_fnc_weaponComponents by Jiri Wainar
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+SCRIPT(weaponComponents);
+
+params [["_weapon", "", [""]]];
+
+if (isNil QGVAR(weaponComponentsCache)) then {
+    GVAR(weaponComponentsCache) = [] call CBA_fnc_createNamespace;
+};
+
+private _components = GVAR(weaponComponentsCache) getVariable _weapon;
+
+if (isNil "_components") then {
+    private _config = configfile >> "CfgWeapons" >> _weapon;
+
+    // return empty array if the weapon doesn't exist
+    if (!isClass _config) exitWith {[]};
+
+    // get attachments
+    private _attachments = [];
+
+    {
+        _attachments pushBack toLower getText (_x >> "item");
+    } forEach ("true" configClasses (_config >> "LinkedItems")); // inheritance is apparently disabled for these
+
+    // get first parent without attachments
+    while {isClass _config && {getNumber (_config >> "scope") == 2}} do {
+        if (count (_config >> "LinkedItems") == 0) exitWith {
+            _weapon = configName _config;
+        };
+
+        _config = inheritsFrom _config;
+    };
+
+    _components = [toLower _weapon];
+    _components append _attachments;
+
+    GVAR(weaponComponentsCache) setVariable [_weapon, _components];
+};
+
+_components

--- a/addons/common/fnc_weaponComponents.sqf
+++ b/addons/common/fnc_weaponComponents.sqf
@@ -61,4 +61,4 @@ if (isNil "_components") then {
     GVAR(weaponComponentsCache) setVariable [_weapon, _components];
 };
 
-_components
++ _components

--- a/addons/common/test.sqf
+++ b/addons/common/test.sqf
@@ -5,7 +5,7 @@
 #define DEBUG_MODE_FULL
 #include "script_component.hpp"
 
-#define TESTS ["config", "inventory"]
+#define TESTS ["config", "inventory", "weaponComponents"]
 
 SCRIPT(test-common);
 

--- a/addons/common/test_weaponComponents.sqf
+++ b/addons/common/test_weaponComponents.sqf
@@ -1,0 +1,47 @@
+
+#define LOGF diag_log text format
+#define TESTEXP if (!isNil "_result" && {_result isEqualTo _expected}) then {LOGF ["TEST: OK - %1 result", _result]} else {LOGF ["TEST: FAIL - %1 result; %2 expected", _result, _expected]}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+_fnc_name = "CBA_fnc_weaponComponents";
+_fnc = call compile _fnc_name;
+
+LOGF ["========== TEST ========== - %1 -", _fnc_name];
+if (!isNil "_fnc") then {LOGF ["TEST: OK - %1 defined", _fnc_name]} else {LOGF ["TEST: FAIL - %1 undefined"]};
+
+_result = "" call _fnc;
+_expected = [];
+TESTEXP;
+
+_result = "arifle_MX_F" call _fnc;
+_expected = ["arifle_mx_f"];
+TESTEXP;
+
+_result = "arifle_MXC_Holo_pointer_snds_F" call _fnc;
+_expected = ["arifle_mxc_f","optic_holosight","muzzle_snds_h","acc_pointer_ir"];
+TESTEXP;
+
+_result = ["arifle_MXM_DMS_LP_BI_snds_F"] call _fnc;
+_expected = ["arifle_mxm_f","optic_dms","acc_pointer_ir","bipod_01_f_snd","muzzle_snds_h"];
+TESTEXP;
+
+_result = "arifle_MXC_Black_F" call _fnc;
+_expected = ["arifle_mxc_black_f"];
+TESTEXP;
+
+_result = "Laserdesignator_02" call _fnc;
+_expected = ["laserdesignator_02"];
+TESTEXP;
+
+_result = ["FirstAidKit"] call _fnc;
+_expected = ["firstaidkit"];
+TESTEXP;
+
+_result = "H_Cap_marshal" call _fnc;
+_expected = ["h_cap_marshal"];
+TESTEXP;
+
+_result = ["B_Soldier_F"] call _fnc;
+_expected = [];
+TESTEXP;


### PR DESCRIPTION
ref #289

Fixes broken `CBA_fnc_dropWeapon` and `CBA_fnc_dropMagazine`. Instead of using the broken drop action, these remove the item from the inventory and create a GWH with all items instead.
Unfortunately the weapon is broken up into it's parts, but there is no other way currently.
Also adds optional paramter to dropMagazine, to use a mag with a specified ammo count.
Also adds `CBA_fnc_dropItem` for first aid kits etc.
dropWeapon needs a functional weaponComponets function. `CBA_fnc_weaponComponents` is a much improved version of the BI variant (which reports the black MX as tan MX, the Opfor DLC laserdesignator as the normal free laserdesignator, etc. etc.)
