### PR TITLE
Update fnc_taskPatrol func header

### DIFF
--- a/addons/ai/fnc_taskPatrol.sqf
+++ b/addons/ai/fnc_taskPatrol.sqf
@@ -6,10 +6,10 @@ Description:
 
 Parameters:
     - Group (Group or Object)
+
+Optional:
     - Position (XYZ, Object, Location or Group)
     - Radius (Scalar)
-
-Optional:    
     - Waypoint Count (Scalar)
     - Waypoint Type (String)
     - Behaviour (String)
@@ -47,6 +47,11 @@ _position = _position call CBA_fnc_getPos;
 [_group] call CBA_fnc_clearWaypoints;
 
 private _this =+ _this;
+switch (count _this) do {
+    case 1 : {_this append [_position, _radius]};
+    case 2 : {_this pushback _radius};
+    default {};
+};
 if (count _this > 3) then {
     _this deleteAt 3;
 };

--- a/addons/ai/fnc_taskPatrol.sqf
+++ b/addons/ai/fnc_taskPatrol.sqf
@@ -21,7 +21,7 @@ Optional:
 
 Example:
     (begin example)
-    [this, getmarkerpos "objective1"] call CBA_fnc_taskPatrol
+    [this, getmarkerpos "objective1", 50] call CBA_fnc_taskPatrol
     [this, this, 300, 7, "MOVE", "AWARE", "YELLOW", "FULL", "STAG COLUMN", "this call CBA_fnc_searchNearby", [3,6,9]] call CBA_fnc_taskPatrol;
     (end)
 

--- a/addons/ai/fnc_taskPatrol.sqf
+++ b/addons/ai/fnc_taskPatrol.sqf
@@ -6,10 +6,10 @@ Description:
 
 Parameters:
     - Group (Group or Object)
-
-Optional:
     - Position (XYZ, Object, Location or Group)
     - Radius (Scalar)
+
+Optional:    
     - Waypoint Count (Scalar)
     - Waypoint Type (String)
     - Behaviour (String)


### PR DESCRIPTION
I noticed that an error is thrown from fnc_addWaypoint if the position and radius wasn't passed so they would not be optional.

Also, could someone explain to me the point of line 49: private _this += _this;
I've been trying to understand the point of it, but I've removed it and the function works the same with or without it from what I can tell. Is it left over code by chance?