### PR TITLE
add '_thisArgs', '_thisId', '_thisType' and '_thisFnc'  and  to CBA events

### DIFF
--- a/addons/events/CfgFunctions.hpp
+++ b/addons/events/CfgFunctions.hpp
@@ -46,6 +46,10 @@ class CfgFunctions {
                 description = "Registers an event handler for a specific CBA event.";
                 file = "\x\cba\addons\events\fnc_addEventHandler.sqf";
             };
+            class addEventHandlerArgs {
+                description = "Registers an event handler for a specific CBA event with arguments.";
+                file = "\x\cba\addons\events\fnc_addEventHandlerArgs.sqf";
+            };
             class removeEventHandler {
                 description = "Removes an event handler previously registered with CBA_fnc_addEventHandler.";
                 file = "\x\cba\addons\events\fnc_removeEventHandler.sqf";

--- a/addons/events/fnc_addEventHandler.sqf
+++ b/addons/events/fnc_addEventHandler.sqf
@@ -7,10 +7,9 @@ Description:
 Parameters:
     _eventName - Type of event to handle. <STRING>
     _eventFunc - Function to call when event is raised. <CODE>
-    _arguments - Arguments to pass to event handler. (optional) <Any>
 
 Returns:
-    _eventId - Unique ID of the event handler (can be used with <CBA_fnc_removeEventHandler>).
+    _eventId - Unique ID of the event handler (can be used with <CBA_fnc_removeEventHandler).
 
 Examples:
     (begin example)
@@ -24,7 +23,7 @@ Author:
 SCRIPT(addEventHandler);
 
 [{
-    params [["_eventName", "", [""]], ["_eventFunc", nil, [{}]], ["_arguments", []]];
+    params [["_eventName", "", [""]], ["_eventFunc", nil, [{}]]];
 
     if (_eventName isEqualTo "" || isNil "_eventFunc") exitWith {-1};
 
@@ -40,11 +39,11 @@ SCRIPT(addEventHandler);
         GVAR(eventHashes) setVariable [_eventName, _eventHash];
     };
 
+    private _internalId = _events pushBack _eventFunc;
+
     // get new id
     private _eventId = [_eventHash, "#lastId"] call CBA_fnc_hashGet;
     INC(_eventId);
-
-    private _internalId = _events pushBack [_eventFunc, _arguments, _eventId];
 
     [_eventHash, "#lastId", _eventId] call CBA_fnc_hashSet;
     [_eventHash, _eventId, _internalId] call CBA_fnc_hashSet;

--- a/addons/events/fnc_addEventHandler.sqf
+++ b/addons/events/fnc_addEventHandler.sqf
@@ -9,7 +9,7 @@ Parameters:
     _eventFunc - Function to call when event is raised. <CODE>
 
 Returns:
-    _eventId - Unique ID of the event handler (can be used with <CBA_fnc_removeEventHandler).
+    _eventId - Unique ID of the event handler (can be used with CBA_fnc_removeEventHandler).
 
 Examples:
     (begin example)

--- a/addons/events/fnc_addEventHandler.sqf
+++ b/addons/events/fnc_addEventHandler.sqf
@@ -7,6 +7,7 @@ Description:
 Parameters:
     _eventName - Type of event to handle. <STRING>
     _eventFunc - Function to call when event is raised. <CODE>
+    _arguments - Arguments to pass to event handler. (optional) <Any>
 
 Returns:
     _eventId - Unique ID of the event handler (can be used with <CBA_fnc_removeEventHandler>).
@@ -22,7 +23,7 @@ Author:
 #include "script_component.hpp"
 SCRIPT(addEventHandler);
 
-params [["_eventName", "", [""]], ["_eventFunc", nil, [{}]]];
+params [["_eventName", "", [""]], ["_eventFunc", nil, [{}]], ["_arguments", []]];
 
 {
     if (_eventName isEqualTo "" || isNil "_eventFunc") exitWith {-1};
@@ -39,7 +40,8 @@ params [["_eventName", "", [""]], ["_eventFunc", nil, [{}]]];
         GVAR(eventHashes) setVariable [_eventName, _eventHash];
     };
 
-    private _internalId = _events pushBack _eventFunc;
+    private _eventData = [_eventFunc, _arguments];
+    private _internalId = _events pushBack _eventData;
 
     // get last id
     private _eventId = [_eventHash, "#lastId"] call CBA_fnc_hashGet;
@@ -47,6 +49,7 @@ params [["_eventName", "", [""]], ["_eventFunc", nil, [{}]]];
     // inc id
     _eventId = _eventId + 1;
 
+    _eventData pushBack _eventId;
     [_eventHash, "#lastId", _eventId] call CBA_fnc_hashSet;
     [_eventHash, _eventId, _internalId] call CBA_fnc_hashSet;
 

--- a/addons/events/fnc_addEventHandler.sqf
+++ b/addons/events/fnc_addEventHandler.sqf
@@ -23,9 +23,9 @@ Author:
 #include "script_component.hpp"
 SCRIPT(addEventHandler);
 
-params [["_eventName", "", [""]], ["_eventFunc", nil, [{}]], ["_arguments", []]];
+[{
+    params [["_eventName", "", [""]], ["_eventFunc", nil, [{}]], ["_arguments", []]];
 
-{
     if (_eventName isEqualTo "" || isNil "_eventFunc") exitWith {-1};
 
     private _events = GVAR(eventNamespace) getVariable _eventName;
@@ -40,18 +40,14 @@ params [["_eventName", "", [""]], ["_eventFunc", nil, [{}]], ["_arguments", []]]
         GVAR(eventHashes) setVariable [_eventName, _eventHash];
     };
 
-    private _eventData = [_eventFunc, _arguments];
-    private _internalId = _events pushBack _eventData;
-
-    // get last id
+    // get new id
     private _eventId = [_eventHash, "#lastId"] call CBA_fnc_hashGet;
+    INC(_eventId);
 
-    // inc id
-    _eventId = _eventId + 1;
+    private _internalId = _events pushBack [_eventFunc, _arguments, _eventId];
 
-    _eventData pushBack _eventId;
     [_eventHash, "#lastId", _eventId] call CBA_fnc_hashSet;
     [_eventHash, _eventId, _internalId] call CBA_fnc_hashSet;
 
     _eventId
-} call CBA_fnc_directCall;
+}, _this] call CBA_fnc_directCall;

--- a/addons/events/fnc_addEventHandlerArgs.sqf
+++ b/addons/events/fnc_addEventHandlerArgs.sqf
@@ -17,7 +17,7 @@ Parameters:
     _arguments - Arguments to pass to event handler. (optional) <Any>
 
 Returns:
-    _eventId - Unique ID of the event handler (can be used with <CBA_fnc_removeEventHandler).
+    _eventId - Unique ID of the event handler (can be used with CBA_fnc_removeEventHandler).
 
 Examples:
     (begin example)
@@ -44,7 +44,7 @@ if (isNil QGVAR(eventsArgs)) then {
 private _eventData = [_arguments, _eventFunc, _eventName];
 private _id = GVAR(eventsArgs) pushBack _eventData;
 
-private _eventFunc = compile format ['
+_eventFunc = compile format ['
     (GVAR(eventsArgs) select %1) params ["_thisArgs", "_thisFnc", "_thisType", "_thisId"];
     _this call _thisFnc;
 ', _id];

--- a/addons/events/fnc_addEventHandlerArgs.sqf
+++ b/addons/events/fnc_addEventHandlerArgs.sqf
@@ -1,0 +1,55 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_addEventHandlerArgs
+
+Description:
+    Registers an event handler for a specific CBA event with arguments.
+
+    A event added with this function will have the following variables defined:
+    _this     - Arguments passed by function calling the events. <ANY>
+    _thisArgs - Arguments added to event by this function. <ANY>
+    _thisId   - Same as the return value of this function. <NUMBER>
+    _thisType - Name of the event. (Same as _eventName passed to this function) <STRING>
+    _thisFnc  - Piece of code added to the event by this function <CODE>
+
+Parameters:
+    _eventName - Type of event to handle. <STRING>
+    _eventFunc - Function to call when event is raised. <CODE>
+    _arguments - Arguments to pass to event handler. (optional) <Any>
+
+Returns:
+    _eventId - Unique ID of the event handler (can be used with <CBA_fnc_removeEventHandler).
+
+Examples:
+    (begin example)
+        ["test1", {
+            systemChat str _thisArgs;
+            [_thisType, _thisId] call CBA_fnc_removeEventHandler
+        }, "hello world"] call CBA_fnc_addEventHandlerArgs;
+
+        "test1" call CBA_fnc_localEvent;
+    (end)
+
+Author:
+    commy2
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+SCRIPT(addEventHandlerArgs);
+
+params [["_eventName", "", [""]], ["_eventFunc", nil, [{}]], ["_arguments", []]];
+
+if (isNil QGVAR(eventsArgs)) then {
+    GVAR(eventsArgs) = [];
+};
+
+private _eventData = [_arguments, _eventFunc, _eventName];
+private _id = GVAR(eventsArgs) pushBack _eventData;
+
+private _eventFunc = compile format ['
+    (GVAR(eventsArgs) select %1) params ["_thisArgs", "_thisFnc", "_thisType", "_thisId"];
+    _this call _thisFnc;
+', _id];
+
+private _eventId = [_eventName, _eventFunc] call CBA_fnc_addEventHandler;
+
+_eventData pushBack _eventId;
+_eventId

--- a/addons/events/fnc_ownerEvent.sqf
+++ b/addons/events/fnc_ownerEvent.sqf
@@ -29,7 +29,7 @@ TRACE_3("params",_eventName,_params,_targetOwner);
 if (_targetOwner == 2) then { //Going to server:
     if (isServer) then {
         //We are the server: Do local event (no network traffic)
-        [_eventName, _params] call CBA_fnc_localEvent;
+        CALL_EVENT(_params,_eventName);
     } else {
         //Remote Server, send event (using publicVariableServer)
         //Note: publicVariableClient does not seem to work on dedicated
@@ -39,7 +39,7 @@ if (_targetOwner == 2) then { //Going to server:
     if (CBA_clientID == _targetOwner) then {
         //We are the target client: Do local event (no network traffic)
         //Note: publicVariableClient to yourself DOES trigger addPublicVariableEventHandler, but it also causes network traffic
-        [_eventName, _params] call CBA_fnc_localEvent;
+        CALL_EVENT(_params,_eventName);
     } else {
         //Remote Client, send event (using publicVariableClient)
         SEND_EVENT_TO_CLIENT(_params,_eventName,_targetOwner);

--- a/addons/events/script_component.hpp
+++ b/addons/events/script_component.hpp
@@ -33,9 +33,7 @@
 
 #define CALL_EVENT(args,event) {\
     if !(isNil "_x") then {\
-        private _thisType = event;\
-        _x params ["_thisFnc", "_thisArgs", "_thisId"];\
-        args call _thisFnc;\
+        args call _x;\
     };\
 } forEach +(GVAR(eventNamespace) getVariable event) // copy array so events can be removed while iterating safely
 

--- a/addons/events/script_component.hpp
+++ b/addons/events/script_component.hpp
@@ -33,7 +33,9 @@
 
 #define CALL_EVENT(params,event) {\
     if !(isNil "_x") then {\
-        params call _x;\
+        private _thisType = event;\
+        _x params ["_thisFnc", "_thisArgs", "_thisId"];\
+        params call _thisFnc;\
     };\
 } forEach (GVAR(eventNamespace) getVariable event)
 

--- a/addons/events/script_component.hpp
+++ b/addons/events/script_component.hpp
@@ -37,7 +37,7 @@
         _x params ["_thisFnc", "_thisArgs", "_thisId"];\
         args call _thisFnc;\
     };\
-} forEach (GVAR(eventNamespace) getVariable event)
+} forEach +(GVAR(eventNamespace) getVariable event) // copy array so events can be removed while iterating safely
 
 #define GETOBJ(obj) (if (obj isEqualType grpNull) then {leader obj} else {obj})
 

--- a/addons/events/script_component.hpp
+++ b/addons/events/script_component.hpp
@@ -31,11 +31,11 @@
 
 #define SEND_TEVENT_TO_SERVER(params,name,targets) TEVENT_PVAR = [name, params, targets]; publicVariableServer TEVENT_PVAR_STR
 
-#define CALL_EVENT(params,event) {\
+#define CALL_EVENT(args,event) {\
     if !(isNil "_x") then {\
         private _thisType = event;\
         _x params ["_thisFnc", "_thisArgs", "_thisId"];\
-        params call _thisFnc;\
+        args call _thisFnc;\
     };\
 } forEach (GVAR(eventNamespace) getVariable event)
 


### PR DESCRIPTION
Closes: #374

Adds the same meta data `CBA_fnc_addBISEventHandler` has to the CBA events.

- adds optional parameter to `CBA_fnc_addEventHandler` to assign arguments to the event.

`_thisArgs` - Arguments passed when adding the event handler.
`_thisId` - Id that can be used to remove the event via `CBA_fnc_removeEventHandler`
`_thisType` - the name of the event ("testEvent" in `["testEvent", ...] call CBA_fnc_addEventHandler`)
`_thisFnc` - function that is executed when the event happens

Note: If the arguments passed to `CBA_fnc_addEventHandler` are an array, they are stored as array reference and not as copy. That means you can modify these arguments even after the event was added.

~~Needs some more testing, will do later ...~~