### PR TITLE
re-add XEH class to taru pods

### DIFF
--- a/addons/xeh/CfgVehicles.hpp
+++ b/addons/xeh/CfgVehicles.hpp
@@ -142,4 +142,98 @@ class CfgVehicles {
         scope = 1;
         displayName = "XEH Initialization Logic";
     };
+
+    // fix taru pods, broken since v1.60
+    class Pod_Heli_Transport_04_crewed_base_F: StaticWeapon {
+        class EventHandlers;
+    };
+
+    class Slingload_base_F;
+    class Pod_Heli_Transport_04_base_F: Slingload_base_F {
+        class EventHandlers;
+
+    };
+    class Land_Pod_Heli_Transport_04_ammo_F: Pod_Heli_Transport_04_base_F {
+        class EventHandlers: EventHandlers {
+            class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
+        };
+    };
+
+    class Land_Pod_Heli_Transport_04_bench_F: Pod_Heli_Transport_04_crewed_base_F {
+        class EventHandlers: EventHandlers {
+            class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
+        };
+    };
+
+    class Land_Pod_Heli_Transport_04_box_F: Pod_Heli_Transport_04_base_F {
+        class EventHandlers: EventHandlers {
+            class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
+        };
+    };
+
+    class Land_Pod_Heli_Transport_04_covered_F: Pod_Heli_Transport_04_crewed_base_F {
+        class EventHandlers: EventHandlers {
+            class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
+        };
+    };
+
+    class Land_Pod_Heli_Transport_04_fuel_F: Pod_Heli_Transport_04_base_F {
+        class EventHandlers: EventHandlers {
+            class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
+        };
+    };
+
+    class Land_Pod_Heli_Transport_04_medevac_F: Pod_Heli_Transport_04_crewed_base_F {
+        class EventHandlers: EventHandlers {
+            class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
+        };
+    };
+
+    class Land_Pod_Heli_Transport_04_repair_F: Pod_Heli_Transport_04_base_F {
+        class EventHandlers: EventHandlers {
+            class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
+        };
+    };
+
+    class Land_Pod_Heli_Transport_04_ammo_black_F: Land_Pod_Heli_Transport_04_ammo_F {
+        class EventHandlers: EventHandlers {
+            class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
+        };
+    };
+
+    class Land_Pod_Heli_Transport_04_bench_black_F: Land_Pod_Heli_Transport_04_bench_F {
+        class EventHandlers: EventHandlers {
+            class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
+        };
+    };
+
+    class Land_Pod_Heli_Transport_04_box_black_F: Land_Pod_Heli_Transport_04_box_F {
+        class EventHandlers: EventHandlers {
+            class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
+        };
+    };
+
+    class Land_Pod_Heli_Transport_04_covered_black_F: Land_Pod_Heli_Transport_04_covered_F {
+        class EventHandlers: EventHandlers {
+            class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
+        };
+    };
+
+    class Land_Pod_Heli_Transport_04_fuel_black_F: Land_Pod_Heli_Transport_04_fuel_F {
+        class EventHandlers: EventHandlers {
+            class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
+        };
+    };
+
+    class Land_Pod_Heli_Transport_04_medevac_black_F: Land_Pod_Heli_Transport_04_medevac_F {
+        class EventHandlers: EventHandlers {
+            class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
+        };
+    };
+
+    class Land_Pod_Heli_Transport_04_repair_black_F: Land_Pod_Heli_Transport_04_repair_F {
+        class EventHandlers: EventHandlers {
+            class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
+        };
+    };
 };


### PR DESCRIPTION
fixes #355 

I have no idea why this happens. This seems to be a bug in EventHandler subclasses thingy internally. Seems like they are no longer accepted if inherited for specific classes.