### PR TITLE
band aid for Taru helicopter not executing xeh init events

### DIFF
--- a/addons/xeh/CfgVehicles.hpp
+++ b/addons/xeh/CfgVehicles.hpp
@@ -236,4 +236,15 @@ class CfgVehicles {
             class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
         };
     };
+
+    // Similar but different issue with the actual taru helicopter. only poking the "init" entry fixes it. cause unknown.
+    class Helicopter_Base_F;
+    class Helicopter_Base_H: Helicopter_Base_F {
+        class EventHandlers;
+    };
+    class Heli_Transport_04_base_F: Helicopter_Base_H {
+        class EventHandlers: EventHandlers {
+            init = "if (local (_this select 0)) then {[(_this select 0), """", false, false] call bis_fnc_initVehicle;};";
+        };
+    };
 };

--- a/addons/xeh/config.cpp
+++ b/addons/xeh/config.cpp
@@ -7,7 +7,7 @@ class CfgPatches {
         url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};
-        requiredAddons[] = {"A3_Data_F","A3_Characters_F","A3_Air_F","A3_Armor_F","A3_Boat_F","A3_Soft_F"};
+        requiredAddons[] = {"A3_Data_F","A3_Characters_F","A3_Air_F","A3_Armor_F","A3_Boat_F","A3_Soft_F","A3_Air_F_Heli_Heli_Transport_04"};
         requiredVersion = 0.1;
         version = "4.0.0"; // Due to older mod versions requiring > 3,3,3 etc
         versionStr = "4.0.0";


### PR DESCRIPTION
fixes: https://github.com/acemod/ACE3/issues/4050

I have no idea why this happens, why it only happens with the Taru and not with other helicopters that have the exact same configs (e.g. Stealth Chinook), why it only happens after 1.58 and why this works, but it does.