### PR TITLE
Replace replace

### DIFF
--- a/addons/strings/fnc_replace.sqf
+++ b/addons/strings/fnc_replace.sqf
@@ -27,14 +27,14 @@ Author:
 SCRIPT(replace);
 
 params [["_string", "", [""]], ["_find", "", [""]], ["_replace", "", [""]]];
-private ["_offset", "_index"];
-if (_find == "" || {_replace find _find != -1}) exitWith {_string};
-
-_offset = count (_find splitString "");
+if (_find == "") exitWith {_string}; // "1" find "" -> 0
+private _result = "";
+private _offset = count (_find splitString "");
 
 while {_string find _find != -1} do {
-    _index = _string find _find;
-    _string = (_string select [0, _index]) + _replace + (_string select [_index + _offset]);
+    private _index = _string find _find;
+    _result = _result + (_string select [0, _index]) + _replace;
+    _string = _string select [_index + _offset];
 };
 
-_string
+_result + _string

--- a/addons/strings/fnc_replace.sqf
+++ b/addons/strings/fnc_replace.sqf
@@ -19,35 +19,22 @@ Example:
     (end)
 
 Author:
-    jaynus
+    BaerMitUmlaut
 --------------------------------------------------------------------------- */
 
 #include "script_component.hpp"
 
 SCRIPT(replace);
 
-// ----------------------------------------------------------------------------
+params [["_string", "", [""]], ["_find", "", [""]], ["_replace", "", [""]]];
+private ["_offset", "_index"];
+if (_find == "" || {_replace find _find != -1}) exitWith {_string};
 
-params ["_string","_pattern","_replacement"];
-private["_i", "_cp", "_findIndex", "_stringArray", "_replaceArray", "_returnArray"];
+_offset = count (_find splitString "");
 
-_returnArray  = [];
-_cp           = count _pattern;
-_stringArray  = toArray _string;
-_replaceArray = toArray _replacement;
-
-_findIndex    = _string find _pattern;
-while { _findIndex != -1 } do {
-    _i = 0;
-    while { _i < _findIndex } do {
-        _returnArray pushBack (_stringArray select _i);
-        _i = _i + 1;
-    };
-    _returnArray append _replaceArray;
-    _stringArray deleteRange [0, _i + _cp];
-
-    _string = toString _stringArray;
-    _findIndex = _string find _pattern;
+while {_string find _find != -1} do {
+    _index = _string find _find;
+    _string = (_string select [0, _index]) + _replace + (_string select [_index + _offset]);
 };
-_returnArray append _stringArray;
-toString _returnArray
+
+_string

--- a/addons/strings/test_strings.sqf
+++ b/addons/strings/test_strings.sqf
@@ -106,6 +106,12 @@ TEST_OP(_str,==,"frag",_fn);
 _str = ["frodo", "o", "ai"] call CBA_fnc_replace;
 TEST_OP(_str,==,"fraidai",_fn);
 
+_str = ["Test", "e", "ea"] call CBA_fnc_replace;
+TEST_OP(_str,==,"Teast",_fn);
+
+_str = ["Mörser", "ö", "oe"] call CBA_fnc_replace;
+TEST_OP(_str,==,"Moerser",_fn);
+
 // ----------------------------------------------------------------------------
 // UNIT TESTS (leftTrim)
 _fn = "CBA_fnc_leftTrim";


### PR DESCRIPTION
This PR replaces the replace function. The old one does not work properly with some characters (for example öüäß) due to buggy BI commands:
```
("ü" splitString "") apply {toArray _x}
-> [[65533],[65533]]
"abcßdef" find "ß"
-> 3
"abcßdef" find "d"
-> 5
```
It also adds params checking and doesn't use any `toArray`/`toString` stuff anymore.