### PR TITLE
change back globalExecute to suspendable environment

### DIFF
--- a/addons/network/fnc_globalExecute.sqf
+++ b/addons/network/fnc_globalExecute.sqf
@@ -42,11 +42,14 @@ _channel = [
     CBA_SEND_TO_SERVER_ONLY
 ] find _channel];
 
+// we want to have this executed in suspendable environment for bwc
+_parameters = [_parameters, _code];
+_code = {(_this select 0) spawn (_this select 1)};
+
 // we want to execute ClientsOnly on dedicated clients and SP clients too
 if (_channel isEqualTo BI_SEND_TO_CLIENTS_ONLY) then {
     _channel = BI_SEND_TO_ALL;
-    _parameters = [_parameters, _code];
-    _code = {if (!isDedicated) then {(_this select 0) call (_this select 1)}};
+    _code = {if (!isDedicated) then {(_this select 0) spawn (_this select 1)}};
 };
 
 [_parameters, _code] remoteExec ["call", _channel];

--- a/addons/network/fnc_globalExecute.sqf
+++ b/addons/network/fnc_globalExecute.sqf
@@ -42,16 +42,16 @@ _channel = [
     CBA_SEND_TO_SERVER_ONLY
 ] find _channel];
 
-// we want to have this executed in suspendable environment for bwc
-_parameters = [_parameters, _code];
-_code = {(_this select 0) spawn (_this select 1)};
-
 // we want to execute ClientsOnly on dedicated clients and SP clients too
 if (_channel isEqualTo BI_SEND_TO_CLIENTS_ONLY) then {
     _channel = BI_SEND_TO_ALL;
-    _code = {if (!isDedicated) then {(_this select 0) spawn (_this select 1)}};
+    _parameters = [_parameters, _code];
+    _code = {if (!isDedicated) then {(_this select 0) call (_this select 1)}};
 };
 
-[_parameters, _code] remoteExec ["call", _channel];
+// we want to have this executed in suspendable environment for bwc
+// using remoteExec with a SQF function (i.e. "BIS_fnc_call") will enter scheduled environment
+// using it with a SQF command (i.e. "call") will not! https://community.bistudio.com/wiki/remoteExec
+[_parameters, _code] remoteExec ["BIS_fnc_call", _channel];
 
 nil


### PR DESCRIPTION
`[-2, {sleep 10;systemchat "Boo";sleep 10;systemchat "bies";}, []] call CBA_fnc_globalExecute;`

`sleep` wouldn't work anymore without this after 2.4