### PR TITLE
improve compatibleItems, fix Arsenal 'ghost optics'

### DIFF
--- a/addons/jr/CfgFunctions.hpp
+++ b/addons/jr/CfgFunctions.hpp
@@ -1,0 +1,19 @@
+
+class CfgFunctions {
+    // replace broken vanilla function with a working one
+    class A3_Bootcamp {
+        class Inventory {
+            class compatibleItems {
+                file = QPATHTOF(fnc_compatibleItems.sqf);
+            };
+        };
+    };
+    class CBA {
+        class Inventory {
+            class compatibleItems {
+                description = "Get list of compatible attachments for a weapon";
+                file = QPATHTOF(fnc_compatibleItems.sqf);
+            };
+        };
+    };
+};

--- a/addons/jr/config.cpp
+++ b/addons/jr/config.cpp
@@ -35,16 +35,6 @@ class CfgPatches {
     };
 };
 
-class CfgFunctions {
-    class CBA {
-        class JR {
-            class compatibleItems {
-                description = "Get list of compatible attachments for a weapon";
-                file = QUOTE(PATHTOF(fnc_compatibleItems.sqf));
-            };
-        };
-    };
-};
-
 #include "jr_classes.hpp"
 #include "cfgweapons.hpp"
+#include "CfgFunctions.hpp"

--- a/addons/jr/fnc_compatibleItems.sqf
+++ b/addons/jr/fnc_compatibleItems.sqf
@@ -9,7 +9,7 @@ Parameters:
     _typefilter - Optional filter. Can be "muzzle", "optic", "pointer" or "bipod". <STRING, NUMBER>
 
 Returns:
-    Class names of with weapon compatible attachments <ARRAY>
+    Class names of attachments compatible with weapon <ARRAY>
 
 Examples:
     (begin example)

--- a/addons/jr/fnc_compatibleItems.sqf
+++ b/addons/jr/fnc_compatibleItems.sqf
@@ -1,37 +1,46 @@
-/*
-    Author: Karel Moricky
-    Enhanced by Robalo
-    Caching added by joko // Jonas
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_compatibleItems
 
-    Description:
-    Return all compatible weapon attachments
+Description:
+    Return all compatible weapon attachments.
 
-    Parameter(s):
-        0: STRING - weapon class
-        1: STRING - optional, accessory type: number (101 - muzzle, 201 - optic, 301 - pointer, 302 - bipod)
+Parameters:
+    _weapon     - A weapons class name <STRING>
+    _typefilter - Optional filter. Can be "muzzle", "optic", "pointer" or "bipod". <STRING, NUMBER>
 
-    Returns:
-        ARRAY of STRINGs
+Returns:
+    Class names of with weapon compatible attachments <ARRAY>
 
-    Examples:
+Examples:
+    (begin example)
         _acclist = ["LMG_Mk200_F"] call CBA_fnc_compatibleItems;
-        _muzzleacclist = ["LMG_Mk200_F", 101] call CBA_fnc_compatibleItems;
- */
+        _muzzleacclist = ["LMG_Mk200_F", "muzzle"] call CBA_fnc_compatibleItems;
+    (end)
+
+Author:
+    Original by Karel Moricky, Enhanced by Robalo, jokoho, commy2
+---------------------------------------------------------------------------- */
 #include "script_component.hpp"
-params [["_weapon", "", [""]], ["_typefilter", 0]];
+SCRIPT(compatibleItems);
+
+params [["_weapon", "", [""]], ["_typefilter", nil, ["", 0]]];
+
 if (_weapon == "") exitWith {[]};
 
 if (isNil QGVAR(namespace)) then {
     GVAR(namespace) = call CBA_fnc_createNamespace;
 };
+
 private _compatibleItems = GVAR(namespace) getVariable _weapon;
 
 if (isNil "_compatibleItems") then {
     _compatibleItems = [];
     private _cfgWeapon = configFile >> "CfgWeapons" >> _weapon;
+
     if (isClass _cfgWeapon) then {
         {
             private _cfgCompatibleItems = _x >> "compatibleItems";
+
             if (isArray _cfgCompatibleItems) then {
                 {
                     #ifndef LINUX_BUILD
@@ -40,7 +49,7 @@ if (isNil "_compatibleItems") then {
                         if !(_x in _compatibleItems) then {_compatibleItems pushBack _x};
                     #endif
                     nil
-                } count (getArray _cfgCompatibleItems);
+                } count getArray _cfgCompatibleItems;
             } else {
                 if (isClass _cfgCompatibleItems) then {
                     {
@@ -56,17 +65,21 @@ if (isNil "_compatibleItems") then {
                 };
             };
             nil
-        } count configProperties [_cfgWeapon >> "WeaponSlotsInfo","isclass _x"];
+        } count configProperties [_cfgWeapon >> "WeaponSlotsInfo", "isclass _x"];
 
         GVAR(namespace) setVariable [_weapon, _compatibleItems]; //save entry in cache
     } else {
-        ["'%1' not found in CfgWeapons",_weapon] call bis_fnc_error;
+        ["'%1' not found in CfgWeapons", _weapon] call bis_fnc_error;
     };
 };
 
-if (_typefilter == 0) then { //return
+if (isNil "_typefilter") then { //return
     + _compatibleItems
 } else {
+    if (_typefilter isEqualType "") then {
+        _typefilter = [-1, 101, 201, 301, 302] param [["", "muzzle", "optic", "pointer", "bipod"] find _typefilter, -1];
+    };
+
     #ifndef LINUX_BUILD
         _compatibleItems select {_typefilter == getNumber (configFile >> "CfgWeapons" >> _x >> "itemInfo" >> "type")}
     #else

--- a/addons/linux/CfgFunctions.hpp
+++ b/addons/linux/CfgFunctions.hpp
@@ -4,6 +4,11 @@
 }
 
 class CfgFunctions {
+    class A3_Bootcamp {
+        class Inventory {
+            F_FILEPATH(jr,compatibleItems);
+        };
+    };
     class CBA {
         class Entities {
             F_FILEPATH(common,getAlive);
@@ -21,6 +26,7 @@ class CfgFunctions {
             F_FILEPATH(common,dropWeapon);
             F_FILEPATH(common,dropMagazine);
             F_FILEPATH(common,addBinocularMagazine);
+            F_FILEPATH(jr,compatibleItems);
         };
 
         class Events {
@@ -31,10 +37,6 @@ class CfgFunctions {
 
         class Hashes {
             F_FILEPATH(hashes,hashCreate);
-        };
-
-        class JR {
-            F_FILEPATH(jr,compatibleItems);
         };
 
         class XEH {


### PR DESCRIPTION
- completely replaces `BIS_fnc_compatibleItem` to fix: https://forums.bistudio.com/topic/168277-cba-community-base-addons-arma-3/?p=3035516 ("ghost optics")
See: https://forums.bistudio.com/topic/168277-cba-community-base-addons-arma-3/?p=3039349

- makes the filter parameter accept strings as well as numbers. Previous header said strings were accepted, but it was actually magic BI numbers no one ever remembers. Now it's "muzzle", "pointer", "optic" and "bipod"