### PR TITLE
Move addMissionEventHandler to postInit

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -1,6 +1,33 @@
 // #define DEBUG_MODE_FULL
 #include "script_component.hpp"
 
+//Install PFEH:
+if (isNil {canSuspend}) then {
+    // pre 1.58
+    ["CBA_PFH", "onEachFrame", {
+        call FUNC(onFrame);
+        GVAR(lastFrameRender) = diag_frameNo;
+    }] call BIS_fnc_addStackedEventHandler;
+
+    FUNC(monitorFrameRender) = {
+        if (abs (diag_frameno - GVAR(lastFrameRender)) > DELAY_MONITOR_THRESHOLD) then {
+            // Restores the onEachFrame handler
+            ["CBA_PFH", "onEachFrame", {
+                call FUNC(onFrame);
+                GVAR(lastFrameRender) = diag_frameNo;
+            }] call BIS_fnc_addStackedEventHandler;
+            TRACE_1("PFH restored",nil);
+        };
+    };
+
+    // Use a trigger, runs every 0.5s, unscheduled execution
+    GVAR(perFrameTrigger) = createTrigger ["EmptyDetector", [0,0,0], false];
+    GVAR(perFrameTrigger) setTriggerStatements ['FUNC(monitorFrameRender) call CBA_fnc_directCall', "", ""];
+} else {
+    // 1.58 and later
+    addMissionEventHandler ["EachFrame", FUNC(onFrame)];
+};
+
 LOG(MSG_INIT);
 
 // NOTE: Due to the way the BIS functions initializations work, and the requirement of BIS_functions_mainscope to be a unit (in a group)

--- a/addons/common/init_perFrameHandler.sqf
+++ b/addons/common/init_perFrameHandler.sqf
@@ -84,31 +84,6 @@ FUNC(onFrame) = {
 
 };
 
-if (isNil {canSuspend}) then {
-    // pre 1.58
-    ["CBA_PFH", "onEachFrame", {
-        call FUNC(onFrame);
-        GVAR(lastFrameRender) = diag_frameNo;
-    }] call BIS_fnc_addStackedEventHandler;
-
-    FUNC(monitorFrameRender) = {
-        if (abs (diag_frameno - GVAR(lastFrameRender)) > DELAY_MONITOR_THRESHOLD) then {
-            // Restores the onEachFrame handler
-            ["CBA_PFH", "onEachFrame", {
-                call FUNC(onFrame);
-                GVAR(lastFrameRender) = diag_frameNo;
-            }] call BIS_fnc_addStackedEventHandler;
-            TRACE_1("PFH restored",nil);
-        };
-    };
-
-    // Use a trigger, runs every 0.5s, unscheduled execution
-    GVAR(perFrameTrigger) = createTrigger ["EmptyDetector", [0,0,0], false];
-    GVAR(perFrameTrigger) setTriggerStatements ['FUNC(monitorFrameRender) call CBA_fnc_directCall', "", ""];
-} else {
-    // 1.58 and later
-    addMissionEventHandler ["EachFrame", FUNC(onFrame)];
-};
 
 // fix for save games. subtract last tickTime from ETA of all PFHs after mission was loaded
 addMissionEventHandler ["Loaded", {


### PR DESCRIPTION
Fixes semi-critical bug introduced in ~~1.60~~1.58: addMissionEventHandler ["EachFrame", has
no effect in preInit when called from singleplayer eden.

Before #303 PFEH's `FUNC(onFrame)` was installed in postInit, so this should work no differently than last release.