### PR TITLE
new method for direct call

### DIFF
--- a/addons/common/config.cpp
+++ b/addons/common/config.cpp
@@ -19,7 +19,3 @@ class CfgPatches {
 
 #include "CfgVehicles.hpp"
 #include "CfgLocationTypes.hpp"
-
-class CBA_DirectCall {
-    class dummy;
-};

--- a/addons/common/fnc_directCall.sqf
+++ b/addons/common/fnc_directCall.sqf
@@ -6,7 +6,7 @@ Description:
 
 Parameters:
     _code      - Code to execute <CODE>
-    _arguments - Parameters to call the code with. [optional] <ANY>
+    _arguments - Parameters to call the code with. (optional) <ANY>
 
 Returns:
     _return - Return value of the function <ANY>
@@ -26,6 +26,8 @@ params [["_CBA_code", {}, [{}]], ["_CBA_arguments", []]];
 
 private "_CBA_return";
 
-"_CBA_return = _CBA_arguments call _CBA_code" configClasses (configFile >> "CBA_DirectCall");
+isNil {
+    _CBA_return = _CBA_arguments call _CBA_code;
+};
 
 if (!isNil "_CBA_return") then {_CBA_return};


### PR DESCRIPTION
The expression after `isNil` is executed in unscheduled environment. This way we also don't overwrite the `_x` variable.