### PR TITLE
don't use same macro name twice

### DIFF
--- a/addons/linux/CfgEventHandlers.hpp
+++ b/addons/linux/CfgEventHandlers.hpp
@@ -1,13 +1,13 @@
 
-#define F_FILEPATH(comp,func) class DOUBLES(PREFIX,comp) {\
+#define F_FILEPATH_XEH(comp,func) class DOUBLES(PREFIX,comp) {\
     init = __EVAL([QUOTE(call COMPILE_FILE_SYS(PREFIX,comp,func)), QUOTE(call COMPILE_FILE_SYS(PREFIX,comp,DOUBLES(func,Linux)))] select IS_LINUX);\
 }
 
 class Extended_PreStart_EventHandlers {
-    F_FILEPATH(events,XEH_preStart);
+    F_FILEPATH_XEH(events,XEH_preStart);
 };
 
 class Extended_PreInit_EventHandlers {
-    F_FILEPATH(common,XEH_preInit);
-    F_FILEPATH(events,XEH_preInit);
+    F_FILEPATH_XEH(common,XEH_preInit);
+    F_FILEPATH_XEH(events,XEH_preInit);
 };


### PR DESCRIPTION
- fixes: `Line 4 #define altered without #undef`