### PR TITLE
Use unique local variable names in CBA_fnc_directCall

### DIFF
--- a/addons/common/fnc_directCall.sqf
+++ b/addons/common/fnc_directCall.sqf
@@ -13,7 +13,8 @@ Returns:
 
 Examples:
     (begin example)
-        0 spawn {{systemChat str (call CBA_fnc_isScheduled)} call CBA_fnc_directCall}
+        0 spawn { {systemChat str canSuspend} call CBA_fnc_directCall; };
+        -> false
     (end)
 
 Author:
@@ -21,10 +22,10 @@ Author:
 ---------------------------------------------------------------------------- */
 #include "script_component.hpp"
 
-params [["_code", {}, [{}]], ["_arguments", []]];
+params [["_CBA_code", {}, [{}]], ["_CBA_arguments", []]];
 
-private "_return";
+private "_CBA_return";
 
-"_return = _arguments call _code" configClasses (configFile >> "CBA_DirectCall");
+"_CBA_return = _CBA_arguments call _CBA_code" configClasses (configFile >> "CBA_DirectCall");
 
-if (!isNil "_return") then {_return};
+if (!isNil "_CBA_return") then {_CBA_return};


### PR DESCRIPTION
`_code`, `_return` and `_arguments` are common local variable names. This has the problem of these variables potentially overwriting other local variables from the parent scope of where `CBA_fnc_directCall` was executed from.

Example:
```
private _arguments = [1,2,3];

{
    systemChat str _arguments; // expected: [1,2,3], got: []
} call CBA_fnc_directCall;
```

All other* local variables carry over just fine. By tagging these local variables, we can make this function more flexible without having to pass every local variable as argument.

* exception is `_x` which is overwritten by `configClasses`. I could restore `_x` too by adding another dummy variable as placeholder, but that requires some additional tricks with `param` (because the game would error if you reference an undefined `_x` variable in scheduled env.), so I think it's not worth it.