### PR TITLE
CBA settings fixes

### DIFF
--- a/addons/settings/Cfg3DEN.hpp
+++ b/addons/settings/Cfg3DEN.hpp
@@ -14,7 +14,7 @@ class Cfg3DEN {
                             displayName = "";
                             tooltip = "";
                             defaultValue = QUOTE(NULL_HASH);
-                            expression = QUOTE(missionNamespace setVariable [ARR_3(QUOTE(QGVAR(hash)),_value,true)]);
+                            expression = ""
                             wikiType = "[[Array]]";
                         };
                     };

--- a/addons/settings/XEH_preInit.sqf
+++ b/addons/settings/XEH_preInit.sqf
@@ -9,7 +9,7 @@ ADDON = false;
 ["Test_Setting_1", "CHECKBOX", ["-test checkbox-", "-tooltip-"], "My Category", true] call cba_settings_fnc_init;
 ["Test_Setting_2", "LIST",     ["-test list-",     "-tooltip-"], "My Category", [[1,0], ["enabled","disabled"], 1]] call cba_settings_fnc_init;
 ["Test_Setting_3", "SLIDER",   ["-test slider-",   "-tooltip-"], "My Category", [0, 10, 5, 0]] call cba_settings_fnc_init;
-["Test_Setting_4", "COLOR",    ["-test color-",    "-tooltip-"], "My Category", [1,1,0]] call cba_settings_fnc_init;
+["Test_Setting_4", "COLOR",    ["-test color-",    "-tooltip-"], "My Category", [1,1,0], false, {diag_log text format ["Color Setting Changed: %1", _this];}] call cba_settings_fnc_init;
 #endif
 
 // --- init settings namespaces

--- a/addons/settings/fnc_init.sqf
+++ b/addons/settings/fnc_init.sqf
@@ -141,7 +141,7 @@ if (!isNil "_settingInfo") then {
 };
 
 // --- read previous setting values from mission
-_settingsHash = missionNamespace getVariable [QGVAR(hash), "Scenario" get3DENMissionAttribute QGVAR(hash)];
+_settingsHash = getMissionConfigValue QGVAR(hash);
 
 if (isNil "_settingsHash") then {
     _settingsHash = NULL_HASH;

--- a/addons/settings/initMissionSettings.sqf
+++ b/addons/settings/initMissionSettings.sqf
@@ -3,7 +3,7 @@
 0 = 0 spawn {
     {
         // --- read previous setting values from mission
-        private _settingsHash = missionNamespace getVariable [QGVAR(hash), "Scenario" get3DENMissionAttribute QGVAR(hash)];
+        private _settingsHash = getMissionConfigValue QGVAR(hash);
 
         if (isNil "_settingsHash") then {
             _settingsHash = NULL_HASH;

--- a/addons/settings/script_component.hpp
+++ b/addons/settings/script_component.hpp
@@ -78,7 +78,7 @@
 #define NAMESPACE_GETVAR(namespace,varname,default) ([namespace getVariable varname] param [0, default])
 
 #define GET_VALUE(namespace,setting) ((GVAR(namespace) getVariable setting) param [0])
-#define GET_FORCED(namespace,setting) ((NAMESPACE_GETVAR(namespace,setting,[]) param [1, false]) || {isMultiplayer && {NAMESPACE_GETVAR(GVAR(defaultSettings),setting,[]) param [7, false]}})
+#define GET_FORCED(namespace,setting) ((NAMESPACE_GETVAR(GVAR(namespace),setting,[]) param [1, false]) || {isMultiplayer && {NAMESPACE_GETVAR(GVAR(defaultSettings),setting,[]) param [7, false]}})
 
 #define GET_TEMP_NAMESPACE(source) ([ARR_3(GVAR(clientSettingsTemp),GVAR(serverSettingsTemp),GVAR(missionSettingsTemp))] param [[ARR_3('client','server','mission')] find toLower source])
 #define SET_TEMP_NAMESPACE_VALUE(setting,value,source)   GET_TEMP_NAMESPACE(source) setVariable [ARR_2(setting,[ARR_2(value,(GET_TEMP_NAMESPACE(source) getVariable setting) param [1])])]


### PR DESCRIPTION
- Use getMissionConfigValue instead of broadcasting variable
- Fix GET_FORCED macro

3den expressions don't happen until after preInit
So `_settingsHash` would always be nil in `CBA_settings_fnc_init` if you add settings at preInit