### PR TITLE
Fix Modules/Patrol Stringtable

### DIFF
--- a/addons/modules/stringtable.xml
+++ b/addons/modules/stringtable.xml
@@ -100,7 +100,7 @@
         <Key ID="STR_CBA_Modules_PatrolCenterType">
             <English>Patrol Center Type</English>
         </Key>
-        <Key ID="STR_CBA_Modules_PatrolCenterType_Desc)">
+        <Key ID="STR_CBA_Modules_PatrolCenterType_Desc">
             <English>Set what kind of object is being passed as the center point</English>
         </Key>
         <Key ID="STR_CBA_Modules_PatrolPosition">


### PR DESCRIPTION
Minor fix for 
```
String STR_cba_modules_PatrolCenterType_Desc not found
```

Also, as far as I can tell the module descriptions have no effect in 3den.