### PR TITLE
Fix missing string error for CBA diagnostic

### DIFF
--- a/addons/diagnostic/stringtable.xml
+++ b/addons/diagnostic/stringtable.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project name="CBA_A3">
     <Package name="Diagnostics">
-        <Key ID="STR_CBA_Diagnostics_Component">
+        <Key ID="STR_CBA_Diagnostic_Component">
             <English>Community Base Addons - Diagnostics</English>
         </Key>
     </Package>


### PR DESCRIPTION
Fixes "String STR_cba_diagnostic_component not found"