### PR TITLE
Change QFUNC to make use of DFUNC

### DIFF
--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -722,10 +722,10 @@ Author:
 #define FUNCMAIN(var1) TRIPLES(PREFIX,fnc,var1)
 #define FUNC_INNER(var1,var2) TRIPLES(DOUBLES(PREFIX,var1),fnc,var2)
 #define EFUNC(var1,var2) FUNC_INNER(var1,var2)
-#define QFUNC(var1) QUOTE(FUNC(var1))
+#define QFUNC(var1) QUOTE(DFUNC(var1))
 #define QFUNCMAIN(var1) QUOTE(FUNCMAIN(var1))
 #define QFUNC_INNER(var1,var2) QUOTE(FUNC_INNER(var1,var2))
-#define QEFUNC(var1,var2) QUOTE(EFUNC(var1,var2))
+#define QEFUNC(var1,var2) QUOTE(DEFUNC(var1,var2))
 
 #ifndef PRELOAD_ADDONS
     #define PRELOAD_ADDONS class CfgAddons \


### PR DESCRIPTION
When using QFUNC, the intend most often is to have the name of the variable referencing the function as a string. This behaviour works when compiling without debug enabled. However if debug is enabled, QFUNC compiles in with the debug wrapper, becoming a code string instead of a string representation of a variable reference.

A good example where this change of behaviour can be a problem is config attributes that refer to a call back (used a lot within ACE). In normal build, you will use a getvar to get the relevant code, as it is expected to point to the function. When using debug, you will need to do a compile instead, as it's a string representing a code block.

This commit makes it so that when using debug, the behaviour will remain the same - QFUNC will result in a string representation of the function.