### PR TITLE
use BIS_fnc_selectRandom for 1.54 compat

### DIFF
--- a/addons/help/fnc_setCreditsLine.sqf
+++ b/addons/help/fnc_setCreditsLine.sqf
@@ -37,7 +37,7 @@ if (CBA_DisableCredits) exitWith {};
 
 // find addon with author
 private _config = configFile >> "CfgPatches";
-private _entry = selectRandom ("isArray (_x >> 'author')" configClasses _config);
+private _entry = ("isArray (_x >> 'author') && {!(getArray (_x >> 'author') isEqualTo [])}" configClasses _config) call (uiNamespace getVariable "BIS_fnc_selectRandom"); //bwc for 1.54 (Linux build)
 
 if (isNil "_entry") exitWith {};
 

--- a/addons/jr/config.cpp
+++ b/addons/jr/config.cpp
@@ -24,14 +24,12 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"A3_Weapons_F","A3_Weapons_F_Mark"};
-        author[] = {"Robalo"};
     };
     class asdg_jointmuzzles { //compat
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"A3_Weapons_F","A3_Weapons_F_Mark"};
-        author[] = {"Robalo"};
     };
 };
 

--- a/addons/jr_prep/config.cpp
+++ b/addons/jr_prep/config.cpp
@@ -7,7 +7,6 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"A3_Weapons_F","A3_Weapons_F_Mark"};
         version = VERSION;
-        author[] = {"Robalo"};
         authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };

--- a/addons/xeh/config.cpp
+++ b/addons/xeh/config.cpp
@@ -14,10 +14,10 @@ class CfgPatches {
     };
 
     // Backwards compatibility
-    class cba_xeh_a3: ADDON {};
-    class Extended_EventHandlers: ADDON {};
-    class CBA_Extended_EventHandlers: ADDON {};
-    class cba_ee: ADDON {};
+    class cba_xeh_a3: ADDON {author[] = {};};
+    class Extended_EventHandlers: ADDON {author[] = {};};
+    class CBA_Extended_EventHandlers: ADDON {author[] = {};};
+    class cba_ee: ADDON {author[] = {};};
 };
 
 #include "CfgEventHandlers.hpp"


### PR DESCRIPTION
- replaces `selectRandom` with `BIS_fnc_selectRandom` for 1.54 which is the latest Linux build.
- since this function is used on the main menu, the function has to be retrieved from ui namespace
- this also deletes the author entries of duplicate CfgPatches entries (those are for bwc), to balance out which authors are shown :)