### PR TITLE
Don't run fireteam sync PREH after apex

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -60,12 +60,15 @@ for "_i" from 0 to ((count (CFG)) - 1) do {
 };
 
 // system to synch team colors
+// Note: 1.62 added Multiplayer synchronization for assigned team
+// Run the PFEH only if on previous versions, keep the event for backwards compatability
+
 PREP(onTeamColorChanged);
 PREP(synchTeamColors);
 
 ["CBA_teamColorChanged", FUNC(onTeamColorChanged)] call CBA_fnc_addEventHandler;
 
-if (hasInterface) then {
+if (hasInterface && {(productVersion select 2) < 162}) then {
     [FUNC(synchTeamColors), 1, []] call CBA_fnc_addPerFrameHandler;
 
     if (didJIP) then {

--- a/addons/common/fnc_onTeamColorChanged.sqf
+++ b/addons/common/fnc_onTeamColorChanged.sqf
@@ -19,6 +19,9 @@ Author:
 params ["_unit", "_team"];
 
 _unit assignTeam _team;
+
+if ((productVersion select 2) > 162) exitWith {};
+
 if (local (leader _unit)) then {
     _unit setVariable [QGVAR(synchedTeam), _team, true];
 };


### PR DESCRIPTION
Tag @BaerMitUmlaut 

APEX changelog:
>Added: Multiplayer synchronization for assigned team functionality

We shouldn't need the PFEH running to sync.
It will still run on linux versions before 1.62.

ACE used the `CBA_teamColorChanged` event and I see no reason to remove it as other might have as well.