### PR TITLE
Improve function header 'CBA_fnc_waitUntilAndExecute'

### DIFF
--- a/addons/common/fnc_waitUntilAndExecute.sqf
+++ b/addons/common/fnc_waitUntilAndExecute.sqf
@@ -5,9 +5,12 @@ Description:
     Executes a code once in non sched environment after a condition is true.
 
 Parameters:
-    _conditionFunction - The function to evaluate as condition. <CODE>
-    _statementFunction - The function to run once the condition is true. <CODE>
-    _args     - Parameters passed to the function executing. This will be the same array every execution. [optional] <ANY>
+    _condition - The function to evaluate as condition. <CODE>
+    _statement - The function to run once the condition is true. <CODE>
+    _args      - Parameters passed to the function executing. This will be the same array every execution. (optional) <ANY>
+
+Passed Arguments:
+    _this      - Parameters passed by this function. Same as '_args' above. <ANY>
 
 Returns:
     Nothing
@@ -22,6 +25,8 @@ Author:
 ---------------------------------------------------------------------------- */
 #include "script_component.hpp"
 
-params [["_conditionFunction", {}, [{}]], ["_statementFunction", {}, [{}]], ["_args", []]];
+params [["_condition", {}, [{}]], ["_statement", {}, [{}]], ["_args", []]];
 
-GVAR(waitUntilAndExecArray) pushBack [_conditionFunction, _statementFunction, _args];
+GVAR(waitUntilAndExecArray) pushBack [_condition, _statement, _args];
+
+nil

--- a/addons/common/fnc_waitUntilAndExecute.sqf
+++ b/addons/common/fnc_waitUntilAndExecute.sqf
@@ -2,12 +2,12 @@
 Function: CBA_fnc_waitUntilAndExecute
 
 Description:
-    Executes a code once in non sched environment after a condition is true.
+    Executes a code once in unscheduled environment after a condition is true.
 
 Parameters:
     _condition - The function to evaluate as condition. <CODE>
     _statement - The function to run once the condition is true. <CODE>
-    _args      - Parameters passed to the function executing. This will be the same array every execution. (optional) <ANY>
+    _args      - Parameters passed to the functions (statement and condition) executing. (optional) <ANY>
 
 Passed Arguments:
     _this      - Parameters passed by this function. Same as '_args' above. <ANY>


### PR DESCRIPTION
See: #392

- Shortened local variable name to save some space
- Make function report `nil` (like the function header suggests) instead of a seemingly random number.