### PR TITLE
copy returned array of compatibleItems

### DIFF
--- a/addons/jr/fnc_compatibleItems.sqf
+++ b/addons/jr/fnc_compatibleItems.sqf
@@ -55,7 +55,7 @@ if (isNil "_compatibleItems") then {
 };
 
 if (_typefilter == 0) then { //return
-    _compatibleItems
+    + _compatibleItems
 } else {
     _compatibleItems select {_typefilter == getNumber(configFile>>"CfgWeapons">>_x>>"itemInfo">>"type")};
 };


### PR DESCRIPTION
Cache could be corrupted by modifing the returned array by reference.
Basically same as: https://github.com/commy2/CBA_A3/commit/1fff98361b7c216fa7d2723c721fd7ca54da814d