### PR TITLE
Fix event error

### DIFF
--- a/addons/events/XEH_postInit.sqf
+++ b/addons/events/XEH_postInit.sqf
@@ -1,12 +1,13 @@
 #include "script_component.hpp"
 
 // execute JIP events after post init to guarantee execution of events added during postInit
-{
+[{
     {
         private _event = GVAR(eventNamespaceJIP) getVariable _x;
-
-        if ((_event select 0) isEqualTo EVENT_PVAR_STR) then {
-            (_event select 1) call CBA_fnc_localEvent;
+        if (_event isEqualType []) then {
+            if ((_event select 0) isEqualTo EVENT_PVAR_STR) then {
+                (_event select 1) call CBA_fnc_localEvent;
+            };
         };
     } forEach allVariables GVAR(eventNamespaceJIP);
-} call CBA_fnc_execNextFrame;
+}, []] call CBA_fnc_execNextFrame;


### PR DESCRIPTION
With full modset I get nonstop errors after #314
```
Error select: Type Bool, expected Array,String,Config entry
File x\cba\addons\events\XEH_postInit.sqf, line 8
```

`allVariables cba_events_eventNamespaceJIP;` has "cba_xeh_isinitialized" and "cba_xeh_isprocessed" which are just `true`

So just a funny side effect of the XEH fallback loop running and setting unexpected variables on the logic.