### PR TITLE
use ASL position instead of AGL to get direction vector

### DIFF
--- a/addons/common/fnc_turretDir.sqf
+++ b/addons/common/fnc_turretDir.sqf
@@ -33,8 +33,8 @@ private _gunBeg = _vehicle selectionPosition getText (_turretConfig >> "gunBeg")
 private _gunEnd = _vehicle selectionPosition getText (_turretConfig >> "gunEnd");
 
 if !(_relativeToModel) then {
-    _gunBeg = _vehicle modelToWorld _gunBeg;
-    _gunEnd = _vehicle modelToWorld _gunEnd;
+    _gunBeg = AGLToASL (_vehicle modelToWorld _gunBeg);
+    _gunEnd = AGLToASL (_vehicle modelToWorld _gunEnd);
 };
 
 private _turretDir = _gunEnd vectorFromTo _gunBeg;


### PR DESCRIPTION
Currently it's using the AGL position, which means that there will be an offset in the z-axis by exactly the altitude difference between those two points. It never really comes into play since these points are (typically) __very__ close to each other, but this is the correct way.