### PR TITLE
fix: globalEventJIP would be executed twice

### DIFF
--- a/addons/events/XEH_postInit.sqf
+++ b/addons/events/XEH_postInit.sqf
@@ -10,8 +10,10 @@
             };
         };
     } forEach allVariables GVAR(eventNamespaceJIP);
-}, []] call CBA_fnc_execNextFrame;
 
+    // allow new incoming jip events
+    [QGVAR(eventJIP), CBA_fnc_localEvent] call CBA_fnc_addEventHandler;
+}, []] call CBA_fnc_execNextFrame;
 
 if (isServer) then {
     CBA_clientID = [0, 2] select isMultiplayer;

--- a/addons/events/fnc_globalEventJIP.sqf
+++ b/addons/events/fnc_globalEventJIP.sqf
@@ -38,6 +38,6 @@ if (_jipID isEqualTo "") then {
 GVAR(eventNamespaceJIP) setVariable [_jipID, [EVENT_PVAR_STR, [_eventName, _params]], true];
 
 // execute on every machine
-[_eventName, _params] call CBA_fnc_globalEvent;
+[QGVAR(eventJIP), [_eventName, _params]] call CBA_fnc_globalEvent;
 
 _jipID


### PR DESCRIPTION
- `globalEventJIP` will trigger the event twice if the global event arrives on the client before the JIP stack is read.

This PR changes the event to use a wrapper, so that the event can be discarded on each individual machine should the JIP stack be not be processed already.

@jonpas please test if this fixes your issue.