### PR TITLE
make 'CBA_fnc_players' not return headless clients

### DIFF
--- a/addons/common/CfgFunctions.hpp
+++ b/addons/common/CfgFunctions.hpp
@@ -37,6 +37,7 @@ class CfgFunctions {
             F_FILEPATH(selectWeapon);
             F_FILEPATH(switchPlayer);
             F_FILEPATH(currentUnit);
+            F_FILEPATH(players);
         };
 
         class Vehicles {

--- a/addons/common/backwards_comp.sqf
+++ b/addons/common/backwards_comp.sqf
@@ -5,11 +5,6 @@ CBA_fnc_createCenter = {
     _side
 };
 
-CBA_fnc_players = {
-    WARNING('Deprecated function used: CBA_fnc_players (new: allPlayers)');
-    allPlayers
-};
-
 CBA_fnc_locked = {
     WARNING('Deprecated function used: CBA_fnc_locked (new: locked)');
     locked _this > 1

--- a/addons/common/fnc_players.sqf
+++ b/addons/common/fnc_players.sqf
@@ -21,4 +21,4 @@ Author:
 #include "script_component.hpp"
 SCRIPT(players);
 
-(allUnits + allDead) select {isPlayer _x && {!(_x isKindOf "HeadlessClient_F")}}
+[allUnits + allDead, {isPlayer _x && {!(_x isKindOf "HeadlessClient_F")}}] call BIS_fnc_conditionalSelect

--- a/addons/common/fnc_players.sqf
+++ b/addons/common/fnc_players.sqf
@@ -1,0 +1,24 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_players
+
+Description:
+    Reports all (human) player objects. Does not include headless client entities.
+
+Parameters:
+    None
+
+Returns:
+    List of all player objects <ARRAY>
+
+Examples:
+    (begin example)
+        [] call CBA_fnc_players
+    (end)
+
+Author:
+    commy2
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+SCRIPT(players);
+
+(allUnits + allDead) select {isPlayer _x && {!(_x isKindOf "HeadlessClient_F")}}


### PR DESCRIPTION
-closes #353

`allPlayers` and `BIS_fnc_listPlayers` report players and headless clients. This function does not.
Can't use `allPlayers`, because apparently it reports not all units in a local hosted MP game.