### PR TITLE
Handle nil/non-bool returns for keyHandlers

### DIFF
--- a/addons/events/fnc_keyHandlerDown.sqf
+++ b/addons/events/fnc_keyHandlerDown.sqf
@@ -49,10 +49,11 @@ private _blockInput = false;
 
             _blockInput = _params call _code;
 
-            if ((isNil "_blockInput") || {!(_blockInput isEqualType false)}) then {
-                LOG(PFORMAT_2("Keybind Handler returned nil or non-bool", _x, _blockInput));
-                _blockInput = false; //Set to a bool, so we don't return garbage at end
-            };
+            #ifdef DEBUG_MODE_FULL
+                if ((isNil "_blockInput") || {!(_blockInput isEqualType false)}) then {
+                    LOG(PFORMAT_2("Keybind Handler returned nil or non-bool", _x, _blockInput));
+                };
+            #endif
         };
 
         if (_blockInput isEqualTo true) exitWith {};
@@ -72,4 +73,5 @@ private _blockInput = false;
     };
 } forEach (GVAR(keyUpStates) param [_inputKey, []]);
 
-_blockInput
+//Only return true if _blockInput is defined and is type bool (handlers could return anything):
+(!isNil "_blockInput") && {_blockInput isEqualTo true}

--- a/addons/events/fnc_keyHandlerDown.sqf
+++ b/addons/events/fnc_keyHandlerDown.sqf
@@ -48,6 +48,11 @@ private _blockInput = false;
             _params pushBack _x;
 
             _blockInput = _params call _code;
+
+            if ((isNil "_blockInput") || {!(_blockInput isEqualType false)}) then {
+                LOG(PFORMAT_2("Keybind Handler returned nil or non-bool", _x, _blockInput));
+                _blockInput = false; //Set to a bool, so we don't return garbage at end
+            };
         };
 
         if (_blockInput isEqualTo true) exitWith {};


### PR DESCRIPTION
When user added key handler returns bad data, arma throws a generic unhelpful error.
```
Error in expression <#line 1 "x\cba\addons\events\fnc_keyHand>
 Error position: <#line 1 "x\cba\addons\events\fnc_keyHand>
 Error Type Script, expected Bool
```

`_blockInput` is returned at bottom of our function, so if a handler returns bad data, our function will return it as well.

`LOG(` won't show under normal debug; we could swap to `WARNING(` if we want to give feedback (this is what we had before #284)?

keyHandlerUp is similar, but doesn't return the results, so it shouldn't matter there.
