### PR TITLE
Make fnc_headDir compatible with the 1.54 ports

### DIFF
--- a/addons/common/fnc_headDir.sqf
+++ b/addons/common/fnc_headDir.sqf
@@ -76,7 +76,11 @@ if (_unit != call CBA_fnc_currentUnit) then {
 private _diff = -_azimuth;
 
 if !(_offset isEqualTo "") then {
+#ifndef LINUX_BUILD
     ADD(_diff,_unit getDir ([_offset] call CBA_fnc_getPos));
+#else
+    ADD(_diff,[_unit, [_offset] call CBA_fnc_getPos] call BIS_fnc_dirTo);
+#endif
 };
 if (_diff < 0) then {
     ADD(_diff,360);

--- a/addons/common/fnc_headDir.sqf
+++ b/addons/common/fnc_headDir.sqf
@@ -79,7 +79,7 @@ if !(_offset isEqualTo "") then {
 #ifndef LINUX_BUILD
     ADD(_diff,_unit getDir ([_offset] call CBA_fnc_getPos));
 #else
-    ADD(_diff,[_unit, [_offset] call CBA_fnc_getPos] call BIS_fnc_dirTo);
+    ADD(_diff,[ARR_2(_unit,[_offset] call CBA_fnc_getPos)] call BIS_fnc_dirTo);
 #endif
 };
 if (_diff < 0) then {

--- a/addons/common/fnc_headDir_Linux.sqf
+++ b/addons/common/fnc_headDir_Linux.sqf
@@ -1,0 +1,2 @@
+#define LINUX_BUILD
+#include "fnc_headDir.sqf"

--- a/addons/linux/CfgFunctions.hpp
+++ b/addons/linux/CfgFunctions.hpp
@@ -10,6 +10,11 @@ class CfgFunctions {
         };
     };
     class CBA {
+
+        class Anims {
+            F_FILEPATH(common,headDir);
+        };
+
         class Entities {
             F_FILEPATH(common,getAlive);
             F_FILEPATH(common,getMagazineIndex);


### PR DESCRIPTION
This makes fnc_headDir load without errors when using the 1.54 MacOS/Linux
ports.