### PR TITLE
Add override capability to fnc_taskAttack

### DIFF
--- a/addons/ai/fnc_taskAttack.sqf
+++ b/addons/ai/fnc_taskAttack.sqf
@@ -31,6 +31,7 @@ params ["_group","_position", ["_radius",0]];
 _group = _group call CBA_fnc_getGroup;
 if !(local _group) exitWith {}; // Don't create waypoints on each machine
 
-[_group] call CBA_fnc_clearWaypoints; // Clear existing waypoints
+// Override any previously set waypoints
+[_group] call CBA_fnc_clearWaypoints;
 
 [_group, _position, _radius, "SAD", "COMBAT", "RED"] call CBA_fnc_addWaypoint;

--- a/addons/ai/fnc_taskAttack.sqf
+++ b/addons/ai/fnc_taskAttack.sqf
@@ -31,4 +31,6 @@ params ["_group","_position", ["_radius",0]];
 _group = _group call CBA_fnc_getGroup;
 if !(local _group) exitWith {}; // Don't create waypoints on each machine
 
+[_group] call CBA_fnc_clearWaypoints; // Clear existing waypoints
+
 [_group, _position, _radius, "SAD", "COMBAT", "RED"] call CBA_fnc_addWaypoint;

--- a/addons/ai/fnc_taskAttack.sqf
+++ b/addons/ai/fnc_taskAttack.sqf
@@ -10,6 +10,7 @@ Parameters:
 
 Optional:
     - Search Radius (Scalar)
+    - Remove Assigned Waypoints (Bool)
 
 Example:
     (begin example)
@@ -26,12 +27,14 @@ Author:
 
 #include "script_component.hpp"
 
-params ["_group","_position", ["_radius",0]];
+params ["_group","_position", ["_radius",0], ["_override",false]];
 
 _group = _group call CBA_fnc_getGroup;
 if !(local _group) exitWith {}; // Don't create waypoints on each machine
 
-// Override any previously set waypoints
-[_group] call CBA_fnc_clearWaypoints;
+// Allow TaskAttack to override other set waypoints
+if (_override) then {
+    [_group] call CBA_fnc_clearWaypoints;
+};
 
 [_group, _position, _radius, "SAD", "COMBAT", "RED"] call CBA_fnc_addWaypoint;


### PR DESCRIPTION
When playing around with the attack, defend, and patrol functions I noticed that if the group was already set to either patrol or defend that their behavior would change but not move or change course. Probably not needed often, but still nice to have the capability of redirecting the group.