### PR TITLE
Documentation cleanup, stage 1

### DIFF
--- a/addons/ai/fnc_taskDefend.sqf
+++ b/addons/ai/fnc_taskDefend.sqf
@@ -2,7 +2,10 @@
 Function: CBA_fnc_taskDefend
 
 Description:
-    A function for a group to defend a parsed location. Groups will mount nearby static machine guns, and bunker in nearby buildings. They may also patrol the radius unless otherwise specified.
+    A function for a group to defend a parsed location.
+
+    Groups will mount nearby static machine guns and bunker in nearby buildings.
+    They may also patrol the radius unless otherwise specified.
 
 Parameters:
     - Group (Group or Object)

--- a/addons/ai/fnc_taskSearchArea.sqf
+++ b/addons/ai/fnc_taskSearchArea.sqf
@@ -3,6 +3,7 @@ Function: CBA_fnc_taskSearchArea
 
 Description:
     Given group will indefinitely randomly search the given marker/trigger area.
+
     Will also perform random building searches.
 
 Parameters:

--- a/addons/arrays/fnc_findTypeName.sqf
+++ b/addons/arrays/fnc_findTypeName.sqf
@@ -2,7 +2,7 @@
 Function: CBA_fnc_findTypeName
 
 Description:
-    A function that returns the index of the first entry of the given type in an array.
+    Returns the index of the first entry of the given type in an array.
 
 Parameters:
     0: Array

--- a/addons/arrays/fnc_findTypeOf.sqf
+++ b/addons/arrays/fnc_findTypeOf.sqf
@@ -2,7 +2,9 @@
 Function: CBA_fnc_findTypeOf
 
 Description:
-    A function that returns the index of the first entry (either object or class name string) of the given type in an array.
+   Returns the index of the first entry of a given type in an array.
+
+   The type argument is either an object or a class name string.
 
 Parameters:
     0: Array

--- a/addons/arrays/fnc_join.sqf
+++ b/addons/arrays/fnc_join.sqf
@@ -4,8 +4,9 @@ Function: CBA_fnc_join
 DEPRECATED - Please use <joinString at https://community.bistudio.com/wiki/joinString> added in Arma 3 1.50
 
 Description:
-    Joins an array of values into a single string, joining each fragment around
-    a separator string. Inverse of <CBA_fnc_split>.
+    Joins an array of values into a single string.
+
+    Eeach value is joined around a separator string. Inverse of <CBA_fnc_split>.
 
 Parameters:
     _array - Array to join together as a string [Array]

--- a/addons/arrays/fnc_sortNestedArray.sqf
+++ b/addons/arrays/fnc_sortNestedArray.sqf
@@ -2,7 +2,9 @@
 Function: CBA_fnc_sortNestedArray
 
 Description:
-    Used to sort a nested array from lowest to highest using quick sort based on the specified column, which must have numerical data.
+    Used to sort a nested array from lowest to highest using quick sort.
+
+    Sorting is based on the specified column, which must have numerical data.
 
 Parameters:
     _array: array - Nested array to be sorted

--- a/addons/common/fnc_addPlayerAction.sqf
+++ b/addons/common/fnc_addPlayerAction.sqf
@@ -2,8 +2,9 @@
 Function: CBA_fnc_addPlayerAction
 
 Description:
-    Adds persistent action to player (which will also be available in vehicles
-    and after respawn or teamswitch).
+    Adds persistent action to the player.
+
+    The action will be available in vehicles and after respawn or teamswitch.
 
     Remove action with <CBA_fnc_removePlayerAction>. *Do not* use standard
     removeAction command with these player-action indices!

--- a/addons/common/fnc_createNamespace.sqf
+++ b/addons/common/fnc_createNamespace.sqf
@@ -3,6 +3,7 @@ Function: CBA_fnc_createNamespace
 
 Description:
     Creates a namespace. Used to store and read variables via setVariable and getVariable.
+
     The Namespace is destroyed after the mission ends. getVariable ARRAY is not supported.
 
 Parameters:

--- a/addons/common/fnc_getFirer.sqf
+++ b/addons/common/fnc_getFirer.sqf
@@ -3,6 +3,7 @@ Function: CBA_fnc_getFirer
 
 Description:
     A function used to find out which unit exactly fired.
+
     Replacement for gunner, on multi-turret vehicles.
 
 Parameters:

--- a/addons/common/fnc_getNearest.sqf
+++ b/addons/common/fnc_getNearest.sqf
@@ -2,7 +2,9 @@
 Function: CBA_fnc_getNearest
 
 Description:
-    A function used to find out the nearest entity parsed in an array to a position. Compares the distance between entity's in the parsed array.
+    Find out the nearest entity parsed in an array to a position.
+
+    Compares the distance between entity's in the parsed array.
 
 Parameters:
     _position - <MARKER, OBJECT, LOCATION, GROUP, TASK or POSITION>

--- a/addons/common/fnc_getNearestBuilding.sqf
+++ b/addons/common/fnc_getNearestBuilding.sqf
@@ -2,7 +2,7 @@
 Function: CBA_fnc_getNearestBuilding
 
 Description:
-    A function used to find out the nearest building and appropriate building positions available.
+    Find the nearest building and number of building positions available.
 
 Parameters:
     _position - <OBJECT, POSITION>

--- a/addons/common/fnc_mapRelPos.sqf
+++ b/addons/common/fnc_mapRelPos.sqf
@@ -2,8 +2,9 @@
 Function: CBA_fnc_mapRelPos
 
 Description:
-    Find a position relative to a known position on the map. Passing strings
-    in for the Northing and Easting is the preferred way.
+    Find a position relative to a known position on the map.
+
+    Passing strings in for the Northing and Easting is the preferred way.
 
 Parameters:
     _pos - Position in 10 digit grid format [Easting, Northing] [Array]

--- a/addons/common/fnc_removeBackpackCargo.sqf
+++ b/addons/common/fnc_removeBackpackCargo.sqf
@@ -3,6 +3,7 @@ Function: CBA_fnc_removeBackpackCargo
 
 Description:
     Removes specific backpack(s) from local cargo space.
+
     Warning: Backpack's inventory information is lost.
 
     * Use <CBA_fnc_removeBackpackCargoGlobal> if you want to remove the backpack(s) in

--- a/addons/common/fnc_removeMagazineCargo.sqf
+++ b/addons/common/fnc_removeMagazineCargo.sqf
@@ -3,6 +3,7 @@ Function: CBA_fnc_removeMagazineCargo
 
 Description:
     Removes specific magazine(s) from local cargo space.
+
     Warning: Magazine's ammo count is lost and becomes full.
 
     * Use <CBA_fnc_removeMagazineCargoGlobal> if you want to remove the magazine(s) in

--- a/addons/common/fnc_removeWeaponCargo.sqf
+++ b/addons/common/fnc_removeWeaponCargo.sqf
@@ -3,6 +3,7 @@ Function: CBA_fnc_removeWeaponCargo
 
 Description:
     Removes specific weapon(s) from local cargo space.
+
     Warning: Weapon's attachments are lost.
 
     * Use <CBA_fnc_removeWeaponCargoGlobal> if you want to remove the weapon(s) in

--- a/addons/common/fnc_selectWeapon.sqf
+++ b/addons/common/fnc_selectWeapon.sqf
@@ -3,6 +3,7 @@ Function: CBA_fnc_selectWeapon
 
 Description:
     Selects a weapon including correctly selecting a weapon mode of specified.
+
     Has to be executed on the machine where the unit is local.
 
 Parameters:

--- a/addons/common/fnc_turretPath.sqf
+++ b/addons/common/fnc_turretPath.sqf
@@ -2,7 +2,8 @@
 Function: CBA_fnc_turretPath
 
 Description:
-    A function used to report the soldiers turret path in the current vehicle.
+    Get a unit's turret path in the current vehicle.
+
     Reverse version of the turretUnit scripting command.
 
 Parameters:

--- a/addons/common/fnc_turretPathWeapon.sqf
+++ b/addons/common/fnc_turretPathWeapon.sqf
@@ -2,7 +2,8 @@
 Function: CBA_fnc_turretPathWeapon
 
 Description:
-    A function used to report the turret path belonging to a weapon of given vehicle.
+    Get the turret path belonging to a weapon of given vehicle.
+
     Reverse version of the weaponsTurret scripting command.
 
 Parameters:

--- a/addons/common/fnc_vehicleRole.sqf
+++ b/addons/common/fnc_vehicleRole.sqf
@@ -2,7 +2,8 @@
 Function: CBA_fnc_vehicleRole
 
 Description:
-    A function used to report the soldiers role in his current vehicle.
+    Get a unit's role in its current vehicle.
+
     Used because assignedVehicleRole reports the role assigned by the group leader instead of the current position.
 
 Parameters:

--- a/addons/common/fnc_weaponComponents.sqf
+++ b/addons/common/fnc_weaponComponents.sqf
@@ -3,6 +3,7 @@ Function: CBA_fnc_weaponComponents
 
 Description:
     Reports class name of base weapon without attachments and all attachments belonging to a pre equipped weapon.
+
     Base weapon and attachments are reported in lower case capitalization.
     Fixed version of BIS_fnc_weaponComponents.
 

--- a/addons/diagnostic/fnc_peek.sqf
+++ b/addons/diagnostic/fnc_peek.sqf
@@ -2,7 +2,8 @@
 Function: CBA_fnc_peek
 
 Description:
-    Peek at variable on the server
+    Peek at variable on the server.
+
     To receive the variable content back, you will have to
     ["cba_diagnostics_receive_peak", {_this call myFunction}] call CBA_fnc_addEventHandler;
 

--- a/addons/events/fnc_addBISEventHandler.sqf
+++ b/addons/events/fnc_addBISEventHandler.sqf
@@ -3,6 +3,7 @@ Function: CBA_fnc_addBISEventHandler
 
 Description:
     Adds an event handler with arguments.
+
     Additional arguments are passed as _thisArgs. The ID is passed as _thisID.
 
 Parameters:

--- a/addons/events/fnc_addDisplayHandler.sqf
+++ b/addons/events/fnc_addDisplayHandler.sqf
@@ -3,7 +3,9 @@ Function: CBA_fnc_addDisplayHandler
 
 Description:
     Adds an action to the main display.
-    They are reapplied after loading a save game. Actions only persist for the mission and are removed after restart.
+
+    They are reapplied after loading a save game. Actions only persist for the
+    mission and are removed after restart.
 
 Parameters:
     _type - Display handler type to attach. <STRING>

--- a/addons/events/fnc_globalEventJIP.sqf
+++ b/addons/events/fnc_globalEventJIP.sqf
@@ -2,7 +2,10 @@
 Function: CBA_fnc_globalEventJIP
 
 Description:
-    Raises a CBA event on all machines. Event is put on a stack that is executed on every future JIP machine. Stack can be overwritten by using the same JIP-Stack-ID.
+    Raises a CBA event on all machines.
+
+    Event is put on a stack that is executed on every future JIP machine.
+    Stack can be overwritten by using the same JIP-Stack-ID.
 
 Parameters:
     _eventName - Type of event to publish. <STRING>

--- a/addons/help/fnc_setCreditsLine.sqf
+++ b/addons/help/fnc_setCreditsLine.sqf
@@ -2,7 +2,8 @@
 Function: CBA_help_fnc_setCreditsLine
 
 Description:
-    Picks a random CfgPatches entry with an "author" entry and displays author, version and url in the main menu and ingame in the pause menu.
+    Picks a random CfgPatches entry with an "author" entry and displays author,
+    version and URL in the main menu and ingame in the pause menu.
 
 Parameters:
     0: _display - Either Main menu or Pause menu display or a control of these displays. <DISPLAY, CONTROL>

--- a/addons/help/fnc_setVersionLine.sqf
+++ b/addons/help/fnc_setVersionLine.sqf
@@ -2,7 +2,9 @@
 Function: CBA_help_fnc_setVersionLine
 
 Description:
-    Displays all CfgPatches with a "versionDesc" entry in the main menu. Mods are cycled automatically every 3 seconds or can be browsed using LMB and RMB.
+    Displays all CfgPatches with a "versionDesc" entry in the main menu.
+
+    Mods are cycled automatically every 3 seconds or can be browsed using LMB and RMB.
     Double clicking executes the script in "versionAct".
 
 Parameters:

--- a/addons/network/fnc_publicVariable.sqf
+++ b/addons/network/fnc_publicVariable.sqf
@@ -3,6 +3,7 @@ Function: CBA_fnc_publicVariable
 
 Description:
 	CBA_fnc_publicVariable does only broadcast the new value if it doesn't exist in missionNamespace or the new value is different to the one in missionNamespace.
+
 	Checks also for different types. Nil as value gets always broadcasted.
 
 	Should reduce network traffic.

--- a/addons/network/fnc_setVarNet.sqf
+++ b/addons/network/fnc_setVarNet.sqf
@@ -3,6 +3,7 @@ Function: CBA_fnc_setVarNet
 
 Description:
 	Same as setVariable ["name",var, true] but only broadcasts when the value of var is different to the one which is already saved in the variable space.
+
 	Checks also for different types. Nil as value gets always broadcasted.
 
 	Should reduce network traffic.

--- a/addons/strings/fnc_floatToString.sqf
+++ b/addons/strings/fnc_floatToString.sqf
@@ -3,8 +3,10 @@ Function: CBA_fnc_floatToString
 
 Description:
     Returns a higher precision string representation of a IEEE 754 floating point
-    number than the str function. This function is as barebones as possible. Inline
-    macro version of this function can be used with FLOAT_TO_STRING(num).
+    number than the str function.
+
+    This function is as barebones as possible. Inline macro version of this
+    function can be used with FLOAT_TO_STRING(num).
 
 Limitations:
 

--- a/addons/strings/fnc_formatElapsedTime.sqf
+++ b/addons/strings/fnc_formatElapsedTime.sqf
@@ -2,8 +2,9 @@
 Function: CBA_fnc_formatElapsedTime
 
 Description:
-    Formats time in seconds according to a format. Intended to show time elapsed,
-    rather than time-of-day.
+    Formats time in seconds according to a format.
+
+    Intended to show time elapsed, rather than time-of-day.
 
 Parameters:
     _seconds - Number of seconds to format, for example from 'time' command [number]

--- a/addons/strings/fnc_formatNumber.sqf
+++ b/addons/strings/fnc_formatNumber.sqf
@@ -3,7 +3,9 @@ Function: CBA_fnc_formatNumber
 
 Description:
     Formats a number to a minimum integer width and to a specific number of
-    decimal places (including padding with 0s and correct rounding). Numbers
+    decimal places.
+
+    The formatting includes padding with 0s and correct rounding. Numbers
     are always displayed fully, never being condensed using an exponent (e.g.
     the number 1.234e9 would be given as "1234000000").
 

--- a/addons/strings/fnc_substr.sqf
+++ b/addons/strings/fnc_substr.sqf
@@ -2,7 +2,9 @@
 Function: CBA_fnc_substr
 
 Description:
-    Retrieves a substring of this instance. The substring starts at a specified character position and has a specified length.
+    Retrieves a substring of this instance.
+
+    The substring starts at a specified character position and has a specified length.
 
 Parameters:
     _string - String to extract from [String]

--- a/addons/vectors/fnc_simplifyAngle.sqf
+++ b/addons/vectors/fnc_simplifyAngle.sqf
@@ -3,6 +3,7 @@ Function: CBA_fnc_simplifyAngle
 
 Description:
     Returns an equivalent angle to the specified angle in the range 0 to 360.
+
     If the input angle is in the range 0 to 360, it will be returned unchanged.
 
 Parameters:

--- a/addons/vectors/fnc_simplifyAngle180.sqf
+++ b/addons/vectors/fnc_simplifyAngle180.sqf
@@ -3,6 +3,7 @@ Function: CBA_fnc_simplifyAngle180
 
 Description:
     Returns an equivalent angle to the specified angle in the range -180 to 180.
+
     If the input angle is in the range -180 to 180, it will be returned unchanged.
 
 Parameters:

--- a/addons/vectors/fnc_vectCross.sqf
+++ b/addons/vectors/fnc_vectCross.sqf
@@ -2,14 +2,16 @@
 Function: CBA_fnc_vectCross
 
 Description:
- Returns the cross product vector of two vectors.  Vectors must both be three dimensional.
+   Returns the cross product vector of two vectors.
+
+   Vectors must both be three dimensional.
 
 Parameters:
- _u the first vector.
- _v the second vector.
+    _u the first vector.
+    _v the second vector.
 
 Returns:
- the cross product (vector) of the two vectors.
+    The cross product (vector) of the two vectors.
 
 Examples:
     (begin example)

--- a/addons/vectors/fnc_vectCross2D.sqf
+++ b/addons/vectors/fnc_vectCross2D.sqf
@@ -2,14 +2,17 @@
 Function: CBA_fnc_vectCross2D
 
 Description:
- Returns the cross product vector of two 2D vectors. The result is an integer value (positive or negative), representing the magnitude of the height component.
+    Returns the cross product vector of two 2D vectors.
+
+    The result is an integer value (positive or negative), representing the
+    magnitude of the height component.
 
 Parameters:
- _u the first vector.
- _v the second vector.
+    _u the first vector.
+    _v the second vector.
 
 Returns:
- the cross product (scalar magnitude) of the two vectors.
+    The cross product (scalar magnitude) of the two vectors.
 
 Examples:
     (begin example)

--- a/addons/vectors/fnc_vectDot.sqf
+++ b/addons/vectors/fnc_vectDot.sqf
@@ -2,14 +2,15 @@
 Function: CBA_fnc_vectDot
 
 Description:
- Returns the dot product of two vectors.  Vectors can be either two or three dimesions, but they must be the same dimension.
+    Returns the dot product of two vectors.
+    Vectors can be either two or three dimesions, but they must be the same dimension.
 
 Parameters:
- _u the first vector.
- _v the second vector.
+    _u the first vector.
+    _v the second vector.
 
 Returns:
- the dot product (scalar) of the two vectors.
+    The dot product (scalar) of the two vectors.
 
 Examples:
     (begin example)

--- a/addons/vectors/fnc_vectRotate2D.sqf
+++ b/addons/vectors/fnc_vectRotate2D.sqf
@@ -2,7 +2,9 @@
 Function: CBA_fnc_vectRotate2D
 
 Description:
-    Rotates a 2D vector around a given center, for rotating of a vector from its origin, use BIS_fnc_rotateVector2D
+    Rotates a 2D vector around a given center.
+
+    For rotating of a vector from its origin, use BIS_fnc_rotateVector2D
 
 Parameters:
     Center, Vector, Angle


### PR DESCRIPTION
Keep the first sentence of a function file's Description short
and separated from the rest of the description text. This first
sentence is used to auto-generate CfgFunctions.hpp by the
tools/funcitons_config.rb script, which is also used to generate
files needed to create the on-line HTML function documentation.