### PR TITLE
add CBA_fnc_binocularMagazine

### DIFF
--- a/addons/common/CfgFunctions.hpp
+++ b/addons/common/CfgFunctions.hpp
@@ -68,6 +68,7 @@ class CfgFunctions {
             F_FILEPATH(dropMagazine);
             F_FILEPATH(dropItem);
             F_FILEPATH(binocularMagazine);
+            F_FILEPATH(removeBinocularMagazine);
         };
 
         class Cargo {

--- a/addons/common/CfgFunctions.hpp
+++ b/addons/common/CfgFunctions.hpp
@@ -68,6 +68,7 @@ class CfgFunctions {
             F_FILEPATH(dropMagazine);
             F_FILEPATH(dropItem);
             F_FILEPATH(binocularMagazine);
+            F_FILEPATH(addBinocularMagazine);
             F_FILEPATH(removeBinocularMagazine);
         };
 

--- a/addons/common/CfgFunctions.hpp
+++ b/addons/common/CfgFunctions.hpp
@@ -67,6 +67,7 @@ class CfgFunctions {
             F_FILEPATH(dropWeapon);
             F_FILEPATH(dropMagazine);
             F_FILEPATH(dropItem);
+            F_FILEPATH(binocularMagazine);
         };
 
         class Cargo {

--- a/addons/common/fnc_addBinocularMagazine.sqf
+++ b/addons/common/fnc_addBinocularMagazine.sqf
@@ -34,9 +34,6 @@ if (isNil "_ammo") then {
 };
 
 private _loadout = getUnitLoadout _unit;
-
-private _binocularInfo = _loadout param [8];
-_binocularInfo set [4, [_magazine, _ammo]];
-_loadout set [8, _binocularInfo];
+(_loadout select 8) set [4, [_magazine, _ammo]];
 
 _unit setUnitLoadout _loadout;

--- a/addons/common/fnc_addBinocularMagazine.sqf
+++ b/addons/common/fnc_addBinocularMagazine.sqf
@@ -3,6 +3,7 @@ Function: CBA_fnc_addBinocularMagazine
 
 Description:
     Adds a magazine to the units rangefinder.
+    Note that this breaks the unique magazine ids due to the usage of setUnitLoadout.
 
 Parameters:
     _unit     - A unit <OBJECT>

--- a/addons/common/fnc_addBinocularMagazine.sqf
+++ b/addons/common/fnc_addBinocularMagazine.sqf
@@ -1,0 +1,41 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_addBinocularMagazine
+
+Description:
+    Adds a magazine to the units rangefinder.
+
+Parameters:
+    _unit     - A unit <OBJECT>
+    _magazine - The magazine to add <STRING>
+    _ammo     - Ammo count of the magazine (optional, default: full magazine) <NUMBER>
+
+Returns:
+    None
+
+Examples:
+    (begin example)
+        player addWeapon "Laserdesignator";
+        [player, "Laserbatteries"] call CBA_fnc_addBinocularMagazine;
+    (end)
+
+Author:
+    commy2
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+SCRIPT(addBinocularMagazine);
+
+params [["_unit", objNull, [objNull]], ["_magazine", "", [""]], ["_ammo", nil, [0]]];
+
+if (!local _unit) exitWith {};
+
+if (isNil "_ammo") then {
+    _ammo = getNumber (configFile >> "CfgMagazines" >> _magazine >> "count");
+};
+
+private _loadout = getUnitLoadout _unit;
+
+private _binocularInfo = _loadout param [8];
+_binocularInfo set [4, [_magazine, _ammo]];
+_loadout set [8, _binocularInfo];
+
+_unit setUnitLoadout _loadout;

--- a/addons/common/fnc_addBinocularMagazine.sqf
+++ b/addons/common/fnc_addBinocularMagazine.sqf
@@ -3,6 +3,7 @@ Function: CBA_fnc_addBinocularMagazine
 
 Description:
     Adds a magazine to the units rangefinder.
+
     Note that this breaks the unique magazine ids due to the usage of setUnitLoadout.
 
 Parameters:

--- a/addons/common/fnc_binocularMagazine.sqf
+++ b/addons/common/fnc_binocularMagazine.sqf
@@ -1,0 +1,36 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_binocularMagazine
+
+Description:
+    Returns the magazine of the units rangefinder.
+
+Parameters:
+    _unit - A unit <OBJECT>
+
+Returns:
+    Magazine of the units binocular <STRING>
+
+Examples:
+    (begin example)
+        player call CBA_fnc_binocularMagazine
+    (end)
+
+Author:
+    commy2
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+SCRIPT(binocularMagazine);
+
+params [["_unit", objNull, [objNull]]];
+
+private _binocular = binocular _unit;
+private _magazine = "";
+
+{
+    if ((_x select 0) isEqualTo _binocular) exitWith {
+        // note: if there is no magazine, _x(4,0) will be nil
+        _magazine = (_x select 4) param [0, ""];
+    };
+} forEach weaponsitems _unit;
+
+_magazine

--- a/addons/common/fnc_removeBinocularMagazine.sqf
+++ b/addons/common/fnc_removeBinocularMagazine.sqf
@@ -1,0 +1,35 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_removeBinocularMagazine
+
+Description:
+    Removes the magazine of the units rangefinder.
+
+Parameters:
+    _unit - A unit <OBJECT>
+
+Returns:
+    None
+
+Examples:
+    (begin example)
+        player call CBA_fnc_removeBinocularMagazine
+    (end)
+
+Author:
+    commy2
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+SCRIPT(removeBinocularMagazine);
+
+params [["_unit", objNull, [objNull]]];
+
+if (!local _unit) exitWith {};
+
+private _binocular = binocular _unit;
+private _selectBinocular = currentWeapon _unit isEqualTo _binocular;
+
+_unit addWeapon _binocular;
+
+if (_selectBinocular) then {
+    _unit selectWeapon _binocular;
+};


### PR DESCRIPTION
- Adds `CBA_fnc_binocularMagazine` which reports the units "binocular magazine" (laserbatteries in laserdesignator)
- Adds `CBA_fnc_addBinocularMagazine` which adds a magazine to the units binocular.
- Adds `CBA_fnc_removeBinocularMagazine` which removes the units "binocular magazine" (if any)

Those are the current best SQF work arounds for these missing commands. (as far as I can tell)

This follows the same logic as `primaryWeaponMagazine`, `handgunMagazine`, `removePrimaryWeaponItem`, `addSecondaryWeaponItem` etc.