### PR TITLE
Fix execNextFrame out of order in preInit

### DIFF
--- a/addons/common/fnc_execNextFrame.sqf
+++ b/addons/common/fnc_execNextFrame.sqf
@@ -23,7 +23,7 @@ Author:
 
 params [["_function", {}, [{}]], ["_args", []]];
 
-if (GVAR(nextFramePreInit) || {diag_frameno != GVAR(nextFrameNo)}) then {
+if (diag_frameno != GVAR(nextFrameNo)) then {
     GVAR(nextFrameBufferA) pushBack [_args, _function];
 } else {
     GVAR(nextFrameBufferB) pushBack [_args, _function];

--- a/addons/common/fnc_execNextFrame.sqf
+++ b/addons/common/fnc_execNextFrame.sqf
@@ -23,7 +23,7 @@ Author:
 
 params [["_function", {}, [{}]], ["_args", []]];
 
-if (diag_frameno != GVAR(nextFrameNo)) then {
+if (GVAR(nextFramePreInit) || {diag_frameno != GVAR(nextFrameNo)}) then {
     GVAR(nextFrameBufferA) pushBack [_args, _function];
 } else {
     GVAR(nextFrameBufferB) pushBack [_args, _function];

--- a/addons/common/init_perFrameHandler.sqf
+++ b/addons/common/init_perFrameHandler.sqf
@@ -10,9 +10,9 @@ GVAR(lastTickTime) = diag_tickTime;
 
 GVAR(waitAndExecArray) = [];
 GVAR(waitAndExecArrayIsSorted) = false;
-GVAR(nextFrameNo) = diag_frameno;
-GVAR(nextFramePreInit) = true;
-GVAR(nextFrameBufferA) = [[[], {GVAR(nextFramePreInit) = false; GVAR(nextFrameNo) = diag_frameno;}]];
+GVAR(nextFrameNo) = diag_frameno + 1;
+// PostInit can be 2 frames after preInit, need to manually set nextFrameNo, so new items get added to buffer B while processing A for the first time:
+GVAR(nextFrameBufferA) = [[[], {GVAR(nextFrameNo) = diag_frameno;}]];
 GVAR(nextFrameBufferB) = [];
 GVAR(waitUntilAndExecArray) = [];
 

--- a/addons/common/init_perFrameHandler.sqf
+++ b/addons/common/init_perFrameHandler.sqf
@@ -11,7 +11,8 @@ GVAR(lastTickTime) = diag_tickTime;
 GVAR(waitAndExecArray) = [];
 GVAR(waitAndExecArrayIsSorted) = false;
 GVAR(nextFrameNo) = diag_frameno;
-GVAR(nextFrameBufferA) = [];
+GVAR(nextFramePreInit) = true;
+GVAR(nextFrameBufferA) = [[[], {GVAR(nextFramePreInit) = false; GVAR(nextFrameNo) = diag_frameno;}]];
 GVAR(nextFrameBufferB) = [];
 GVAR(waitUntilAndExecArray) = [];
 


### PR DESCRIPTION
Exec next frame uses the logic `diag_frameno != GVAR(nextFrameNo)`,
but between preInit and postInit there can be more than 1 frame.

Items can be called out of order and items added can be called in the same frame (see C/D):

Before:
```
[13657] - Adding A (@preInit)
[13659] - Adding C (@PostInit)
[13660] - Running C, adding D
[13660] - Running D
[13661] - Running A, adding B
[13662] - Running B
```
 
After:
```
[2455] - Adding A (@preInit)
[2457] - Adding C (@PostInit)
[2458] - Running A, adding B
[2458] - Running C, adding D
[2459] - Running B
[2459] - Running D
```

This fix addes an extra conditional, pushing everything into the first buffer until it has been run.