### PR TITLE
Add meta.cpp file

### DIFF
--- a/meta.cpp
+++ b/meta.cpp
@@ -1,0 +1,2 @@
+protocol = 1;
+publishedid = 450814997;

--- a/tools/make.py
+++ b/tools/make.py
@@ -73,7 +73,7 @@ dssignfile = ""
 prefix = "cba"
 pbo_name_prefix = "cba_"
 signature_blacklist = []
-importantFiles = ["mod.cpp", "README.md", "LICENSE.md", "logo_cba_ca.paa"]
+importantFiles = ["mod.cpp", "meta.cpp", "README.md", "LICENSE.md", "logo_cba_ca.paa"]
 versionFiles = ["mod.cpp"]
 
 ###############################################################################


### PR DESCRIPTION
Metadata file used by the server browser in the A3 game launcher
to pull mods used on a server directly from the Steam Workshop.
This changeset was originally submitted by bux578 but went missing
along the way.