### PR TITLE
fix XEH preInit not executed after returning from 3den

### DIFF
--- a/addons/xeh/CfgEventHandlers.hpp
+++ b/addons/xeh/CfgEventHandlers.hpp
@@ -80,9 +80,8 @@ class Extended_Reloaded_EventHandlers {};
 
 // display xeh
 class Extended_DisplayLoad_EventHandlers {
-    // fix for preInit = 1 functions not being executed when entering 3den from main menu
     class Display3DEN {
-        ADDON = "[] call CBA_fnc_preInit;";
+        ADDON = QUOTE(call COMPILE_FILE(XEH_3DENDisplayLoad));
     };
 };
 class Extended_DisplayUnload_EventHandlers {};

--- a/addons/xeh/XEH_3DENDisplayLoad.sqf
+++ b/addons/xeh/XEH_3DENDisplayLoad.sqf
@@ -1,0 +1,7 @@
+#include "script_component.hpp"
+
+// fix for preInit = 1 functions not being executed when entering 3den from main menu
+[] call CBA_fnc_preInit;
+
+// since 1.60, preInit = 1 functions aren't executed when returning from a preview either ...
+add3DENEventHandler ["OnMissionPreviewEnd", {[] call CBA_fnc_preInit}];


### PR DESCRIPTION
closes: #349

this must've been broken by the hotfix yesterday as this worked fine before, even with 1.60

there is a failsafe in `fnc_preInit.sqf`, so even if BI reverts their change, we won't have it executed twice or something.