### PR TITLE
Add "initRetro" event to addClassEventHandler

### DIFF
--- a/addons/xeh/fnc_addClassEventHandler.sqf
+++ b/addons/xeh/fnc_addClassEventHandler.sqf
@@ -38,6 +38,13 @@ if (!GVAR(fallbackRunning) && {ISINCOMP(_className)}) then {
 // no such CfgVehicles class
 if (!isClass _config) exitWith {false};
 
+//Handle initReto event type:
+private _runRetroactiveInit = false;
+if (_eventName == "initRetro") then {
+    _runRetroactiveInit = true;
+    _eventName = "init";
+};
+
 _eventName = toLower _eventName;
 
 // no such event
@@ -61,6 +68,11 @@ private _eventVarName = format [QGVAR(%1), _eventName];
             };
 
             (_unit getVariable _eventVarName) pushBack _eventFunc;
+
+            //Run initReto now if the unit has already been initialized
+            if (_runRetroactiveInit && {ISINITIALIZED(_unit)}) then {
+                [_unit] call _eventFunc;
+            };
         };
     };
 } forEach (_entities arrayIntersect _entities); // filter duplicates

--- a/addons/xeh/fnc_addClassEventHandler.sqf
+++ b/addons/xeh/fnc_addClassEventHandler.sqf
@@ -10,7 +10,7 @@ Parameters:
     2: _eventFunc        - Function to execute when event happens. <CODE>
     3: _allowInheritance - Allow event for objects that only inherit from the given classname? [optional] <BOOLEAN> (default: true)
     4: _excludedClasses  - Exclude these classes from this event including their children [optional] <ARRAY> (default: [])
-    5: _applyInitRetroactivly - Apply "init" event type on existing units that have already been initilized. [optional] <BOOLEAN> ((default: false)
+    5: _applyInitRetroactively - Apply "init" event type on existing units that have already been initilized. [optional] <BOOLEAN> ((default: false)
 
 Returns:
     _success - Whether adding the event was successful or not. <BOOLEAN>
@@ -27,7 +27,7 @@ Author:
 ---------------------------------------------------------------------------- */
 #include "script_component.hpp"
 
-params [["_className", "", [""]], ["_eventName", "", [""]], ["_eventFunc", {}, [{}]], ["_allowInheritance", true, [false]], ["_excludedClasses", [], [[]]], ["_applyInitRetroactivly", false, [false]]];
+params [["_className", "", [""]], ["_eventName", "", [""]], ["_eventFunc", {}, [{}]], ["_allowInheritance", true, [false]], ["_excludedClasses", [], [[]]], ["_applyInitRetroactively", false, [false]]];
 
 private _config = configFile >> "CfgVehicles" >> _className;
 
@@ -50,8 +50,8 @@ if (_eventName == "FiredBIS") exitWith {
 if !(_eventName in GVAR(EventsLowercase)) exitWith {false};
 
 // don't use "apply retroactively" for non init events
-if (_applyInitRetroactivly && {!(_eventName in ["init", "initpost"])}) then {
-    _applyInitRetroactivly = false;
+if (_applyInitRetroactively && {!(_eventName in ["init", "initpost"])}) then {
+    _applyInitRetroactively = false;
 };
 
 // add events to already existing objects
@@ -70,7 +70,7 @@ private _eventVarName = format [QGVAR(%1), _eventName];
             (_unit getVariable _eventVarName) pushBack _eventFunc;
 
             //Run initReto now if the unit has already been initialized
-            if (_applyInitRetroactivly && {ISINITIALIZED(_unit)}) then {
+            if (_applyInitRetroactively && {ISINITIALIZED(_unit)}) then {
                 [_unit] call _eventFunc;
             };
         };

--- a/addons/xeh/fnc_addClassEventHandler.sqf
+++ b/addons/xeh/fnc_addClassEventHandler.sqf
@@ -49,6 +49,11 @@ if (_eventName == "FiredBIS") exitWith {
 };
 if !(_eventName in GVAR(EventsLowercase)) exitWith {false};
 
+// don't use "apply retroactively" for non init events
+if (_applyInitRetroactivly && {!(_eventName in ["init", "initpost"])}) then {
+    _applyInitRetroactivly = false;
+};
+
 // add events to already existing objects
 private _entities = entities "" + allUnits;
 private _eventVarName = format [QGVAR(%1), _eventName];


### PR DESCRIPTION
 - Adds ability to run init code on all current and future objects via addClassEventHandler

Example usage:
```
["SettingsInitialized", {
    if (feature_enabled) then {
        ["CAManBase", "initRetro", {
            systemChat format ["Enable Feature On %1", _this]
        }] call CBA_fnc_addClassEventHandler;
    };
} call ace_common_fnc_addEventHandler;
````

Normal "init" would have no effect on existing units because unit's init event has already happened by the time the settingsInit event has happened.