### PR TITLE
improve 'CBA_fnc_sortNestedArray'

### DIFF
--- a/addons/arrays/fnc_sortNestedArray.sqf
+++ b/addons/arrays/fnc_sortNestedArray.sqf
@@ -10,7 +10,7 @@ Description:
 Parameters:
     _array - Nested array to be sorted <ARRAY>
     _index - Sub array item index to be sorted on <NUMBER>
-    _order - true: ascending, false: descending (optional: true) <BOOLEAN>
+    _order - true: ascending, false: descending (optional, default: true) <BOOLEAN>
 
 Example:
     (begin example)

--- a/addons/arrays/fnc_sortNestedArray.sqf
+++ b/addons/arrays/fnc_sortNestedArray.sqf
@@ -5,75 +5,37 @@ Description:
     Used to sort a nested array from lowest to highest using quick sort.
 
     Sorting is based on the specified column, which must have numerical data.
+    Original array is modified.
 
 Parameters:
-    _array: array - Nested array to be sorted
-    _index: integer - sub array item index to be sorted on
+    _array - Nested array to be sorted <ARRAY>
+    _index - Sub array item index to be sorted on <NUMBER>
+    _order - true: ascending, false: descending (optional: true) <BOOLEAN>
 
 Example:
     (begin example)
-    _array = [_array,1] call CBA_fnc_sortNestedArray
+        _array = [_array, 1] call CBA_fnc_sortNestedArray
     (end)
 
 Returns:
-    Passed in array
+    Sorted array <ARRAY>
 
 Author:
-    Standard algorithm
-
+    commy2
 ---------------------------------------------------------------------------- */
-
 #include "script_component.hpp"
 SCRIPT(sortNestedArray);
 
-/*
-    Modified BIS function to sort nested arrays.
-    Added 2nd parameter to indicate which column (index in nested array) to sort on.
-    Sorts an array of numbers from lowest (left) to highest (right).
-    The passed array is modified by reference.
-    This function uses the quick sort algorithm.
-*/
+params [["_array", [], [[]]], ["_index", 0, [0]], ["_order", true, [false]]];
 
-//set up a function for recursion
-private "_sort";
-_sort = {
-    private ["_h","_i","_j","_x"];
-    params ["_a","_id","_lo","_hi"];
-     // _a, array to be sorted
-     // _id, array item index to be compared
-     // _lo, lower index to sort from
-     // _hi, upper index to sort to
-
-    _h = nil; //used to make a do-while loop below
-    _i = _lo;
-    _j = _hi;
-    if (count _a == 0) exitWith {};
-    _x = (_a select ((_lo + _hi) / 2)) select _id;
-
-    //  partition
-    while {isnil "_h" || {_i <= _j}} do {
-        //find first and last elements within bound that are greater / lower than _x
-        while {(_a select _i) select _id < _x} do {INC(_i)};
-        while {(_a select _j) select _id > _x} do {DEC(_j)};
-
-        if (_i <= _j) then {
-            //swap elements _i and _j
-            _h = _a select _i;
-            _a set [_i, _a select _j];
-            _a set [_j, _h];
-
-            INC(_i);
-            DEC(_j);
-        };
-    };
-
-    // recursion
-    if (_lo < _j) then {[_a, _id, _lo, _j] call _sort};
-    if (_i < _hi) then {[_a, _id, _i, _hi] call _sort};
+private _helperArray = _array apply {
+    [_x select _index, _x]
 };
 
-// and start it off
-[_this select 0, _this select 1, 0, 0 max ((count (_this select 0))-1)] call _sort;
+_helperArray sort _order;
 
-// array is already modified by reference, but return the modified array anyway
-_this select 0
+{
+    _array set [_forEachIndex, _helperArray select _forEachIndex select 1];
+} forEach _array;
+
+_array

--- a/addons/arrays/fnc_sortNestedArray.sqf
+++ b/addons/arrays/fnc_sortNestedArray.sqf
@@ -28,14 +28,20 @@ SCRIPT(sortNestedArray);
 
 params [["_array", [], [[]]], ["_index", 0, [0]], ["_order", true, [false]]];
 
+#ifndef LINUX_BUILD
 private _helperArray = _array apply {
     [_x select _index, _x]
 };
+#else
+private _helperArray = [_array, {
+    [_x select _index, _x]
+}] call CBA_fnc_filter;
+#endif
 
 _helperArray sort _order;
 
 {
-    _array set [_forEachIndex, _helperArray select _forEachIndex select 1];
-} forEach _array;
+    _array set [_forEachIndex, _x select 1];
+} forEach _helperArray;
 
 _array

--- a/addons/arrays/fnc_sortNestedArray_Linux.sqf
+++ b/addons/arrays/fnc_sortNestedArray_Linux.sqf
@@ -1,0 +1,2 @@
+#define LINUX_BUILD
+#include "fnc_sortNestedArray.sqf"

--- a/addons/linux/CfgFunctions.hpp
+++ b/addons/linux/CfgFunctions.hpp
@@ -30,6 +30,10 @@ class CfgFunctions {
             F_FILEPATH(jr,compatibleItems);
         };
 
+        class Arrays {
+            F_FILEPATH(arrays,sortNestedArray);
+        };
+
         class Events {
             F_FILEPATH(events,addPlayerEventHandler);
             F_FILEPATH(events,addKeyHandler);


### PR DESCRIPTION
- makes `CBA_fnc_sortNestedArray` use SQFs native `sort` command
- adds optional parameter to reverse sorting order

`BIS_fnc_sortBy` is using the same method now