### PR TITLE
fix script error when calling undefined events

### DIFF
--- a/addons/events/script_component.hpp
+++ b/addons/events/script_component.hpp
@@ -35,7 +35,7 @@
     if !(isNil "_x") then {\
         args call _x;\
     };\
-} forEach +(GVAR(eventNamespace) getVariable event) // copy array so events can be removed while iterating safely
+} forEach +([GVAR(eventNamespace) getVariable event] param [0, []]) // copy array so events can be removed while iterating safely
 
 #define GETOBJ(obj) (if (obj isEqualType grpNull) then {leader obj} else {obj})
 


### PR DESCRIPTION
After #375 we copy the arrays from the event namespace. This leads to a typical SQF facepalm inducing issue...

`["undefined", 1] call CBA_fnc_localEvent`
```
22:35:17 Error in expression <) then {        _params call _x;    };} forEach +(cba_events_eventNamespace getV>
22:35:17   Error position: <forEach +(cba_events_eventNamespace getV>
22:35:17   Error foreach: Type Number,Not a Number, expected Array
22:35:17 File x\cba\addons\events\fnc_localEvent.sqf, line 7
22:35:17 Error in expression <) then {        _params call _x;    };} forEach +(cba_events_eventNamespace getV>
22:35:17   Error position: <forEach +(cba_events_eventNamespace getV>
22:35:17   Error Generic error in expression
22:35:17 File x\cba\addons\events\fnc_localEvent.sqf, line 7
```

If the variable on the namespace was _undefined_, it would previously do:
`CODE forEach (LOCATION getVariable STRING)`
`CODE forEach nil`
`nil`

Since we are now using the `+` operator to copy the array, it goes:
`CODE forEach +(LOCATION getVariable STRING)`
`CODE forEach +nil`
`CODE forEach nil*`
->ERROR

`nil*` is a special nil tagged as number instead of the "neutral" `nil` from the `getVariable` operator. This is probably because `+` is expected to return \<NUMBER\>. The default syntax for plus is obviously for adding numbers and that's what the internals assume when `nil` is used as argument.
`forEach` expects an array on the right side. In unscheduled environment, the command will fail silently for the "neutral nil", but for the "number type nil" (nil*), the input will be detected as being the wrong type. Therefore it reports:
`Error foreach: Type Number, [...], expected Array`

I'll call these concepts "number flavoured" and "neutral flavoured" nil-types from now on. Thanks.

`param` saves the day again.

