### PR TITLE
use mission event for PlayerConnected

### DIFF
--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -37,4 +37,9 @@ GVAR(addons) = _addons;
 // BWC
 #include "backwards_comp.sqf"
 
+// band aid - remove this once they fix PlayerConnected mission event handler
+// https://forums.bistudio.com/topic/143930-general-discussion-dev-branch/page-942#entry3003074
+[QGVAR(OPC_FIX), "onPlayerConnected", {}] call BIS_fnc_addStackedEventHandler;
+[QGVAR(OPC_FIX), "onPlayerConnected"] call BIS_fnc_removeStackedEventHandler;
+
 ADDON = true;

--- a/addons/common/init_perFrameHandler.sqf
+++ b/addons/common/init_perFrameHandler.sqf
@@ -138,9 +138,17 @@ if (isMultiplayer) then {
             GVAR(lastTickTime) = _tickTime;
         };
 
-        ["CBA_SynchMissionTime", "onPlayerConnected", {
-            _owner publicVariableClient "CBA_missionTime";
-        }] call BIS_fnc_addStackedEventHandler;
+        if (isNil {canSuspend}) then {
+            // pre v1.58
+            ["CBA_SynchMissionTime", "onPlayerConnected", {
+                _owner publicVariableClient "CBA_missionTime";
+            }] call BIS_fnc_addStackedEventHandler;
+        } else {
+            // v1.58 ad later
+            addMissionEventHandler ["PlayerConnected", {
+                (_this select 4) publicVariableClient "CBA_missionTime";
+            }];
+        };
     } else {
         CBA_missionTime = -1;
 

--- a/addons/common/init_perFrameHandler.sqf
+++ b/addons/common/init_perFrameHandler.sqf
@@ -144,7 +144,7 @@ if (isMultiplayer) then {
                 _owner publicVariableClient "CBA_missionTime";
             }] call BIS_fnc_addStackedEventHandler;
         } else {
-            // v1.58 ad later
+            // v1.58 and later
             addMissionEventHandler ["PlayerConnected", {
                 (_this select 4) publicVariableClient "CBA_missionTime";
             }];

--- a/addons/network/XEH_postServerInit.sqf
+++ b/addons/network/XEH_postServerInit.sqf
@@ -4,18 +4,37 @@ LOG(MSG_INIT);
 // Why would we send __SERVER__ to an on PLAYER connected event,
 // [["__SERVER__","0",objNull,true]] call CBA_fnc_globalEvent;
 
-// OPC gets _id, _uid, _name
-[QUOTE(GVAR(opc)), "onPlayerConnected", {
-    if (_name=="__SERVER__") exitWith {};
-    _obj=objNull;
-    {
-        if (_name == name _x) then
+if (isNil {canSuspend}) then {
+    // pre v1.58
+    // OPC gets _id, _uid, _name
+    [QUOTE(GVAR(opc)), "onPlayerConnected", {
+        if (_name=="__SERVER__") exitWith {};
+        _obj=objNull;
         {
-            _obj=_x;
+            if (_name == name _x) then
+            {
+                _obj=_x;
+            };
+        } forEach playableUnits;
+        if (!isNull _obj) then {[_name, _uid, _obj] call FUNC(opc);};
+    }] call BIS_fnc_addStackedEventhandler;
+} else {
+    // v1.58 ad later
+    addMissionEventHandler ["PlayerConnected", {
+        params ["_id", "_uid", "_name", "_jip", "_owner"];
+
+        if (_name == "__SERVER__") exitWith {};
+
+        private _object = objNull;
+        {
+            if (name _x == _name) exitWith { _object = _x; };
+        } forEach playableUnits;
+
+        if (!isNull _object) then {
+            [_name, _uid, _object] call FUNC(opc);
         };
-    } forEach playableUnits;
-    if (!isNull _obj) then {[_name, _uid, _obj] call FUNC(opc);};
-}] call BIS_fnc_addStackedEventhandler;
+    }];
+};
 
 // Announce the completion of the initialization of the script
 ADDON = true;

--- a/addons/network/XEH_postServerInit.sqf
+++ b/addons/network/XEH_postServerInit.sqf
@@ -19,7 +19,7 @@ if (isNil {canSuspend}) then {
         if (!isNull _obj) then {[_name, _uid, _obj] call FUNC(opc);};
     }] call BIS_fnc_addStackedEventhandler;
 } else {
-    // v1.58 ad later
+    // v1.58 and later
     addMissionEventHandler ["PlayerConnected", {
         params ["_id", "_uid", "_name", "_jip", "_owner"];
 


### PR DESCRIPTION
this replaces all `onPlayerConnected` stacked events with `PlayerConnected` mission events. it has the benefit that no mission or addon using a delayed `onPlayerConnected <CODE>` (SQF command) can overwrite our events.
WIP tag, because there currently is a bug, where the `PlayerConnected` mission event does not fire when `onPlayerConnected <CODE>` hasn't been used at least once. this is fixed according to the todays changelog, but the bug seems to be still present in the RC version uploaded to Steam.
I'll test if they fixed that next week.
backwards compatible with 1.54 / Linux, using the same method as in the `EachFrame` PR