### PR TITLE
add parameter to 'createNamespace' to create a public namespace

### DIFF
--- a/addons/common/CfgVehicles.hpp
+++ b/addons/common/CfgVehicles.hpp
@@ -1,0 +1,8 @@
+
+class CfgVehicles {
+    class Static;
+    class CBA_NamespaceDummy: Static {
+        scope = 1;
+        displayName = "";
+    };
+};

--- a/addons/common/config.cpp
+++ b/addons/common/config.cpp
@@ -16,6 +16,8 @@ class CfgPatches {
 
 #include "CfgEventHandlers.hpp"
 #include "CfgFunctions.hpp"
+
+#include "CfgVehicles.hpp"
 #include "CfgLocationTypes.hpp"
 
 class CBA_DirectCall {

--- a/addons/common/fnc_createNamespace.sqf
+++ b/addons/common/fnc_createNamespace.sqf
@@ -7,14 +7,17 @@ Description:
     The Namespace is destroyed after the mission ends. getVariable ARRAY is not supported.
 
 Parameters:
-    None
+    _isGlobal - create a global namespace (optional, default: false) <BOOLEAN>
 
 Returns:
-    _namespace - a namespace <LOCATION>
+    _namespace - a namespace <LOCATION, OBJECT>
 
 Examples:
     (begin example)
         _namespace = call CBA_fnc_createNamespace;
+
+        My_GlobalNamespace = true call CBA_fnc_createNamespace;
+        publicVariable "My_GlobalNamespace";
     (end)
 
 Author:
@@ -23,4 +26,12 @@ Author:
 #include "script_component.hpp"
 SCRIPT(createNamespace);
 
-createLocation ["CBA_NamespaceDummy", [-1000, -1000, 0], 0, 0]
+#define DUMMY_POSITION [-1000, -1000, 0]
+
+params [["_isGlobal", false]];
+
+if (_isGlobal isEqualTo true) then {
+    createVehicle ["CBA_NamespaceDummy", DUMMY_POSITION, [], 0, "NONE"]
+} else {
+    createLocation ["CBA_NamespaceDummy", DUMMY_POSITION, 0, 0]
+};

--- a/addons/common/fnc_deleteNamespace.sqf
+++ b/addons/common/fnc_deleteNamespace.sqf
@@ -21,6 +21,6 @@ Author:
 #include "script_component.hpp"
 SCRIPT(deleteNamespace);
 
-params [["_namespace", locationNull, [locationNull]]];
+params [["_namespace", locationNull, [locationNull, objNull]]];
 
-deleteLocation _namespace;
+_namespace call CBA_fnc_deleteEntity;

--- a/addons/events/XEH_preInit.sqf
+++ b/addons/events/XEH_preInit.sqf
@@ -11,7 +11,7 @@ GVAR(eventNamespace) = call CBA_fnc_createNamespace;
 GVAR(eventHashes) = call CBA_fnc_createNamespace;
 
 if (isServer) then {
-    GVAR(eventNamespaceJIP) = (sideLogic call CBA_fnc_getSharedGroup) createUnit ["Logic", [0,0,0], [], 0, "NONE"]; // createVehicle fails on game logics. Have to use createUnit instead.
+    GVAR(eventNamespaceJIP) = true call CBA_fnc_createNamespace; // createVehicle fails on game logics. Have to use createUnit instead.
     publicVariable QGVAR(eventNamespaceJIP);
 };
 

--- a/addons/events/XEH_preInit.sqf
+++ b/addons/events/XEH_preInit.sqf
@@ -11,7 +11,7 @@ GVAR(eventNamespace) = call CBA_fnc_createNamespace;
 GVAR(eventHashes) = call CBA_fnc_createNamespace;
 
 if (isServer) then {
-    GVAR(eventNamespaceJIP) = true call CBA_fnc_createNamespace; // createVehicle fails on game logics. Have to use createUnit instead.
+    GVAR(eventNamespaceJIP) = true call CBA_fnc_createNamespace;
     publicVariable QGVAR(eventNamespaceJIP);
 };
 


### PR DESCRIPTION
- title
- on a global (public) pseudo namespace one can use `setVariable pulic`
- I made a "Static" dummy object, because the game logics (which have to be created with `createUnit`) have AI overhead ...

- I use `isEqualTo true` instead of forcing a \<BOOLEAN\> with `params` because that would break bwc (on screen error) in case someone uses `call CBA_fnc_...`. That syntax carries over the `_this` variable from the parent scope ...