### PR TITLE
Add 'name' value to all CfgPatches

### DIFF
--- a/addons/ai/config.cpp
+++ b/addons/ai/config.cpp
@@ -1,18 +1,16 @@
 #include "script_component.hpp"
-class CfgPatches
-{
-    class ADDON
-    {
+
+class CfgPatches {
+    class ADDON {
+        author = "$STR_CBA_Author";
+        name = CSTRING(component);
+        url = "$STR_CBA_URL";
         units[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = { "CBA_common" };
+        requiredAddons[] = {"CBA_common"};
         version = VERSION;
-        author = "$STR_CBA_Author";
         authors[] = {"Rommel"};
-        authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };
 
 #include "CfgFunctions.hpp"
-
-

--- a/addons/ai/stringtable.xml
+++ b/addons/ai/stringtable.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project name="CBA_A3">
+    <Package name="AI">
+        <Key ID="STR_CBA_AI_Component">
+            <English>Community Base Addons - Artificial Intelligence</English>
+        </Key>
+    </Package>
+</Project>

--- a/addons/arrays/config.cpp
+++ b/addons/arrays/config.cpp
@@ -1,18 +1,16 @@
 #include "script_component.hpp"
-class CfgPatches
-{
-    class ADDON
-    {
+
+class CfgPatches {
+    class ADDON {
+        author = "$STR_CBA_Author";
+        name = CSTRING(component);
+        url = "$STR_CBA_URL";
         units[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = { "CBA_common" };
+        requiredAddons[] = {"CBA_common"};
         version = VERSION;
-        author = "$STR_CBA_Author";
         authors[] = {"Spooner"};
-        authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };
 
 #include "CfgFunctions.hpp"
-
-

--- a/addons/arrays/stringtable.xml
+++ b/addons/arrays/stringtable.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project name="CBA_A3">
+    <Package name="Arrays">
+        <Key ID="STR_CBA_Arrays_Component">
+            <English>Community Base Addons - Arrays</English>
+        </Key>
+    </Package>
+</Project>

--- a/addons/common/config.cpp
+++ b/addons/common/config.cpp
@@ -2,14 +2,15 @@
 
 class CfgPatches {
     class ADDON {
+        author = "$STR_CBA_Author";
+        name = CSTRING(component);
+        url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"A3_BaseConfig_F"};
         version = VERSION;
-        author = "$STR_CBA_Author";
         authors[] = {"Spooner","Sickboy","Rocko"};
-        authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };
 

--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -1,4 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<Project name="CBA_A3">
+    <Package name="Common">
+        <Key ID="STR_CBA_Common_Component">
+            <English>Community Base Addons - Common Component</English>
+        </Key>
+    </Package>
+</Project>
+
 <Project name="Arma2">
 <Package name="CBA">
 <Container name="STR_DN">

--- a/addons/diagnostic/config.cpp
+++ b/addons/diagnostic/config.cpp
@@ -2,13 +2,14 @@
 
 class CfgPatches {
     class ADDON {
+        author = "$STR_CBA_Author";
+        name = CSTRING(component);
+        url = "$STR_CBA_URL";
         units[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"CBA_common","CBA_events","3DEN"};
         version = VERSION;
-        author = "$STR_CBA_Author";
         authors[] = {"Spooner","Sickboy"};
-        authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };
 

--- a/addons/diagnostic/stringtable.xml
+++ b/addons/diagnostic/stringtable.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project name="CBA_A3">
+    <Package name="Diagnostics">
+        <Key ID="STR_CBA_Diagnostics_Component">
+            <English>Community Base Addons - Diagnostics</English>
+        </Key>
+    </Package>
+</Project>

--- a/addons/diagnostic/xeh/config.cpp
+++ b/addons/diagnostic/xeh/config.cpp
@@ -2,6 +2,9 @@
 #ifndef EH_DEBUG_ENABLED
     class CfgPatches {
         class cba_diagnostics_xeh_disabled {
+            author = "$STR_CBA_Author";
+            name = "$STR_CBA_Optional_Component";
+            url = "$STR_CBA_URL";
             units[] = {};
             weapons[] = {};
             worlds[] = {};
@@ -14,6 +17,9 @@
     #include "script_component.hpp"
     class CfgPatches {
         class ADDON {
+            author = "$STR_CBA_Author";
+            name = "$STR_CBA_Optional_Component";
+            url = "$STR_CBA_URL";
             units[] = {};
             weapons[] = {};
             worlds[] = {};

--- a/addons/events/config.cpp
+++ b/addons/events/config.cpp
@@ -2,13 +2,14 @@
 
 class CfgPatches {
     class ADDON {
+        author = "$STR_CBA_Author";
+        name = CSTRING(component);
+        url = "$STR_CBA_URL";
         units[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"CBA_common"};
         version = VERSION;
-        author = "$STR_CBA_Author";
         authors[] = {"Spooner","Sickboy","Xeno","commy2"};
-        authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };
 

--- a/addons/events/stringtable.xml
+++ b/addons/events/stringtable.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project name="CBA_A3">
+    <Package name="Events">
+        <Key ID="STR_CBA_Events_Component">
+            <English>Community Base Addons - Events</English>
+        </Key>
+    </Package>
+</Project>

--- a/addons/hashes/config.cpp
+++ b/addons/hashes/config.cpp
@@ -1,18 +1,16 @@
 #include "script_component.hpp"
-class CfgPatches
-{
-    class ADDON
-    {
+
+class CfgPatches {
+    class ADDON {
+        author = "$STR_CBA_Author";
+        name = CSTRING(component);
+        url = "$STR_CBA_URL";
         units[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = { "CBA_common" };
+        requiredAddons[] = {"CBA_common"};
         version = VERSION;
-        author = "$STR_CBA_Author";
         authors[] = {"Spooner"};
-        authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };
 
 #include "CfgFunctions.hpp"
-
-

--- a/addons/hashes/stringtable.xml
+++ b/addons/hashes/stringtable.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project name="CBA_A3">
+    <Package name="Hashes">
+        <Key ID="STR_CBA_Hashes_Component">
+            <English>Community Base Addons - Hashes</English>
+        </Key>
+    </Package>
+</Project>

--- a/addons/help/CfgRscStd.hpp
+++ b/addons/help/CfgRscStd.hpp
@@ -2,14 +2,14 @@
 class RscButton;
 class CBA_Credits_Ver_Btn: RscButton {
     idc = -1; //template
-    colorText[] = {1, 1, 1, 0};
-    colorDisabled[] = {1, 1, 1, 0};
-    colorBackground[] = {1, 1, 1, 0};
-    colorBackgroundDisabled[] = {1, 1, 1, 0};
-    colorBackgroundActive[] = {1, 1, 1, 0};
-    colorShadow[] = {1, 1, 1, 0};
-    colorFocused[] = {1, 1, 1, 0};
-    soundClick[] = {"", 0.1, 1};
+    colorText[] = {1,1,1,0};
+    colorDisabled[] = {1,1,1,0};
+    colorBackground[] = {1,1,1,0};
+    colorBackgroundDisabled[] = {1,1,1,0};
+    colorBackgroundActive[] = {1,1,1,0};
+    colorShadow[] = {1,1,1,0};
+    colorFocused[] = {1,1,1,0};
+    soundClick[] = {"",0.1,1};
     x = -1;
     y = -1;
     w = 0;
@@ -20,7 +20,7 @@ class CBA_Credits_Ver_Btn: RscButton {
 class RscStructuredText;
 class CBA_Credits_Cont: RscStructuredText {
     idc = -1; //template
-    colorBackground[] = { 0, 0, 0, 0 };
+    colorBackground[] = {0,0,0,0};
     __SX(25);
     __SY(23);
     __SW(30);

--- a/addons/help/config.cpp
+++ b/addons/help/config.cpp
@@ -2,14 +2,15 @@
 
 class CfgPatches {
     class ADDON {
+        author = "$STR_CBA_Author";
+        name = CSTRING(component);
+        url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_common","cba_hashes","cba_keybinding","A3_UI_F"};
         version = VERSION;
-        author = "$STR_CBA_Author";
         authors[] = {"alef","Rocko","Sickboy"};
-        authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };
 

--- a/addons/help/fnc_setCreditsLine.sqf
+++ b/addons/help/fnc_setCreditsLine.sqf
@@ -49,6 +49,10 @@ if (isNil "_entry") exitWith {};
 // addon name
 private _name = configName _entry;
 
+if (isText (_entry >> "name")) then {
+    _name = getText (_entry >> "name");
+};
+
 if (!CBA_MonochromeCredits) then {
     _name = format ["<t color='#99cccc'>%1</t>", _name];
 };

--- a/addons/help/stringtable.xml
+++ b/addons/help/stringtable.xml
@@ -1,62 +1,64 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Project name="Arma3">
-<Package name="CBA">
-<Container name="STR_DN">
-<Key ID="STR_DN_CBA_HELP_KEYS">
-    <English>Keybindings</English>
-    <German>Tastendruckzuweisung</German>
-    <Spanish>Keybindings</Spanish>
-    <Czech>Keybindings</Czech>
-    <Russian>Keybindings</Russian>
-    <Italian>Keybindings</Italian>
-    <Polish>Klawisze</Polish>
-    <French>Keybindings</French>
-    <Hungarian>Keybindings</Hungarian>
-</Key>
-<Key ID="STR_DN_CBA_WEBSITE">
-    <English>Bugtracker</English>
-    <German>Bugtracker</German>
-    <Spanish>Bugtracker</Spanish>
-    <Czech>Bugtracker</Czech>
-    <Russian>Bugtracker</Russian>
-    <Italian>Bugtracker</Italian>
-    <Polish>Zgłaszanie błędów</Polish>
-    <French>Bugtracker</French>
-    <Hungarian>Bugtracker</Hungarian>
-</Key>
-<Key ID="STR_DN_CBA_WEBSITE_WIKI">
-    <English>Wiki (Documentation)</English>
-    <German>Wiki (Documentation)</German>
-    <Spanish>Wiki (Documentation)</Spanish>
-    <Czech>Wiki (Documentation)</Czech>
-    <Russian>Wiki (Documentation)</Russian>
-    <Italian>Wiki (Documentation)</Italian>
-    <Polish>Wiki (dokumentacja)</Polish>
-    <French>Wiki (Documentation)</French>
-    <Hungarian>Wiki (Documentation)</Hungarian>
-</Key>
-<Key ID="STR_DN_CBA_CREDITS">
-    <English>Credits</English>
-    <German>Credits</German>
-    <Spanish>Credits</Spanish>
-    <Czech>Credits</Czech>
-    <Russian>Credits</Russian>
-    <Italian>Credits</Italian>
-    <Polish>Twórcy</Polish>
-    <French>Credits</French>
-    <Hungarian>Credits</Hungarian>
-</Key>
-<Key ID="STR_DN_CBA_CREDITS_ADDONS">
-    <English>Credits - Addons</English>
-    <German>Credits - Addons</German>
-    <Spanish>Credits - Addons</Spanish>
-    <Czech>Credits - Addons</Czech>
-    <Russian>Credits - Addons</Russian>
-    <Italian>Credits - Addons</Italian>
-    <Polish>Twórcy - Addons</Polish>
-    <French>Credits - Addons</French>
-    <Hungarian>Credits - Addons</Hungarian>
-</Key>
-</Container>
-</Package>
+<Project name="CBA_A3">
+    <Package name="Help">
+        <Key ID="STR_CBA_Help_Component">
+            <English>Community Base Addons - Help</English>
+        </Key>
+
+        <Key ID="STR_DN_CBA_HELP_KEYS">
+            <English>Keybindings</English>
+            <German>Tastendruckzuweisung</German>
+            <Spanish>Keybindings</Spanish>
+            <Czech>Keybindings</Czech>
+            <Russian>Keybindings</Russian>
+            <Italian>Keybindings</Italian>
+            <Polish>Klawisze</Polish>
+            <French>Keybindings</French>
+            <Hungarian>Keybindings</Hungarian>
+        </Key>
+        <Key ID="STR_DN_CBA_WEBSITE">
+            <English>Bugtracker</English>
+            <German>Bugtracker</German>
+            <Spanish>Bugtracker</Spanish>
+            <Czech>Bugtracker</Czech>
+            <Russian>Bugtracker</Russian>
+            <Italian>Bugtracker</Italian>
+            <Polish>Zgłaszanie błędów</Polish>
+            <French>Bugtracker</French>
+            <Hungarian>Bugtracker</Hungarian>
+        </Key>
+        <Key ID="STR_DN_CBA_WEBSITE_WIKI">
+            <English>Wiki (Documentation)</English>
+            <German>Wiki (Documentation)</German>
+            <Spanish>Wiki (Documentation)</Spanish>
+            <Czech>Wiki (Documentation)</Czech>
+            <Russian>Wiki (Documentation)</Russian>
+            <Italian>Wiki (Documentation)</Italian>
+            <Polish>Wiki (dokumentacja)</Polish>
+            <French>Wiki (Documentation)</French>
+            <Hungarian>Wiki (Documentation)</Hungarian>
+        </Key>
+        <Key ID="STR_DN_CBA_CREDITS">
+            <English>Credits</English>
+            <German>Credits</German>
+            <Spanish>Credits</Spanish>
+            <Czech>Credits</Czech>
+            <Russian>Credits</Russian>
+            <Italian>Credits</Italian>
+            <Polish>Twórcy</Polish>
+            <French>Credits</French>
+            <Hungarian>Credits</Hungarian>
+        </Key>
+        <Key ID="STR_DN_CBA_CREDITS_ADDONS">
+            <English>Credits - Addons</English>
+            <German>Credits - Addons</German>
+            <Spanish>Credits - Addons</Spanish>
+            <Czech>Credits - Addons</Czech>
+            <Russian>Credits - Addons</Russian>
+            <Italian>Credits - Addons</Italian>
+            <Polish>Twórcy - Addons</Polish>
+            <French>Credits - Addons</French>
+            <Hungarian>Credits - Addons</Hungarian>
+        </Key>
+    </Package>
 </Project>

--- a/addons/jr/config.cpp
+++ b/addons/jr/config.cpp
@@ -11,14 +11,15 @@
 
 class CfgPatches {
     class ADDON {
+        author = "$STR_CBA_Author";
+        name = CSTRING(component);
+        url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"A3_Weapons_F","A3_Weapons_F_Mark","CBA_jr_prep"};
         version = VERSION;
-        author = "$STR_CBA_Author";
         authors[] = {"Robalo"};
-        authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
     class asdg_jointrails { //compat
         units[] = {};

--- a/addons/jr/stringtable.xml
+++ b/addons/jr/stringtable.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project name="CBA_A3">
+    <Package name="JR">
+        <Key ID="STR_CBA_JR_Component">
+            <English>Community Base Addons - Joint Rails</English>
+        </Key>
+    </Package>
+</Project>

--- a/addons/jr_prep/config.cpp
+++ b/addons/jr_prep/config.cpp
@@ -2,19 +2,19 @@
 
 class CfgPatches {
     class ADDON {
+        author = "$STR_CBA_Author";
+        name = ECSTRING(jr,component);
+        url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"A3_Weapons_F","A3_Weapons_F_Mark"};
         version = VERSION;
-        authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };
 
 class CfgWeapons {
-
     class Rifle_Base_F;
-    
     class Rifle_Long_Base_F : Rifle_Base_F {
         class WeaponSlotsInfo;
     };
@@ -115,5 +115,4 @@ class CfgWeapons {
             delete MuzzleSlot;
         };
     };
-
 };

--- a/addons/keybinding/config.cpp
+++ b/addons/keybinding/config.cpp
@@ -1,15 +1,15 @@
 #include "script_component.hpp"
-class CfgPatches
-{
-    class ADDON
-    {
+
+class CfgPatches {
+    class ADDON {
+        author = "$STR_CBA_Author";
+        name = CSTRING(component);
+        url = "$STR_CBA_URL";
         units[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = { "CBA_common", "A3_UI_F" };
+        requiredAddons[] = {"CBA_common", "A3_UI_F"};
         version = VERSION;
-        author = "$STR_CBA_Author";
         authors[] = {"Taosenai"};
-        authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };
 
@@ -17,5 +17,3 @@ class CfgPatches
 #include "CfgFunctions.hpp"
 
 #include "gui\gui.hpp"
-
-

--- a/addons/keybinding/stringtable.xml
+++ b/addons/keybinding/stringtable.xml
@@ -1,23 +1,28 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package name="CBA">
-    <Key ID="STR_cba_keybinding_configureAddons">
-        <English>Configure Addons</English>
-        <Polish>Konfiguracja addonów</Polish>
-    </Key>
-    <Key ID="STR_cba_keybinding_configureBase">
-        <English>Configure Base</English>
-        <Polish>Konfiguracja bazy</Polish>
-    </Key>
-    <Key ID="STR_cba_keybinding_unkownKey">
-        <English>Unknown Code %1</English>
-        <Polish>Nieznany klawisz %1</Polish>
-    </Key>
-    <Key ID="STR_cba_keybinding_canNotEdit">
-        <English>You must load an intro/world/mission to view/change.</English>
-        <Polish>Musisz wczytać intro/świat/misję by móc zmieniać/podglądać klawisze.</Polish>
-    </Key>
-    <Key ID="STR_cba_keybinding_doubleClickToStart">
-        <English>Double click any action to change its binding</English>
-        <Polish>Naciśnij dwukrotnie na daną akcję aby zmienić jej klawisz</Polish>
-    </Key>
-</Package>
+<Project name="CBA_A3">
+    <Package name="Main">
+        <Key ID="STR_CBA_Keybinding_Component">
+            <English>Community Base Addons - Keybinding</English>
+        </Key>
+        <Key ID="STR_cba_keybinding_configureAddons">
+            <English>Configure Addons</English>
+            <Polish>Konfiguracja addonów</Polish>
+        </Key>
+        <Key ID="STR_cba_keybinding_configureBase">
+            <English>Configure Base</English>
+            <Polish>Konfiguracja bazy</Polish>
+        </Key>
+        <Key ID="STR_cba_keybinding_unkownKey">
+            <English>Unknown Code %1</English>
+            <Polish>Nieznany klawisz %1</Polish>
+        </Key>
+        <Key ID="STR_cba_keybinding_canNotEdit">
+            <English>You must load an intro/world/mission to view/change.</English>
+            <Polish>Musisz wczytać intro/świat/misję by móc zmieniać/podglądać klawisze.</Polish>
+        </Key>
+        <Key ID="STR_cba_keybinding_doubleClickToStart">
+            <English>Double click any action to change its binding</English>
+            <Polish>Naciśnij dwukrotnie na daną akcję aby zmienić jej klawisz</Polish>
+        </Key>
+    </Package>
+</Project>

--- a/addons/linux/config.cpp
+++ b/addons/linux/config.cpp
@@ -2,14 +2,15 @@
 
 class CfgPatches {
     class ADDON {
+        author = "$STR_CBA_Author";
+        name = ECSTRING(Optional,Component);
+        url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_common","cba_events","cba_hashes","cba_jr","cba_xeh"};
         version = VERSION;
-        author = "$STR_CBA_Author";
         authors[] = {"commy2"};
-        authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };
 

--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -2,7 +2,10 @@
 
 // Simply a package which requires other addons.
 class CfgPatches {
-    class ADDON    {
+    class ADDON {
+        author = "$STR_CBA_Author";
+        name = CSTRING(component);
+        url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
@@ -10,9 +13,7 @@ class CfgPatches {
         requiredAddons[] = {"cba_common", "cba_arrays", "cba_hashes", "cba_strings", "cba_events", "cba_diagnostic", "cba_network", "cba_ai", "cba_vectors", "cba_ui", "cba_ui_helper", "cba_help"};
         versionDesc = "C.B.A.";
         VERSION_CONFIG;
-        author = "$STR_CBA_Author";
         authors[] = {};
-        authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };
 

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -5,5 +5,14 @@
             <English>CBA Team</English>
             <German>CBA-Team</German>
         </Key>
+        <Key ID="STR_CBA_URL">
+            <English>https://www.github.com/CBATeam/CBA_A3</English>
+        </Key>
+        <Key ID="STR_CBA_Main_Component">
+            <English>Community Base Addons - Main Component</English>
+        </Key>
+        <Key ID="STR_CBA_Optional_Component">
+            <English>Community Base Addons - Optional Component</English>
+        </Key>
     </Package>
 </Project>

--- a/addons/main_a3/config.cpp
+++ b/addons/main_a3/config.cpp
@@ -2,16 +2,15 @@
 
 class CfgPatches {
     class ADDON {
+        author = "$STR_CBA_Author";
+        name = ECSTRING(main,component);
+        url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {
-            "CBA_Main"
-        };
+        requiredAddons[] = {"CBA_Main"};
         VERSION_CONFIG;
-        author = "$STR_CBA_Author";
         authors[] = {};
-        authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };
 

--- a/addons/network/config.cpp
+++ b/addons/network/config.cpp
@@ -1,17 +1,18 @@
 #include "script_component.hpp"
-class CfgPatches
-{
-    class ADDON
-    {
+
+class CfgPatches {
+    class ADDON {
+        author = "$STR_CBA_Author";
+        name = CSTRING(component);
+        url = "$STR_CBA_URL";
         units[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = { "CBA_common", "CBA_events" };
         version = VERSION;
-        author = "$STR_CBA_Author";
         authors[] = {"Sickboy"};
-        authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };
+
 class CfgSettings {
     class CBA {
         class COMPONENT {
@@ -19,5 +20,6 @@ class CfgSettings {
         };
     };
 };
+
 #include "CfgEventHandlers.hpp"
 #include "CfgFunctions.hpp"

--- a/addons/network/stringtable.xml
+++ b/addons/network/stringtable.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project name="CBA_A3">
+    <Package name="Network">
+        <Key ID="STR_CBA_Network_Component">
+            <English>Community Base Addons - Network</English>
+        </Key>
+    </Package>
+</Project>

--- a/addons/strings/config.cpp
+++ b/addons/strings/config.cpp
@@ -1,18 +1,16 @@
 #include "script_component.hpp"
-class CfgPatches
-{
-    class ADDON
-    {
+
+class CfgPatches {
+    class ADDON {
+        author = "$STR_CBA_Author";
+        name = CSTRING(component);
+        url = "$STR_CBA_URL";
         units[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = { "CBA_common" };
         version = VERSION;
-        author = "$STR_CBA_Author";
         authors[] = {"Spooner", "Kronzky"};
-        authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };
 
 #include "CfgFunctions.hpp"
-
-

--- a/addons/strings/stringtable.xml
+++ b/addons/strings/stringtable.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project name="CBA_A3">
+    <Package name="Strings">
+        <Key ID="STR_CBA_Strings_Component">
+            <English>Community Base Addons - Strings</English>
+        </Key>
+    </Package>
+</Project>

--- a/addons/ui/config.cpp
+++ b/addons/ui/config.cpp
@@ -1,21 +1,22 @@
 ﻿#include "script_component.hpp"
 
 class CfgPatches {
-    class cba_ui {
+    class ADDON {
+        author = "$STR_CBA_Author";
+        name = CSTRING(component);
+        url = "$STR_CBA_URL";
         units[] = {};
         requiredVersion = 1;
-        requiredAddons[] = { "CBA_common", "CBA_arrays", "A3_Ui_F" };
+        requiredAddons[] = {"CBA_common","CBA_arrays","A3_Ui_F"};
         version = VERSION;
-        author = "$STR_CBA_Author";
         authors[] = {"Dr Eyeball"};
-        authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };
 
 #include "CfgFunctions.hpp"
 
 class Extended_PreInit_EventHandlers {
-    class cba_ui {
+    class ADDON {
         clientInit = QUOTE(call COMPILE_FILE(XEH_preClientInit));
     };
 };
@@ -51,5 +52,3 @@ class _flexiMenu_RscShortcutButton: RscShortcutButton {
 #include "flexiMenu\data\menu_buttonList.hpp"
 #include "flexiMenu\data\menu_iconRow.hpp"
 #include "flexiMenu\data\menu_popup.hpp"
-
-

--- a/addons/ui/stringtable.xml
+++ b/addons/ui/stringtable.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project name="CBA_A3">
+    <Package name="Ui">
+        <Key ID="STR_CBA_Ui_Component">
+            <English>Community Base Addons - User Interface</English>
+        </Key>
+    </Package>
+</Project>

--- a/addons/ui_helper/config.cpp
+++ b/addons/ui_helper/config.cpp
@@ -1,13 +1,15 @@
 #include "script_component.hpp"
+
 class CfgPatches {
     class ADDON {
+        author = "$STR_CBA_Author";
+        name = ECSTRING(ui,component);
+        url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};
         worlds[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {
-            "CBA_common","A3_UI_F"
-        };
+        requiredAddons[] = {"CBA_common","A3_UI_F"};
     };
 };
 

--- a/addons/vectors/config.cpp
+++ b/addons/vectors/config.cpp
@@ -1,18 +1,17 @@
 #include "script_component.hpp"
-class CfgPatches
-{
-    class ADDON
-    {
+
+class CfgPatches {
+    class ADDON {
+        author = "$STR_CBA_Author";
+        name = CSTRING(component);
+        url = "$STR_CBA_URL";
         units[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = { "CBA_common" };
+        requiredAddons[] = {"CBA_common"};
         version = VERSION;
-        author = "$STR_CBA_Author";
         authors[] = {"Vigilante"};
-        authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };
+
 #include "CfgEventHandlers.hpp"
 #include "CfgFunctions.hpp"
-
-

--- a/addons/vectors/stringtable.xml
+++ b/addons/vectors/stringtable.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project name="CBA_A3">
+    <Package name="Vectors">
+        <Key ID="STR_CBA_Vectors_Component">
+            <English>Community Base Addons - Vectors</English>
+        </Key>
+    </Package>
+</Project>

--- a/addons/versioning/config.cpp
+++ b/addons/versioning/config.cpp
@@ -1,17 +1,16 @@
 #include "script_component.hpp"
-class CfgPatches
-{
-    class ADDON
-    {
+
+class CfgPatches {
+    class ADDON {
+        author = "$STR_CBA_Author";
+        name = CSTRING(component);
+        url = "$STR_CBA_URL";
         units[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = { "CBA_common", "CBA_strings", "CBA_hashes", "CBA_diagnostic", "CBA_events", "CBA_network" };
         version = VERSION;
-        author = "$STR_CBA_Author";
         authors[] = {"Sickboy"};
-        authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };
+
 #include "CfgEventHandlers.hpp"
-
-

--- a/addons/versioning/stringtable.xml
+++ b/addons/versioning/stringtable.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project name="CBA_A3">
+    <Package name="Versioning">
+        <Key ID="STR_CBA_Versioning_Component">
+            <English>Community Base Addons - Versioning</English>
+        </Key>
+    </Package>
+</Project>

--- a/addons/xeh/config.cpp
+++ b/addons/xeh/config.cpp
@@ -2,6 +2,9 @@
 
 class CfgPatches {
     class ADDON {
+        author = "$STR_CBA_Author";
+        name = CSTRING(component);
+        url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};
         requiredAddons[] = {"A3_Data_F","A3_Characters_F","A3_Air_F","A3_Armor_F","A3_Boat_F","A3_Soft_F"};
@@ -9,9 +12,10 @@ class CfgPatches {
         version = "4.0.0"; // Due to older mod versions requiring > 3,3,3 etc
         versionStr = "4.0.0";
         versionAr[] = {4,0,0};
-        author = "$STR_CBA_Author";
         authors[] = {"Solus","Killswitch","commy2"};
-        authorUrl = "https://github.com/CBATeam/CBA_A3";
+
+        // this prevents any patched class from requiring XEH
+        addonRootClass = "A3_Characters_F";
     };
 
     // Backwards compatibility

--- a/addons/xeh/stringtable.xml
+++ b/addons/xeh/stringtable.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project name="CBA_A3">
+    <Package name="XEH">
+        <Key ID="STR_CBA_XEH_Component">
+            <English>Community Base Addons - Extended Event Handlers</English>
+        </Key>
+    </Package>
+</Project>

--- a/optionals/cache_disable/config.cpp
+++ b/optionals/cache_disable/config.cpp
@@ -2,14 +2,15 @@
 
 class CfgPatches {
     class ADDON {
+        author = "$STR_CBA_Author";
+        name = ECSTRING(Optional,Component);
+        url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"CBA_Extended_EventHandlers", "CBA_Main"};
         version = VERSION;
-        author = "$STR_CBA_Author";
         authors[] = {"Sickboy"};
-        authorUrl = "http://dev-heaven.net/projects/cca";
     };
 };
 

--- a/optionals/diagnostic_disable_xeh_logging/config.cpp
+++ b/optionals/diagnostic_disable_xeh_logging/config.cpp
@@ -11,6 +11,9 @@
 
 class CfgPatches {
     class Disable_XEH_Logging {
+        author = "$STR_CBA_Author";
+        name = "$STR_CBA_Optional_Component";
+        url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};
         requiredVersion = 0.1;

--- a/optionals/diagnostic_enable_logging/config.cpp
+++ b/optionals/diagnostic_enable_logging/config.cpp
@@ -1,27 +1,23 @@
 #include "script_component.hpp"
 
-class CfgPatches
-{
-    class ADDON
-    {
+class CfgPatches {
+    class ADDON {
+        author = "$STR_CBA_Author";
+        name = ECSTRING(Optional,Component);
+        url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"CBA_Diagnostic"};
         version = VERSION;
-        author = "$STR_CBA_Author";
         authors[] = {"Sickboy"};
-        authorUrl = "http://dev-heaven.net/projects/cca";
     };
 };
-class Extended_Init_EventHandlers
-{
-    class All
-    {
-        class cba_diagnostic_logging
-        {
+
+class Extended_Init_EventHandlers {
+    class All {
+        class cba_diagnostic_logging {
             init = "diag_log [diag_frameNo, diag_fps, diag_tickTime, time, _this, typeOf (_this select 0), getPosASL (_this select 0)]";
         };
     };
 };
-

--- a/optionals/diagnostic_enable_perf_loop/config.cpp
+++ b/optionals/diagnostic_enable_perf_loop/config.cpp
@@ -1,30 +1,20 @@
-////////////////////////////////////////////////////////////////////
-//DeRap: Produced from mikero's Dos Tools Dll version 5.16
-//Produced on Mon Jun 07 03:11:11 2010 : Created on Mon Jun 07 03:11:11 2010
-//http://dev-heaven.net/projects/list_files/mikero-pbodll
-////////////////////////////////////////////////////////////////////
+#include "script_component.hpp"
 
-#define _ARMA_
-
-//Class cba_diagnostic_enable_perf_loop : config.bin{
-class CfgPatches
-{
-    class cba_diagnostic_enable_perf_loop
-    {
+class CfgPatches {
+    class ADDON {
+        author = "$STR_CBA_Author";
+        name = ECSTRING(Optional,Component);
+        url = "$STR_CBA_URL";
         units[] = {};
         requiredVersion = 1.02;
         requiredAddons[] = {"CBA_common","CBA_diagnostic"};
         version = "0.4.1.101";
-        author = "$STR_CBA_Author";
         authors[] = {"Spooner","Sickboy"};
-        authorUrl = "http://dev-heaven.net/projects/cca";
     };
 };
-class Extended_postInit_EventHandlers
-{
-    class cba_diagnostic_enable_perf_loop
-    {
+
+class Extended_PostInit_EventHandlers {
+    class ADDON {
         init = "[] spawn cba_diagnostic_fnc_perf_loop";
     };
 };
-//};

--- a/optionals/jr_disable_long_scopes_on_short_mg_rail/config.cpp
+++ b/optionals/jr_disable_long_scopes_on_short_mg_rail/config.cpp
@@ -1,17 +1,16 @@
 #include "script_component.hpp"
 
-class CfgPatches
-{
-    class ADDON
-    {
+class CfgPatches {
+    class ADDON {
+        author = "$STR_CBA_Author";
+        name = ECSTRING(Optional,Component);
+        url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_jr"};
         version = VERSION;
-        author = "$STR_CBA_Author";
         authors[] = {"Robalo"};
-        authorUrl = "https://github.com/CBATeam/CBA_A3";
     };
 };
 


### PR DESCRIPTION
See: https://community.bistudio.com/wiki/CfgPatches

- also fixes certain objects placed in 3DEN causing the mission to require CBA due to use touching the class by adding XEH classes.
- also uses the new "name" instead of the configs classname in the help module (if present)