### PR TITLE
Remove PlayerConnected, PlayerDisconnected band aid

### DIFF
--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -37,9 +37,4 @@ GVAR(addons) = _addons;
 // BWC
 #include "backwards_comp.sqf"
 
-// band aid - remove this once they fix PlayerConnected mission event handler
-// https://forums.bistudio.com/topic/143930-general-discussion-dev-branch/page-942#entry3003074
-[QGVAR(OPC_FIX), "onPlayerConnected", {}] call BIS_fnc_addStackedEventHandler;
-[QGVAR(OPC_FIX), "onPlayerConnected"] call BIS_fnc_removeStackedEventHandler;
-
 ADDON = true;


### PR DESCRIPTION
**When merged this pull request will:**
- Removes PlayerConnected, PlayerDisconnected band aid fix
- this is no longer necessary in v1.62

```
0 = addMissionEventHandler ["PlayerConnected", { systemChat str ["C", _this]}];
0 = addMissionEventHandler ["PlayerDisonnected", { systemChat str ["D", _this]}];
```