### PR TITLE
Versioning - Handle non-numbers in arrays

### DIFF
--- a/addons/versioning/XEH_preInit.sqf
+++ b/addons/versioning/XEH_preInit.sqf
@@ -46,6 +46,11 @@ PREP(version_check);
 FUNC(version_compare) = {
     private ["_failed", "_c"];
     params ["_value","_localValue"];
+
+    //Handle non-number arrays - eg. {"mod", {"1.0"}, "(true)"}
+    if ((!(_value isEqualTo [])) && {!(_value isEqualTypeAll 0)}) exitWith {true};
+    if ((!(_localValue isEqualTo [])) && {!(_localValue isEqualTypeAll 0)}) exitWith {true};
+
     _failed = false;
     _c = count _localValue;
 


### PR DESCRIPTION
Using strings inside the version required array causes a error
`ACE[] = {"ace_common", {"3.6.0"}, "(true)"};`
will cause:
`Error >: Type String, expected Number,Not a Number`

Which seems to cascade and break all of postInit.

Simple fix to check that the arrays are all numbers, if not it will fail the check.