### PR TITLE
Fix mikro converting true to 1

### DIFF
--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -48,7 +48,7 @@ class CfgSettings {
                     // CBA requiring CBA_A3, if A3 is found
                     CBA_A3[] = {"cba_main_a3", {1,0,0}, "isClass(configFile >> 'CfgPatches' >> 'A3_Map_Stratis')"};
 
-                    XEH[] = {"cba_xeh", {1,0,0}, "true"};
+                    XEH[] = {"cba_xeh", {1,0,0}, "(true)"};
                 };
             };
         };

--- a/addons/main_a3/config.cpp
+++ b/addons/main_a3/config.cpp
@@ -19,7 +19,7 @@ class CfgSettings {
         class Versioning {
             class PREFIX {
                 class Dependencies {
-                    CBA[] = {"cba_main", { 1,0,0 },"true"};
+                    CBA[] = {"cba_main", { 1,0,0 },"(true)"};
                 };
             };
         };


### PR DESCRIPTION
Ref #290
Trivial fix for mikero's dll 5.24 converting `"true"` to `1` in arrays, which will now causes minor rpt warning:

`"x\cba\addons\versioning\XEH_postInit.sqf:32","WARNING: Versioning conditional return is bad["CBA",["cba_main",[2,3,1],1]]"]`