### PR TITLE
switch help framework to 'authorS', remove all author[]

### DIFF
--- a/addons/ai/config.cpp
+++ b/addons/ai/config.cpp
@@ -7,7 +7,8 @@ class CfgPatches
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = { "CBA_common" };
         version = VERSION;
-        author[] = {"Rommel"};
+        author = "$STR_CBA_Author";
+        authors[] = {"Rommel"};
         authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };

--- a/addons/arrays/config.cpp
+++ b/addons/arrays/config.cpp
@@ -7,7 +7,8 @@ class CfgPatches
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = { "CBA_common" };
         version = VERSION;
-        author[] = {"Spooner"};
+        author = "$STR_CBA_Author";
+        authors[] = {"Spooner"};
         authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };

--- a/addons/common/config.cpp
+++ b/addons/common/config.cpp
@@ -7,7 +7,8 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"A3_BaseConfig_F"};
         version = VERSION;
-        author[] = {"Spooner","Sickboy","Rocko"};
+        author = "$STR_CBA_Author";
+        authors[] = {"Spooner","Sickboy","Rocko"};
         authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };

--- a/addons/diagnostic/config.cpp
+++ b/addons/diagnostic/config.cpp
@@ -6,7 +6,8 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"CBA_common","CBA_events","3DEN"};
         version = VERSION;
-        author[] = {"Spooner","Sickboy"};
+        author = "$STR_CBA_Author";
+        authors[] = {"Spooner","Sickboy"};
         authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };

--- a/addons/events/config.cpp
+++ b/addons/events/config.cpp
@@ -6,7 +6,8 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"CBA_common"};
         version = VERSION;
-        author[] = {"Spooner","Sickboy","Xeno","commy2"};
+        author = "$STR_CBA_Author";
+        authors[] = {"Spooner","Sickboy","Xeno","commy2"};
         authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };

--- a/addons/hashes/config.cpp
+++ b/addons/hashes/config.cpp
@@ -7,7 +7,8 @@ class CfgPatches
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = { "CBA_common" };
         version = VERSION;
-        author[] = {"Spooner"};
+        author = "$STR_CBA_Author";
+        authors[] = {"Spooner"};
         authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };

--- a/addons/help/config.cpp
+++ b/addons/help/config.cpp
@@ -7,7 +7,8 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_common","cba_hashes","cba_keybinding","A3_UI_F"};
         version = VERSION;
-        author[] = {"alef","Rocko","Sickboy"};
+        author = "$STR_CBA_Author";
+        authors[] = {"alef","Rocko","Sickboy"};
         authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };

--- a/addons/help/fnc_setCreditsLine.sqf
+++ b/addons/help/fnc_setCreditsLine.sqf
@@ -38,7 +38,11 @@ if (CBA_DisableCredits) exitWith {};
 
 // find addon with author
 private _config = configFile >> "CfgPatches";
-private _entry = ("isText (_x >> 'author') && {getText (_x >> 'author') != localize 'STR_A3_Bohemia_Interactive'}" configClasses _config) call (uiNamespace getVariable "BIS_fnc_selectRandom"); //bwc for 1.54 (Linux build)
+private _entry = ("
+    isText (_x >> 'author') &&
+    {getText (_x >> 'author') != localize 'STR_A3_Bohemia_Interactive'} &&
+    {getText (_x >> 'author') != ''}
+" configClasses _config) call (uiNamespace getVariable "BIS_fnc_selectRandom"); //bwc for 1.54 (Linux build)
 
 if (isNil "_entry") exitWith {};
 
@@ -65,11 +69,19 @@ if (isArray (_entry >> "authors")) then {
 // url if any
 private _url = "";
 
-if (isText (_entry >> "authorUrl")) then {
-    _url = getText (_entry >> "authorUrl");
+if (isText (_entry >> "url")) then {
+    _url = getText (_entry >> "url");
 
     if (!CBA_MonochromeCredits) then {
         _url = format ["<t color='#566D7E'>%1</t>", _url];
+    };
+} else {
+    if (isText (_entry >> "authorUrl")) then {
+        _url = getText (_entry >> "authorUrl");
+
+        if (!CBA_MonochromeCredits) then {
+            _url = format ["<t color='#566D7E'>%1</t>", _url];
+        };
     };
 };
 

--- a/addons/help/fnc_setCreditsLine.sqf
+++ b/addons/help/fnc_setCreditsLine.sqf
@@ -38,7 +38,7 @@ if (CBA_DisableCredits) exitWith {};
 
 // find addon with author
 private _config = configFile >> "CfgPatches";
-private _entry = ("isArray (_x >> 'author') && {!(getArray (_x >> 'author') isEqualTo [])}" configClasses _config) call (uiNamespace getVariable "BIS_fnc_selectRandom"); //bwc for 1.54 (Linux build)
+private _entry = ("isText (_x >> 'author') && {getText (_x >> 'author') != localize 'STR_A3_Bohemia_Interactive'}" configClasses _config) call (uiNamespace getVariable "BIS_fnc_selectRandom"); //bwc for 1.54 (Linux build)
 
 if (isNil "_entry") exitWith {};
 
@@ -50,14 +50,17 @@ if (!CBA_MonochromeCredits) then {
 };
 
 // author(s) name
-private _authors = getArray (_entry >> "author");
-private _author = _authors deleteAt 0;
+private _author = getText (_entry >> "author");
 
-{
-    if (_x isEqualType "") then {
-        _author = format ["%1, %2", _author, _x];
-    };
-} forEach _authors;
+if (isArray (_entry >> "authors")) then {
+    private _authors = getArray (_entry >> "authors");
+
+    {
+        if (_x isEqualType "") then {
+            _author = format ["%1, %2", _author, _x];
+        };
+    } forEach _authors;
+};
 
 // url if any
 private _url = "";

--- a/addons/jr/config.cpp
+++ b/addons/jr/config.cpp
@@ -16,7 +16,8 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"A3_Weapons_F","A3_Weapons_F_Mark","CBA_jr_prep"};
         version = VERSION;
-        author[] = {"Robalo"};
+        author = "$STR_CBA_Author";
+        authors[] = {"Robalo"};
         authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
     class asdg_jointrails { //compat

--- a/addons/keybinding/config.cpp
+++ b/addons/keybinding/config.cpp
@@ -7,7 +7,8 @@ class CfgPatches
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = { "CBA_common", "A3_UI_F" };
         version = VERSION;
-        author[] = {"Taosenai"};
+        author = "$STR_CBA_Author";
+        authors[] = {"Taosenai"};
         authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };

--- a/addons/linux/config.cpp
+++ b/addons/linux/config.cpp
@@ -7,7 +7,8 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_common","cba_events","cba_hashes","cba_jr","cba_xeh"};
         version = VERSION;
-        author[] = {"commy2"};
+        author = "$STR_CBA_Author";
+        authors[] = {"commy2"};
         authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };

--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -10,7 +10,8 @@ class CfgPatches {
         requiredAddons[] = {"cba_common", "cba_arrays", "cba_hashes", "cba_strings", "cba_events", "cba_diagnostic", "cba_network", "cba_ai", "cba_vectors", "cba_ui", "cba_ui_helper", "cba_help"};
         versionDesc = "C.B.A.";
         VERSION_CONFIG;
-        author[] = {"CBA Team"};
+        author = "$STR_CBA_Author";
+        authors[] = {};
         authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project name="CBA_A3">
-  <Package name="Main">
-    <Key ID="STR_CBA_Author">
-      <English>CBA-Team</English>
-      <German>CBA-Team</German>
-    </Key>
-  </Package>
+    <Package name="Main">
+        <Key ID="STR_CBA_Author">
+            <English>CBA-Team</English>
+            <German>CBA-Team</German>
+        </Key>
+    </Package>
 </Project>

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project name="CBA_A3">
+  <Package name="Main">
+    <Key ID="STR_CBA_Author">
+      <English>CBA-Team</English>
+      <German>CBA-Team</German>
+    </Key>
+  </Package>
+</Project>

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -2,7 +2,7 @@
 <Project name="CBA_A3">
     <Package name="Main">
         <Key ID="STR_CBA_Author">
-            <English>CBA-Team</English>
+            <English>CBA Team</English>
             <German>CBA-Team</German>
         </Key>
     </Package>

--- a/addons/main_a3/config.cpp
+++ b/addons/main_a3/config.cpp
@@ -9,7 +9,8 @@ class CfgPatches {
             "CBA_Main"
         };
         VERSION_CONFIG;
-        author[] = {"CBA Team"};
+        author = "$STR_CBA_Author";
+        authors[] = {};
         authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };

--- a/addons/network/config.cpp
+++ b/addons/network/config.cpp
@@ -7,7 +7,8 @@ class CfgPatches
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = { "CBA_common", "CBA_events" };
         version = VERSION;
-        author[] = {"Sickboy"};
+        author = "$STR_CBA_Author";
+        authors[] = {"Sickboy"};
         authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };

--- a/addons/strings/config.cpp
+++ b/addons/strings/config.cpp
@@ -7,7 +7,8 @@ class CfgPatches
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = { "CBA_common" };
         version = VERSION;
-        author[] = {"Spooner", "Kronzky"};
+        author = "$STR_CBA_Author";
+        authors[] = {"Spooner", "Kronzky"};
         authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };

--- a/addons/ui/config.cpp
+++ b/addons/ui/config.cpp
@@ -6,7 +6,8 @@ class CfgPatches {
         requiredVersion = 1;
         requiredAddons[] = { "CBA_common", "CBA_arrays" };
         version = VERSION;
-        author[] = {"Dr Eyeball"};
+        author = "$STR_CBA_Author";
+        authors[] = {"Dr Eyeball"};
         authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };

--- a/addons/vectors/config.cpp
+++ b/addons/vectors/config.cpp
@@ -7,7 +7,8 @@ class CfgPatches
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = { "CBA_common" };
         version = VERSION;
-        author[] = {"Vigilante"};
+        author = "$STR_CBA_Author";
+        authors[] = {"Vigilante"};
         authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };

--- a/addons/versioning/config.cpp
+++ b/addons/versioning/config.cpp
@@ -7,7 +7,8 @@ class CfgPatches
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = { "CBA_common", "CBA_strings", "CBA_hashes", "CBA_diagnostic", "CBA_events", "CBA_network" };
         version = VERSION;
-        author[] = {"Sickboy"};
+        author = "$STR_CBA_Author";
+        authors[] = {"Sickboy"};
         authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };

--- a/addons/xeh/config.cpp
+++ b/addons/xeh/config.cpp
@@ -15,10 +15,10 @@ class CfgPatches {
     };
 
     // Backwards compatibility
-    class cba_xeh_a3: ADDON {authors[] = {};};
-    class Extended_EventHandlers: ADDON {authors[] = {};};
-    class CBA_Extended_EventHandlers: ADDON {authors[] = {};};
-    class cba_ee: ADDON {authors[] = {};};
+    class cba_xeh_a3: ADDON { author = ""; };
+    class Extended_EventHandlers: ADDON { author = ""; };
+    class CBA_Extended_EventHandlers: ADDON { author = ""; };
+    class cba_ee: ADDON { author = ""; };
 };
 
 #include "CfgEventHandlers.hpp"

--- a/addons/xeh/config.cpp
+++ b/addons/xeh/config.cpp
@@ -9,15 +9,16 @@ class CfgPatches {
         version = "4.0.0"; // Due to older mod versions requiring > 3,3,3 etc
         versionStr = "4.0.0";
         versionAr[] = {4,0,0};
-        author[] = {"CBA Team","Solus","Killswitch","commy2"};
+        author = "$STR_CBA_Author";
+        authors[] = {"Solus","Killswitch","commy2"};
         authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 
     // Backwards compatibility
-    class cba_xeh_a3: ADDON {author[] = {};};
-    class Extended_EventHandlers: ADDON {author[] = {};};
-    class CBA_Extended_EventHandlers: ADDON {author[] = {};};
-    class cba_ee: ADDON {author[] = {};};
+    class cba_xeh_a3: ADDON {authors[] = {};};
+    class Extended_EventHandlers: ADDON {authors[] = {};};
+    class CBA_Extended_EventHandlers: ADDON {authors[] = {};};
+    class cba_ee: ADDON {authors[] = {};};
 };
 
 #include "CfgEventHandlers.hpp"


### PR DESCRIPTION
- changes CBA Help framework to use new BI `author` entry. (while filtering out all BI classes)
- to keep functionality of having multiple authors per PBO, add optional `authors[]` entry.
- add standardized `STR_CBA_Author` string as author to all CBA PBOs.

This will __not__ fix the `No Entry blah/author` error pop ups of other mods. Either BI fixes the game or every mod author has to adjust.