### PR TITLE
add 'CBA_fnc_addPlayerEventHandler'

### DIFF
--- a/addons/common/CfgFunctions.hpp
+++ b/addons/common/CfgFunctions.hpp
@@ -36,6 +36,7 @@ class CfgFunctions {
             F_FILEPATH(canUseWeapon);
             F_FILEPATH(selectWeapon);
             F_FILEPATH(switchPlayer);
+            F_FILEPATH(currentUnit);
         };
 
         class Vehicles {

--- a/addons/common/fnc_currentUnit.sqf
+++ b/addons/common/fnc_currentUnit.sqf
@@ -1,0 +1,20 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_currentUnit
+
+Description:
+    Returns the currently controlled unit.
+    Different from "player" when remote controlling units via zeus.
+
+Parameters:
+    None
+
+Returns:
+    Currently controlled unit <OBJECT>
+
+Author:
+    commy2
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+SCRIPT(currentUnit);
+
+missionNamespace getVariable ["bis_fnc_moduleRemoteControl_unit", player]

--- a/addons/common/fnc_currentUnit.sqf
+++ b/addons/common/fnc_currentUnit.sqf
@@ -2,8 +2,7 @@
 Function: CBA_fnc_currentUnit
 
 Description:
-    Returns the currently controlled unit.
-    Different from "player" when remote controlling units via zeus.
+    Returns the controlled unit. ("player" or remote controlled unit via zeus)
 
 Parameters:
     None

--- a/addons/events/CfgFunctions.hpp
+++ b/addons/events/CfgFunctions.hpp
@@ -6,6 +6,10 @@ class CfgFunctions {
                 description = "Adds an event handler with arguments.";
                 file = "\x\cba\addons\events\fnc_addBISEventHandler.sqf";
             };
+            class addPlayerEventHandler {
+                description = "Adds a player event handler.";
+                file = "\x\cba\addons\events\fnc_addPlayerEventHandler.sqf";
+            };
             class addDisplayHandler {
                 description = "Adds an action to the main display.";
                 file = "\x\cba\addons\events\fnc_addDisplayHandler.sqf";

--- a/addons/events/CfgFunctions.hpp
+++ b/addons/events/CfgFunctions.hpp
@@ -10,6 +10,10 @@ class CfgFunctions {
                 description = "Adds a player event handler.";
                 file = "\x\cba\addons\events\fnc_addPlayerEventHandler.sqf";
             };
+            class removePlayerEventHandler {
+                description = "Removes a player event handler.";
+                file = "\x\cba\addons\events\fnc_removePlayerEventHandler.sqf";
+            };
             class addDisplayHandler {
                 description = "Adds an action to the main display.";
                 file = "\x\cba\addons\events\fnc_addDisplayHandler.sqf";

--- a/addons/events/fnc_addPlayerEventHandler.sqf
+++ b/addons/events/fnc_addPlayerEventHandler.sqf
@@ -34,7 +34,9 @@ SCRIPT(addPlayerEventHandler);
 
 params [["_type", "", [""]], ["_function", {}, [{}]]];
 
-private _id = switch (toLower _type) do {
+_type = toLower _type;
+
+private _id = switch (_type) do {
 case ("unit"): {
     [QGVAR(unitEvent), _function] call CBA_fnc_addEventHandler // return id
 };
@@ -62,84 +64,88 @@ case ("visiblemap"): {
 default {-1};
 };
 
-// add loop for polling if it doesn't exist yet
-if (isNil QGVAR(pollingLoopAdded) && {_id != -1}) then {
-    GVAR(pollingLoopAdded) = true;
+if (_id != -1) then {
+    // add loop for polling if it doesn't exist yet
+    if (isNil QGVAR(playerEHInfo)) then {
+        GVAR(playerEHInfo) = [];
 
-    GVAR(oldUnit) = objNull;
-    GVAR(oldWeapon) = "";
-    GVAR(oldLoadout) = [];
-    GVAR(oldLoadoutNoAmmo) = [];
-    GVAR(oldVehicle) = objNull;
-    GVAR(oldTurret) = [];
-    GVAR(oldVisionMode) = -1;
-    GVAR(oldCameraView) = "";
-    GVAR(oldVisibleMap) = false;
+        GVAR(oldUnit) = objNull;
+        GVAR(oldWeapon) = "";
+        GVAR(oldLoadout) = [];
+        GVAR(oldLoadoutNoAmmo) = [];
+        GVAR(oldVehicle) = objNull;
+        GVAR(oldTurret) = [];
+        GVAR(oldVisionMode) = -1;
+        GVAR(oldCameraView) = "";
+        GVAR(oldVisibleMap) = false;
 
-    addMissionEventHandler ["EachFrame", {
-        private _player = call CBA_fnc_currentUnit;
-        if !(_player isEqualTo GVAR(oldUnit)) then {
-            GVAR(oldUnit) = _player;
-            [QGVAR(unitEvent), [_player]] call CBA_fnc_localEvent;
-        };
-
-        private _data = currentWeapon _player;
-        if !(_data isEqualTo GVAR(oldWeapon)) then {
-            GVAR(oldWeapon) = _data;
-            [QGVAR(weaponEvent), [_player, _data]] call CBA_fnc_localEvent;
-        };
-
-        _data = getUnitLoadout _player;
-        if !(_data isEqualTo GVAR(oldLoadout)) then {
-            GVAR(oldLoadout) = _data;
-
-            // we don't want to trigger this just because your ammo counter decreased.
-            _data = + GVAR(oldLoadout);
-
-            {
-                private _weaponInfo = _data param [_forEachIndex, []];
-                if !(_weaponInfo isEqualTo []) then {
-                    _weaponInfo set [4, _x];
-                    _weaponInfo deleteAt 5;
-                };
-            } forEach [primaryWeaponMagazine _player, secondaryWeaponMagazine _player, handgunMagazine _player];
-
-            if !(_data isEqualTo GVAR(oldLoadoutNoAmmo)) then {
-                GVAR(oldLoadoutNoAmmo) = _data;
-                [QGVAR(loadoutEvent), [_player, GVAR(oldLoadout)]] call CBA_fnc_localEvent;
+        GVAR(playerEHInfo) pushBack addMissionEventHandler ["EachFrame", {
+            private _player = call CBA_fnc_currentUnit;
+            if !(_player isEqualTo GVAR(oldUnit)) then {
+                GVAR(oldUnit) = _player;
+                [QGVAR(unitEvent), [_player]] call CBA_fnc_localEvent;
             };
-        };
 
-        _data = vehicle _player;
-        if !(_data isEqualTo GVAR(oldVehicle)) then {
-            GVAR(oldVehicle) = _data;
-            [QGVAR(vehicleEvent), [_player, _data]] call CBA_fnc_localEvent;
-        };
+            private _data = currentWeapon _player;
+            if !(_data isEqualTo GVAR(oldWeapon)) then {
+                GVAR(oldWeapon) = _data;
+                [QGVAR(weaponEvent), [_player, _data]] call CBA_fnc_localEvent;
+            };
 
-        _data = _player call CBA_fnc_turretPath;
-        if !(_data isEqualTo GVAR(oldTurret)) then {
-            GVAR(oldTurret) = _data;
-            [QGVAR(turretEvent), [_player, _data]] call CBA_fnc_localEvent;
-        };
+            _data = getUnitLoadout _player;
+            if !(_data isEqualTo GVAR(oldLoadout)) then {
+                GVAR(oldLoadout) = _data;
 
-        _data = currentVisionMode _player;
-        if !(_data isEqualTo GVAR(oldVisionMode)) then {
-            GVAR(oldVisionMode) = _data;
-            [QGVAR(visionModeEvent), [_player, _data]] call CBA_fnc_localEvent;
-        };
+                // we don't want to trigger this just because your ammo counter decreased.
+                _data = + GVAR(oldLoadout);
 
-        _data = cameraView;
-        if !(_data isEqualTo GVAR(oldCameraView)) then {
-            GVAR(oldCameraView) = _data;
-            [QGVAR(cameraViewEvent), [_player, _data]] call CBA_fnc_localEvent;
-        };
+                {
+                    private _weaponInfo = _data param [_forEachIndex, []];
+                    if !(_weaponInfo isEqualTo []) then {
+                        _weaponInfo set [4, _x];
+                        _weaponInfo deleteAt 5;
+                    };
+                } forEach [primaryWeaponMagazine _player, secondaryWeaponMagazine _player, handgunMagazine _player];
 
-        _data = visibleMap;
-        if !(_data isEqualTo GVAR(oldVisibleMap)) then {
-            GVAR(oldVisibleMap) = _data;
-            [QGVAR(visibleMapEvent), [_player, _data]] call CBA_fnc_localEvent;
-        };
-    }];
+                if !(_data isEqualTo GVAR(oldLoadoutNoAmmo)) then {
+                    GVAR(oldLoadoutNoAmmo) = _data;
+                    [QGVAR(loadoutEvent), [_player, GVAR(oldLoadout)]] call CBA_fnc_localEvent;
+                };
+            };
+
+            _data = vehicle _player;
+            if !(_data isEqualTo GVAR(oldVehicle)) then {
+                GVAR(oldVehicle) = _data;
+                [QGVAR(vehicleEvent), [_player, _data]] call CBA_fnc_localEvent;
+            };
+
+            _data = _player call CBA_fnc_turretPath;
+            if !(_data isEqualTo GVAR(oldTurret)) then {
+                GVAR(oldTurret) = _data;
+                [QGVAR(turretEvent), [_player, _data]] call CBA_fnc_localEvent;
+            };
+
+            _data = currentVisionMode _player;
+            if !(_data isEqualTo GVAR(oldVisionMode)) then {
+                GVAR(oldVisionMode) = _data;
+                [QGVAR(visionModeEvent), [_player, _data]] call CBA_fnc_localEvent;
+            };
+
+            _data = cameraView;
+            if !(_data isEqualTo GVAR(oldCameraView)) then {
+                GVAR(oldCameraView) = _data;
+                [QGVAR(cameraViewEvent), [_player, _data]] call CBA_fnc_localEvent;
+            };
+
+            _data = visibleMap;
+            if !(_data isEqualTo GVAR(oldVisibleMap)) then {
+                GVAR(oldVisibleMap) = _data;
+                [QGVAR(visibleMapEvent), [_player, _data]] call CBA_fnc_localEvent;
+            };
+        }];
+    };
+
+    GVAR(playerEHInfo) pushBack [_type, _id];
 };
 
 _id

--- a/addons/events/fnc_addPlayerEventHandler.sqf
+++ b/addons/events/fnc_addPlayerEventHandler.sqf
@@ -1,0 +1,71 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_addPlayerEventHandler
+
+Description:
+    Adds a player event handler.
+
+Parameters:
+    _type      - Event handler type. <STRING>
+    _function  - Function to add to event. <CODE>
+
+Returns:
+    _id - The ID of the event handler. Same as _thisID <NUMBER>
+
+Examples:
+    (begin example)
+        _id = ["unit", {systemChat str _this}] call CBA_fnc_addPlayerEventHandler;
+    (end)
+
+Author:
+    commy2
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+SCRIPT(addPlayerEventHandler);
+
+params [["_type", "", [""]], ["_function", {}, [{}]]];
+
+_type = toLower _type;
+
+if (isNil QGVAR(addedPlayerEvents)) then {
+    GVAR(addedPlayerEvents) = [] call CBA_fnc_createNamespace;
+};
+
+switch (_type) do {
+case ("unit"): {
+    // add loop for polling if it doesn't exist yet
+    if (isNil {GVAR(addedPlayerEvents) getVariable _type}) then {
+        GVAR(oldUnit) = objNull;
+        GVAR(addedPlayerEvents) setVariable [_type,
+            addMissionEventHandler ["EachFrame", {
+                private _data = call CBA_fnc_currentUnit;
+                if !(_data isEqualTo GVAR(oldUnit)) then {
+                    GVAR(oldUnit) = _data;
+                    [QGVAR(unitEvent), _data] call CBA_fnc_localEvent;
+                };
+            }]
+        ];
+    };
+
+    // add event
+    [QGVAR(unitEvent), _function] call CBA_fnc_addEventHandler // return id
+};
+case ("weapon"): {
+    // add loop for polling if it doesn't exist yet
+    if (isNil {GVAR(addedPlayerEvents) getVariable _type}) then {
+        GVAR(oldWeapon) = "<null>";
+        GVAR(addedPlayerEvents) setVariable [_type,
+            addMissionEventHandler ["EachFrame", {
+                private _data = currentWeapon (call CBA_fnc_currentUnit);
+                if !(_data isEqualTo GVAR(oldWeapon)) then {
+                    GVAR(oldWeapon) = _data;
+                    [QGVAR(weaponEvent), _data] call CBA_fnc_localEvent;
+                };
+            }]
+        ];
+    };
+
+    // add event
+    [QGVAR(weaponEvent), _function] call CBA_fnc_addEventHandler // return id
+};
+default {-1};
+};

--- a/addons/events/fnc_addPlayerEventHandler.sqf
+++ b/addons/events/fnc_addPlayerEventHandler.sqf
@@ -32,165 +32,114 @@ Author:
 #include "script_component.hpp"
 SCRIPT(addPlayerEventHandler);
 
-#define PLAYER_UNIT (missionNamespace getVariable ["bis_fnc_moduleRemoteControl_unit", player])
-
 params [["_type", "", [""]], ["_function", {}, [{}]]];
 
-if (isNil QGVAR(addedPlayerEvents)) then {
-    GVAR(addedPlayerEvents) = [] call CBA_fnc_createNamespace;
-};
-
-switch (toLower _type) do {
+private _id = switch (toLower _type) do {
 case ("unit"): {
-    // add loop for polling if it doesn't exist yet
-    if (isNil {GVAR(addedPlayerEvents) getVariable _type}) then {
-        GVAR(oldUnit) = objNull;
-        GVAR(addedPlayerEvents) setVariable [_type, addMissionEventHandler ["EachFrame", {
-            private _data = PLAYER_UNIT;
-            if !(_data isEqualTo GVAR(oldUnit)) then {
-                GVAR(oldUnit) = _data;
-                [QGVAR(unitEvent), [_data]] call CBA_fnc_localEvent;
-            };
-        }]];
-    };
-
-    // add event
     [QGVAR(unitEvent), _function] call CBA_fnc_addEventHandler // return id
 };
-
 case ("weapon"): {
-    // add loop for polling if it doesn't exist yet
-    if (isNil {GVAR(addedPlayerEvents) getVariable _type}) then {
-        GVAR(oldWeapon) = "";
-        GVAR(addedPlayerEvents) setVariable [_type, addMissionEventHandler ["EachFrame", {
-            private _data = currentWeapon PLAYER_UNIT;
-            if !(_data isEqualTo GVAR(oldWeapon)) then {
-                GVAR(oldWeapon) = _data;
-                [QGVAR(weaponEvent), [PLAYER_UNIT, _data]] call CBA_fnc_localEvent;
-            };
-        }]];
-    };
-
-    // add event
     [QGVAR(weaponEvent), _function] call CBA_fnc_addEventHandler // return id
 };
-
 case ("loadout"): {
-    // add loop for polling if it doesn't exist yet
-    if (isNil {GVAR(addedPlayerEvents) getVariable _type}) then {
-        GVAR(oldLoadout) = [];
-        GVAR(oldLoadoutNoAmmo) = [];
-        GVAR(addedPlayerEvents) setVariable [_type, addMissionEventHandler ["EachFrame", {
-            private _data = getUnitLoadout PLAYER_UNIT;
-            if !(_data isEqualTo GVAR(oldLoadout)) then {
-                GVAR(oldLoadout) = _data;
-
-                // we don't want to trigger this just because your ammo counter decreased.
-                _data = + GVAR(oldLoadout);
-
-                {
-                    private _weaponInfo = _data param [_forEachIndex, []];
-                    if !(_weaponInfo isEqualTo []) then {
-                        _weaponInfo set [4, _x];
-                        _weaponInfo deleteAt 5;
-                    };
-                } forEach [primaryWeaponMagazine PLAYER_UNIT, secondaryWeaponMagazine PLAYER_UNIT, handgunMagazine PLAYER_UNIT];
-
-                if !(_data isEqualTo GVAR(oldLoadoutNoAmmo)) then {
-                    GVAR(oldLoadoutNoAmmo) = _data;
-                    [QGVAR(loadoutEvent), [PLAYER_UNIT, GVAR(oldLoadout)]] call CBA_fnc_localEvent;
-                };
-            };
-        }]];
-    };
-
-    // add event
     [QGVAR(loadoutEvent), _function] call CBA_fnc_addEventHandler // return id
 };
-
 case ("vehicle"): {
-    // add loop for polling if it doesn't exist yet
-    if (isNil {GVAR(addedPlayerEvents) getVariable _type}) then {
-        GVAR(oldVehicle) = objNull;
-        GVAR(addedPlayerEvents) setVariable [_type, addMissionEventHandler ["EachFrame", {
-            private _data = vehicle PLAYER_UNIT;
-            if !(_data isEqualTo GVAR(oldVehicle)) then {
-                GVAR(oldVehicle) = _data;
-                [QGVAR(vehicleEvent), [PLAYER_UNIT, _data]] call CBA_fnc_localEvent;
-            };
-        }]];
-    };
-
-    // add event
     [QGVAR(vehicleEvent), _function] call CBA_fnc_addEventHandler // return id
 };
-
 case ("turret"): {
-    // add loop for polling if it doesn't exist yet
-    if (isNil {GVAR(addedPlayerEvents) getVariable _type}) then {
-        GVAR(oldTurret) = [];
-        GVAR(addedPlayerEvents) setVariable [_type, addMissionEventHandler ["EachFrame", {
-            private _data = PLAYER_UNIT call CBA_fnc_turretPath;
-            if !(_data isEqualTo GVAR(oldTurret)) then {
-                GVAR(oldTurret) = _data;
-                [QGVAR(turretEvent), [PLAYER_UNIT, _data]] call CBA_fnc_localEvent;
-            };
-        }]];
-    };
-
-    // add event
     [QGVAR(turretEvent), _function] call CBA_fnc_addEventHandler // return id
 };
-
 case ("visionmode"): {
-    // add loop for polling if it doesn't exist yet
-    if (isNil {GVAR(addedPlayerEvents) getVariable _type}) then {
-        GVAR(oldVisionMode) = -1;
-        GVAR(addedPlayerEvents) setVariable [_type, addMissionEventHandler ["EachFrame", {
-            private _data = currentVisionMode PLAYER_UNIT;
-            if !(_data isEqualTo GVAR(oldVisionMode)) then {
-                GVAR(oldVisionMode) = _data;
-                [QGVAR(visionModeEvent), [PLAYER_UNIT, _data]] call CBA_fnc_localEvent;
-            };
-        }]];
-    };
-
-    // add event
     [QGVAR(visionModeEvent), _function] call CBA_fnc_addEventHandler // return id
 };
-
 case ("cameraview"): {
-    // add loop for polling if it doesn't exist yet
-    if (isNil {GVAR(addedPlayerEvents) getVariable _type}) then {
-        GVAR(oldCameraView) = "";
-        GVAR(addedPlayerEvents) setVariable [_type, addMissionEventHandler ["EachFrame", {
-            private _data = cameraView;
-            if !(_data isEqualTo GVAR(oldCameraView)) then {
-                GVAR(oldCameraView) = _data;
-                [QGVAR(cameraViewEvent), [PLAYER_UNIT, _data]] call CBA_fnc_localEvent;
-            };
-        }]];
-    };
-
-    // add event
     [QGVAR(cameraViewEvent), _function] call CBA_fnc_addEventHandler // return id
 };
-
 case ("visiblemap"): {
-    // add loop for polling if it doesn't exist yet
-    if (isNil {GVAR(addedPlayerEvents) getVariable _type}) then {
-        GVAR(oldVisibleMap) = false;
-        GVAR(addedPlayerEvents) setVariable [_type, addMissionEventHandler ["EachFrame", {
-            private _data = visibleMap;
-            if !(_data isEqualTo GVAR(oldVisibleMap)) then {
-                GVAR(oldVisibleMap) = _data;
-                [QGVAR(visibleMapEvent), [PLAYER_UNIT, _data]] call CBA_fnc_localEvent;
-            };
-        }]];
-    };
-
-    // add event
     [QGVAR(visibleMapEvent), _function] call CBA_fnc_addEventHandler // return id
 };
 default {-1};
 };
+
+// add loop for polling if it doesn't exist yet
+if (isNil QGVAR(pollingLoopAdded) && {_id != -1}) then {
+    GVAR(pollingLoopAdded) = true;
+
+    GVAR(oldUnit) = objNull;
+    GVAR(oldWeapon) = "";
+    GVAR(oldLoadout) = [];
+    GVAR(oldLoadoutNoAmmo) = [];
+    GVAR(oldVehicle) = objNull;
+    GVAR(oldTurret) = [];
+    GVAR(oldVisionMode) = -1;
+    GVAR(oldCameraView) = "";
+    GVAR(oldVisibleMap) = false;
+
+    addMissionEventHandler ["EachFrame", {
+        private _player = call CBA_fnc_currentUnit;
+        if !(_player isEqualTo GVAR(oldUnit)) then {
+            GVAR(oldUnit) = _player;
+            [QGVAR(unitEvent), [_player]] call CBA_fnc_localEvent;
+        };
+
+        private _data = currentWeapon _player;
+        if !(_data isEqualTo GVAR(oldWeapon)) then {
+            GVAR(oldWeapon) = _data;
+            [QGVAR(weaponEvent), [_player, _data]] call CBA_fnc_localEvent;
+        };
+
+        _data = getUnitLoadout _player;
+        if !(_data isEqualTo GVAR(oldLoadout)) then {
+            GVAR(oldLoadout) = _data;
+
+            // we don't want to trigger this just because your ammo counter decreased.
+            _data = + GVAR(oldLoadout);
+
+            {
+                private _weaponInfo = _data param [_forEachIndex, []];
+                if !(_weaponInfo isEqualTo []) then {
+                    _weaponInfo set [4, _x];
+                    _weaponInfo deleteAt 5;
+                };
+            } forEach [primaryWeaponMagazine _player, secondaryWeaponMagazine _player, handgunMagazine _player];
+
+            if !(_data isEqualTo GVAR(oldLoadoutNoAmmo)) then {
+                GVAR(oldLoadoutNoAmmo) = _data;
+                [QGVAR(loadoutEvent), [_player, GVAR(oldLoadout)]] call CBA_fnc_localEvent;
+            };
+        };
+
+        _data = vehicle _player;
+        if !(_data isEqualTo GVAR(oldVehicle)) then {
+            GVAR(oldVehicle) = _data;
+            [QGVAR(vehicleEvent), [_player, _data]] call CBA_fnc_localEvent;
+        };
+
+        _data = _player call CBA_fnc_turretPath;
+        if !(_data isEqualTo GVAR(oldTurret)) then {
+            GVAR(oldTurret) = _data;
+            [QGVAR(turretEvent), [_player, _data]] call CBA_fnc_localEvent;
+        };
+
+        _data = currentVisionMode _player;
+        if !(_data isEqualTo GVAR(oldVisionMode)) then {
+            GVAR(oldVisionMode) = _data;
+            [QGVAR(visionModeEvent), [_player, _data]] call CBA_fnc_localEvent;
+        };
+
+        _data = cameraView;
+        if !(_data isEqualTo GVAR(oldCameraView)) then {
+            GVAR(oldCameraView) = _data;
+            [QGVAR(cameraViewEvent), [_player, _data]] call CBA_fnc_localEvent;
+        };
+
+        _data = visibleMap;
+        if !(_data isEqualTo GVAR(oldVisibleMap)) then {
+            GVAR(oldVisibleMap) = _data;
+            [QGVAR(visibleMapEvent), [_player, _data]] call CBA_fnc_localEvent;
+        };
+    }];
+};
+
+_id

--- a/addons/events/fnc_addPlayerEventHandler.sqf
+++ b/addons/events/fnc_addPlayerEventHandler.sqf
@@ -4,12 +4,22 @@ Function: CBA_fnc_addPlayerEventHandler
 Description:
     Adds a player event handler.
 
+    Possible events:
+        "unit"       - player controlled unit changed
+        "weapon"     - currently selected weapon change
+        "loadout"    - players loadout changed
+        "vehicle"    - players current vehicle changed
+        "turret"     - position in vehicle changed
+        "visionMode" - player changed to normal/night/thermal view
+        "cameraView" - camera mode changed ("Internal", "External", "Gunner" etc.)
+        "visibleMap" - opened or closed map
+
 Parameters:
     _type      - Event handler type. <STRING>
     _function  - Function to add to event. <CODE>
 
 Returns:
-    _id - The ID of the event handler. Same as _thisID <NUMBER>
+    _id - The ID of the event handler. <NUMBER>
 
 Examples:
     (begin example)
@@ -22,50 +32,165 @@ Author:
 #include "script_component.hpp"
 SCRIPT(addPlayerEventHandler);
 
-params [["_type", "", [""]], ["_function", {}, [{}]]];
+#define PLAYER_UNIT (missionNamespace getVariable ["bis_fnc_moduleRemoteControl_unit", player])
 
-_type = toLower _type;
+params [["_type", "", [""]], ["_function", {}, [{}]]];
 
 if (isNil QGVAR(addedPlayerEvents)) then {
     GVAR(addedPlayerEvents) = [] call CBA_fnc_createNamespace;
 };
 
-switch (_type) do {
+switch (toLower _type) do {
 case ("unit"): {
     // add loop for polling if it doesn't exist yet
     if (isNil {GVAR(addedPlayerEvents) getVariable _type}) then {
         GVAR(oldUnit) = objNull;
-        GVAR(addedPlayerEvents) setVariable [_type,
-            addMissionEventHandler ["EachFrame", {
-                private _data = call CBA_fnc_currentUnit;
-                if !(_data isEqualTo GVAR(oldUnit)) then {
-                    GVAR(oldUnit) = _data;
-                    [QGVAR(unitEvent), _data] call CBA_fnc_localEvent;
-                };
-            }]
-        ];
+        GVAR(addedPlayerEvents) setVariable [_type, addMissionEventHandler ["EachFrame", {
+            private _data = PLAYER_UNIT;
+            if !(_data isEqualTo GVAR(oldUnit)) then {
+                GVAR(oldUnit) = _data;
+                [QGVAR(unitEvent), [_data]] call CBA_fnc_localEvent;
+            };
+        }]];
     };
 
     // add event
     [QGVAR(unitEvent), _function] call CBA_fnc_addEventHandler // return id
 };
+
 case ("weapon"): {
     // add loop for polling if it doesn't exist yet
     if (isNil {GVAR(addedPlayerEvents) getVariable _type}) then {
-        GVAR(oldWeapon) = "<null>";
-        GVAR(addedPlayerEvents) setVariable [_type,
-            addMissionEventHandler ["EachFrame", {
-                private _data = currentWeapon (call CBA_fnc_currentUnit);
-                if !(_data isEqualTo GVAR(oldWeapon)) then {
-                    GVAR(oldWeapon) = _data;
-                    [QGVAR(weaponEvent), _data] call CBA_fnc_localEvent;
-                };
-            }]
-        ];
+        GVAR(oldWeapon) = "";
+        GVAR(addedPlayerEvents) setVariable [_type, addMissionEventHandler ["EachFrame", {
+            private _data = currentWeapon PLAYER_UNIT;
+            if !(_data isEqualTo GVAR(oldWeapon)) then {
+                GVAR(oldWeapon) = _data;
+                [QGVAR(weaponEvent), [PLAYER_UNIT, _data]] call CBA_fnc_localEvent;
+            };
+        }]];
     };
 
     // add event
     [QGVAR(weaponEvent), _function] call CBA_fnc_addEventHandler // return id
+};
+
+case ("loadout"): {
+    // add loop for polling if it doesn't exist yet
+    if (isNil {GVAR(addedPlayerEvents) getVariable _type}) then {
+        GVAR(oldLoadout) = [];
+        GVAR(oldLoadoutNoAmmo) = [];
+        GVAR(addedPlayerEvents) setVariable [_type, addMissionEventHandler ["EachFrame", {
+            private _data = getUnitLoadout PLAYER_UNIT;
+            if !(_data isEqualTo GVAR(oldLoadout)) then {
+                GVAR(oldLoadout) = _data;
+
+                // we don't want to trigger this just because your ammo counter decreased.
+                _data = + GVAR(oldLoadout);
+
+                {
+                    private _weaponInfo = _data param [_forEachIndex, []];
+                    if !(_weaponInfo isEqualTo []) then {
+                        _weaponInfo set [4, _x];
+                        _weaponInfo deleteAt 5;
+                    };
+                } forEach [primaryWeaponMagazine PLAYER_UNIT, secondaryWeaponMagazine PLAYER_UNIT, handgunMagazine PLAYER_UNIT];
+
+                if !(_data isEqualTo GVAR(oldLoadoutNoAmmo)) then {
+                    GVAR(oldLoadoutNoAmmo) = _data;
+                    [QGVAR(loadoutEvent), [PLAYER_UNIT, GVAR(oldLoadout)]] call CBA_fnc_localEvent;
+                };
+            };
+        }]];
+    };
+
+    // add event
+    [QGVAR(loadoutEvent), _function] call CBA_fnc_addEventHandler // return id
+};
+
+case ("vehicle"): {
+    // add loop for polling if it doesn't exist yet
+    if (isNil {GVAR(addedPlayerEvents) getVariable _type}) then {
+        GVAR(oldVehicle) = objNull;
+        GVAR(addedPlayerEvents) setVariable [_type, addMissionEventHandler ["EachFrame", {
+            private _data = vehicle PLAYER_UNIT;
+            if !(_data isEqualTo GVAR(oldVehicle)) then {
+                GVAR(oldVehicle) = _data;
+                [QGVAR(vehicleEvent), [PLAYER_UNIT, _data]] call CBA_fnc_localEvent;
+            };
+        }]];
+    };
+
+    // add event
+    [QGVAR(vehicleEvent), _function] call CBA_fnc_addEventHandler // return id
+};
+
+case ("turret"): {
+    // add loop for polling if it doesn't exist yet
+    if (isNil {GVAR(addedPlayerEvents) getVariable _type}) then {
+        GVAR(oldTurret) = [];
+        GVAR(addedPlayerEvents) setVariable [_type, addMissionEventHandler ["EachFrame", {
+            private _data = PLAYER_UNIT call CBA_fnc_turretPath;
+            if !(_data isEqualTo GVAR(oldTurret)) then {
+                GVAR(oldTurret) = _data;
+                [QGVAR(turretEvent), [PLAYER_UNIT, _data]] call CBA_fnc_localEvent;
+            };
+        }]];
+    };
+
+    // add event
+    [QGVAR(turretEvent), _function] call CBA_fnc_addEventHandler // return id
+};
+
+case ("visionmode"): {
+    // add loop for polling if it doesn't exist yet
+    if (isNil {GVAR(addedPlayerEvents) getVariable _type}) then {
+        GVAR(oldVisionMode) = -1;
+        GVAR(addedPlayerEvents) setVariable [_type, addMissionEventHandler ["EachFrame", {
+            private _data = currentVisionMode PLAYER_UNIT;
+            if !(_data isEqualTo GVAR(oldVisionMode)) then {
+                GVAR(oldVisionMode) = _data;
+                [QGVAR(visionModeEvent), [PLAYER_UNIT, _data]] call CBA_fnc_localEvent;
+            };
+        }]];
+    };
+
+    // add event
+    [QGVAR(visionModeEvent), _function] call CBA_fnc_addEventHandler // return id
+};
+
+case ("cameraview"): {
+    // add loop for polling if it doesn't exist yet
+    if (isNil {GVAR(addedPlayerEvents) getVariable _type}) then {
+        GVAR(oldCameraView) = "";
+        GVAR(addedPlayerEvents) setVariable [_type, addMissionEventHandler ["EachFrame", {
+            private _data = cameraView;
+            if !(_data isEqualTo GVAR(oldCameraView)) then {
+                GVAR(oldCameraView) = _data;
+                [QGVAR(cameraViewEvent), [PLAYER_UNIT, _data]] call CBA_fnc_localEvent;
+            };
+        }]];
+    };
+
+    // add event
+    [QGVAR(cameraViewEvent), _function] call CBA_fnc_addEventHandler // return id
+};
+
+case ("visiblemap"): {
+    // add loop for polling if it doesn't exist yet
+    if (isNil {GVAR(addedPlayerEvents) getVariable _type}) then {
+        GVAR(oldVisibleMap) = false;
+        GVAR(addedPlayerEvents) setVariable [_type, addMissionEventHandler ["EachFrame", {
+            private _data = visibleMap;
+            if !(_data isEqualTo GVAR(oldVisibleMap)) then {
+                GVAR(oldVisibleMap) = _data;
+                [QGVAR(visibleMapEvent), [PLAYER_UNIT, _data]] call CBA_fnc_localEvent;
+            };
+        }]];
+    };
+
+    // add event
+    [QGVAR(visibleMapEvent), _function] call CBA_fnc_addEventHandler // return id
 };
 default {-1};
 };

--- a/addons/events/fnc_removePlayerEventHandler.sqf
+++ b/addons/events/fnc_removePlayerEventHandler.sqf
@@ -1,0 +1,60 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_removePlayerEventHandler
+
+Description:
+    Removes a player event handler.
+
+Parameters:
+    _type - Event handler type. <STRING>
+    _id   - The ID of the event handler. <NUMBER>
+
+Returns:
+    None
+
+Examples:
+    (begin example)
+        ["unit", _id] call CBA_fnc_removePlayerEventHandler;
+    (end)
+
+Author:
+    commy2
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+SCRIPT(removePlayerEventHandler);
+
+params [["_type", "", [""]], ["_id", -1, [0]]];
+
+switch (toLower _type) do {
+case ("unit"): {
+    [QGVAR(unitEvent), _id] call CBA_fnc_removeEventHandler;
+};
+
+case ("weapon"): {
+    [QGVAR(weaponEvent), _id] call CBA_fnc_removeEventHandler;
+};
+
+case ("loadout"): {
+    [QGVAR(loadoutEvent), _id] call CBA_fnc_removeEventHandler;
+};
+
+case ("vehicle"): {
+    [QGVAR(vehicleEvent), _id] call CBA_fnc_removeEventHandler;
+};
+
+case ("turret"): {
+    [QGVAR(turretEvent), _id] call CBA_fnc_removeEventHandler;
+};
+
+case ("visionmode"): {
+    [QGVAR(visionModeEvent), _id] call CBA_fnc_removeEventHandler;
+};
+
+case ("cameraview"): {
+    [QGVAR(cameraViewEvent), _id] call CBA_fnc_removeEventHandler;
+};
+
+case ("visiblemap"): {
+    [QGVAR(visibleMapEvent), _id] call CBA_fnc_removeEventHandler;
+};
+default {nil};
+};

--- a/addons/events/fnc_removePlayerEventHandler.sqf
+++ b/addons/events/fnc_removePlayerEventHandler.sqf
@@ -24,7 +24,9 @@ SCRIPT(removePlayerEventHandler);
 
 params [["_type", "", [""]], ["_id", -1, [0]]];
 
-switch (toLower _type) do {
+_type = toLower _type;
+
+switch (_type) do {
 case ("unit"): {
     [QGVAR(unitEvent), _id] call CBA_fnc_removeEventHandler;
 };
@@ -51,3 +53,14 @@ case ("visiblemap"): {
 };
 default {nil};
 };
+
+if (!isNil QGVAR(playerEHInfo)) then {
+    GVAR(playerEHInfo) deleteAt (GVAR(playerEHInfo) find [_type, _id]);
+
+    if (count GVAR(playerEHInfo) == 1) then {
+        removeMissionEventHandler ["EachFrame", GVAR(playerEHInfo) select 0];
+        GVAR(playerEHInfo) = nil;
+    };
+};
+
+nil

--- a/addons/events/fnc_removePlayerEventHandler.sqf
+++ b/addons/events/fnc_removePlayerEventHandler.sqf
@@ -28,31 +28,24 @@ switch (toLower _type) do {
 case ("unit"): {
     [QGVAR(unitEvent), _id] call CBA_fnc_removeEventHandler;
 };
-
 case ("weapon"): {
     [QGVAR(weaponEvent), _id] call CBA_fnc_removeEventHandler;
 };
-
 case ("loadout"): {
     [QGVAR(loadoutEvent), _id] call CBA_fnc_removeEventHandler;
 };
-
 case ("vehicle"): {
     [QGVAR(vehicleEvent), _id] call CBA_fnc_removeEventHandler;
 };
-
 case ("turret"): {
     [QGVAR(turretEvent), _id] call CBA_fnc_removeEventHandler;
 };
-
 case ("visionmode"): {
     [QGVAR(visionModeEvent), _id] call CBA_fnc_removeEventHandler;
 };
-
 case ("cameraview"): {
     [QGVAR(cameraViewEvent), _id] call CBA_fnc_removeEventHandler;
 };
-
 case ("visiblemap"): {
     [QGVAR(visibleMapEvent), _id] call CBA_fnc_removeEventHandler;
 };


### PR DESCRIPTION
Port (?) from ACE.
This is a framework to add event handlers based around properties of the players avatar that are pretty usefull, but unfortunately require polling.

Possible events:
        - `"unit"`       - player controlled unit changed
        - `"weapon"`     - currently selected weapon change
        - `"loadout"`    - players loadout changed
        - `"vehicle"`    - players current vehicle changed
        - `"turret"`     - position in vehicle changed
        - `"visionMode"` - player changed to normal/night/thermal view
        - `"cameraView"` - camera mode changed ("Internal", "External", "Gunner" etc.)
        - `"visibleMap"` - opened or closed map