### PR TITLE
Fixed incorrect substring usage in find

### DIFF
--- a/addons/strings/fnc_find.sqf
+++ b/addons/strings/fnc_find.sqf
@@ -53,7 +53,7 @@ if(_initialIndex < 1) then {
     if(_initialIndex > (count _haystack) ) exitWith {
         -1
     };
-    private _tempString = [_haystack, _initialIndex, ((count _haystack) - _initialIndex)] call CBA_fnc_substring;
+    private _tempString = [_haystack, _initialIndex] call CBA_fnc_substr;
     _ret = _tempString find _needle;
     if(_ret > -1) then {
         _ret = _ret + _initialIndex;

--- a/addons/strings/test_strings.sqf
+++ b/addons/strings/test_strings.sqf
@@ -32,6 +32,9 @@ TEST_OP(_pos,==,-1,_fn);
 _pos = ["frofrog", "frog"] call CBA_fnc_find;
 TEST_OP(_pos,==,3,_fn);
 
+_pos = ["frog-headed fish", "f", 5] call CBA_fnc_find;
+TEST_OP(_pos,==,12,_fn);
+
 // ----------------------------------------------------------------------------
 // UNIT TESTS (stringSplit)
 _fn = "CBA_fnc_split";


### PR DESCRIPTION
When using substring in fnc_find with initialIndex, the substring should be from the index and to the end of the haystack.
The original code would return -1 for the example:
_result = ["frog-headed fish", "f", 5] call CBA_fnc_find;
And not 12 as shown in the example.