### PR TITLE
Disable default settings button if setting is already default

### DIFF
--- a/addons/settings/fnc_gui_refresh.sqf
+++ b/addons/settings/fnc_gui_refresh.sqf
@@ -2,7 +2,7 @@
 
 private _display = uiNamespace getVariable [QGVAR(display), displayNull];
 private _ctrlOptionsGroup = ((_display getVariable [QGVAR(controls), []]) select {ctrlShown _x}) param [0, controlNull];
-private _contols = _ctrlOptionsGroup getVariable [QGVAR(controls), []];
+private _controls = _ctrlOptionsGroup getVariable [QGVAR(controls), []];
 
 {
     private _linkedControls = _x getVariable QGVAR(linkedControls);
@@ -15,25 +15,31 @@ private _contols = _ctrlOptionsGroup getVariable [QGVAR(controls), []];
     if (!isNil "_value") then {
         switch (toUpper _settingType) do {
             case ("CHECKBOX"): {
-                _linkedControls params ["_ctrlSetting"];
+                _linkedControls params ["_ctrlSetting", "_defaultControl"];
 
                 _ctrlSetting cbSetChecked _value;
+
+                _defaultControl ctrlEnable !(_value isEqualTo _defaultValue);
             };
             case ("LIST"): {
                 _settingData params ["_values"];
-                _linkedControls params ["_ctrlSetting"];
+                _linkedControls params ["_ctrlSetting", "_defaultControl"];
 
                 _ctrlSetting lbSetCurSel (_values find _value);
+
+                _defaultControl ctrlEnable !(_value isEqualTo _defaultValue);
             };
             case ("SLIDER"): {
                 _settingData params ["", "", "_trailingDecimals"];
-                _linkedControls params ["_ctrlSetting", "_ctrlSettingEdit"];
+                _linkedControls params ["_ctrlSetting", "_ctrlSettingEdit", "_defaultControl"];
 
                 _ctrlSetting sliderSetPosition _value;
                 _ctrlSettingEdit ctrlSetText ([_value, 1, _trailingDecimals] call CBA_fnc_formatNumber);
+                
+                _defaultControl ctrlEnable !(_value isEqualTo _defaultValue);
             };
             case ("COLOR"): {
-                _linkedControls params ["_ctrlSettingPreview", "_settingControls"];
+                _linkedControls params ["_ctrlSettingPreview", "_settingControls", "_defaultControl"];
 
                 _value params [
                     ["_r", 0, [0]],
@@ -51,6 +57,8 @@ private _contols = _ctrlOptionsGroup getVariable [QGVAR(controls), []];
                     _ctrlSetting sliderSetPosition _valueX;
                     _ctrlSettingEdit ctrlSetText ([_valueX, 1, 2] call CBA_fnc_formatNumber);
                 } forEach _settingControls;
+
+                _defaultControl ctrlEnable !(_value isEqualTo _defaultValue);
             };
             default {};
         };
@@ -74,4 +82,4 @@ private _contols = _ctrlOptionsGroup getVariable [QGVAR(controls), []];
             default {};
         };
     };
-} forEach _contols;
+} forEach _controls;

--- a/addons/settings/gui_createMenu.sqf
+++ b/addons/settings/gui_createMenu.sqf
@@ -77,7 +77,7 @@ _display setVariable [QGVAR(controls), []];
         private _isOverwritten = [_setting, _source] call FUNC(isOverwritten);
 
         // ----- create setting changer control
-        private _contols = _ctrlOptionsGroup getVariable QGVAR(controls);
+        private _controls = _ctrlOptionsGroup getVariable QGVAR(controls);
         private _linkedControls = [];
 
         switch (toUpper _settingType) do {

--- a/addons/settings/gui_createMenu_checkbox.sqf
+++ b/addons/settings/gui_createMenu_checkbox.sqf
@@ -1,7 +1,7 @@
 // inline function, don't include script_component.hpp
 
-private _ctrlSetting = _display ctrlCreate ["RscCheckBox", count _contols + IDC_OFFSET_SETTING, _ctrlOptionsGroup];
-_contols pushBack _ctrlSetting;
+private _ctrlSetting = _display ctrlCreate ["RscCheckBox", count _controls + IDC_OFFSET_SETTING, _ctrlOptionsGroup];
+_controls pushBack _ctrlSetting;
 
 _ctrlSetting ctrlSetPosition [
     POS_W(16),
@@ -24,6 +24,11 @@ _ctrlSetting ctrlAddEventHandler ["CheckedChanged", {
 
     private _value = _state == 1;
     SET_TEMP_NAMESPACE_VALUE(_setting,_value,_source);
+
+    //If new setting is same as default value, grey out the default button
+    (_control getVariable QGVAR(linkedControls)) params ["", "_defaultControl"];
+    (_defaultControl getVariable QGVAR(data)) params ["", "", "_defaultValue"];
+    _defaultControl ctrlEnable (!(_value isEqualTo _defaultValue));
 }];
 
 _linkedControls pushBack _ctrlSetting;

--- a/addons/settings/gui_createMenu_color.sqf
+++ b/addons/settings/gui_createMenu_color.sqf
@@ -1,7 +1,7 @@
 // inline function, don't include script_component.hpp
 
-private _ctrlSettingPreview = _display ctrlCreate ["RscText", count _contols + IDC_OFFSET_SETTING, _ctrlOptionsGroup];
-_contols pushBack _ctrlSettingPreview;
+private _ctrlSettingPreview = _display ctrlCreate ["RscText", count _controls + IDC_OFFSET_SETTING, _ctrlOptionsGroup];
+_controls pushBack _ctrlSettingPreview;
 
 _ctrlSettingPreview ctrlSetPosition [
     POS_W(9.5),
@@ -28,8 +28,8 @@ _ctrlSettingPreview setVariable [QGVAR(data), _data];
 _linkedControls append [_ctrlSettingPreview, []];
 
 for "_index" from 0 to (((count _defaultValue max 3) min 4) - 1) do {
-    private _ctrlSetting = _display ctrlCreate [SLIDER_TYPES param [_index, "RscXSliderH"], count _contols + IDC_OFFSET_SETTING, _ctrlOptionsGroup];
-    _contols pushBack _ctrlSetting;
+    private _ctrlSetting = _display ctrlCreate [SLIDER_TYPES param [_index, "RscXSliderH"], count _controls + IDC_OFFSET_SETTING, _ctrlOptionsGroup];
+    _controls pushBack _ctrlSetting;
 
     _ctrlSetting ctrlSetPosition [
         POS_W(16),
@@ -60,10 +60,15 @@ for "_index" from 0 to (((count _defaultValue max 3) min 4) - 1) do {
         _color set [_index, _value];
         _ctrlSettingPreview ctrlSetBackgroundColor _color;
         SET_TEMP_NAMESPACE_VALUE(_setting,_currentValue,_source);
+
+        //If new setting is same as default value, grey out the default button
+        (_control getVariable QGVAR(linkedControls)) params ["", "", "_defaultControl"];
+        (_defaultControl getVariable QGVAR(data)) params ["", "", "_defaultValue"];
+        _defaultControl ctrlEnable (!(_currentValue isEqualTo _defaultValue));
     }];
 
-    private _ctrlSettingEdit = _display ctrlCreate ["RscEdit", count _contols + IDC_OFFSET_SETTING, _ctrlOptionsGroup];
-    _contols pushBack _ctrlSettingEdit;
+    private _ctrlSettingEdit = _display ctrlCreate ["RscEdit", count _controls + IDC_OFFSET_SETTING, _ctrlOptionsGroup];
+    _controls pushBack _ctrlSettingEdit;
 
     _ctrlSettingEdit ctrlSetPosition [
         POS_W(24),
@@ -98,6 +103,11 @@ for "_index" from 0 to (((count _defaultValue max 3) min 4) - 1) do {
         _color set [_index, _value];
         _ctrlSettingPreview ctrlSetBackgroundColor _color;
         SET_TEMP_NAMESPACE_VALUE(_setting,_currentValue,_source);
+
+        //If new setting is same as default value, grey out the default button
+        (_control getVariable QGVAR(linkedControls)) params ["", "", "_defaultControl"];
+        (_defaultControl getVariable QGVAR(data)) params ["", "", "_defaultValue"];
+        _defaultControl ctrlEnable (!(_currentValue isEqualTo _defaultValue));
     }];
 
     _ctrlSettingEdit ctrlAddEventHandler ["KillFocus", {

--- a/addons/settings/gui_createMenu_color.sqf
+++ b/addons/settings/gui_createMenu_color.sqf
@@ -52,7 +52,7 @@ for "_index" from 0 to (((count _defaultValue max 3) min 4) - 1) do {
         (_control getVariable QGVAR(data)) params ["_setting", "_source", "_currentValue", "_color"];
         private _index = _control getVariable QGVAR(index);
 
-        (_control getVariable QGVAR(linkedControls)) params ["_ctrlSettingPreview", "_linkedControls"];
+        (_control getVariable QGVAR(linkedControls)) params ["_ctrlSettingPreview", "_linkedControls", "_defaultControl"];
         private _linkedControl = _linkedControls select _index select 1;
         _linkedControl ctrlSetText ([_value, 1, 2] call CBA_fnc_formatNumber);
 
@@ -62,7 +62,6 @@ for "_index" from 0 to (((count _defaultValue max 3) min 4) - 1) do {
         SET_TEMP_NAMESPACE_VALUE(_setting,_currentValue,_source);
 
         //If new setting is same as default value, grey out the default button
-        (_control getVariable QGVAR(linkedControls)) params ["", "", "_defaultControl"];
         (_defaultControl getVariable QGVAR(data)) params ["", "", "_defaultValue"];
         _defaultControl ctrlEnable (!(_currentValue isEqualTo _defaultValue));
     }];
@@ -94,7 +93,7 @@ for "_index" from 0 to (((count _defaultValue max 3) min 4) - 1) do {
         (_control getVariable QGVAR(data)) params ["_setting", "_source", "_currentValue", "_color"];
         private _index = _control getVariable QGVAR(index);
 
-        (_control getVariable QGVAR(linkedControls)) params ["_ctrlSettingPreview", "_linkedControls"];
+        (_control getVariable QGVAR(linkedControls)) params ["_ctrlSettingPreview", "_linkedControls", "_defaultControl"];
 
         private _linkedControl = _linkedControls select _index select 0;
         _linkedControl sliderSetPosition _value;
@@ -105,7 +104,6 @@ for "_index" from 0 to (((count _defaultValue max 3) min 4) - 1) do {
         SET_TEMP_NAMESPACE_VALUE(_setting,_currentValue,_source);
 
         //If new setting is same as default value, grey out the default button
-        (_control getVariable QGVAR(linkedControls)) params ["", "", "_defaultControl"];
         (_defaultControl getVariable QGVAR(data)) params ["", "", "_defaultValue"];
         _defaultControl ctrlEnable (!(_currentValue isEqualTo _defaultValue));
     }];

--- a/addons/settings/gui_createMenu_default.sqf
+++ b/addons/settings/gui_createMenu_default.sqf
@@ -23,6 +23,7 @@ _ctrlSettingDefault ctrlAddEventHandler ["ButtonClick", {
     (_control getVariable QGVAR(data)) params ["_setting", "_source", "_defaultValue", "_settingType", "_settingData"];
     SET_TEMP_NAMESPACE_VALUE(_setting,_defaultValue,_source);
 
+    // Can disable button as the setting will now be the default
     _control ctrlEnable false;
 
     private _linkedControls = _control getVariable QGVAR(linkedControls);

--- a/addons/settings/gui_createMenu_default.sqf
+++ b/addons/settings/gui_createMenu_default.sqf
@@ -1,7 +1,7 @@
 // inline function, don't include script_component.hpp
 
-private _ctrlSettingDefault = _display ctrlCreate ["RscButtonMenu", count _contols + IDC_OFFSET_SETTING, _ctrlOptionsGroup];
-_contols pushBack _ctrlSettingDefault;
+private _ctrlSettingDefault = _display ctrlCreate ["RscButtonMenu", count _controls + IDC_OFFSET_SETTING, _ctrlOptionsGroup];
+_controls pushBack _ctrlSettingDefault;
 
 _ctrlSettingDefault ctrlSetPosition [
     POS_W(27),
@@ -22,6 +22,8 @@ _ctrlSettingDefault ctrlAddEventHandler ["ButtonClick", {
 
     (_control getVariable QGVAR(data)) params ["_setting", "_source", "_defaultValue", "_settingType", "_settingData"];
     SET_TEMP_NAMESPACE_VALUE(_setting,_defaultValue,_source);
+
+    _control ctrlEnable false;
 
     private _linkedControls = _control getVariable QGVAR(linkedControls);
 
@@ -71,6 +73,6 @@ _ctrlSettingDefault ctrlAddEventHandler ["ButtonClick", {
 
 _linkedControls pushBack _ctrlSettingDefault;
 
-if !(_enabled) then {
+if ((!_enabled) || {_currentValue isEqualTo _defaultValue}) then {
     _ctrlSettingDefault ctrlEnable false;
 };

--- a/addons/settings/gui_createMenu_force.sqf
+++ b/addons/settings/gui_createMenu_force.sqf
@@ -1,7 +1,7 @@
 // inline function, don't include script_component.hpp
 
-private _ctrlSettingForce = _display ctrlCreate ["RscCheckBox", count _contols + IDC_OFFSET_SETTING, _ctrlOptionsGroup];
-_contols pushBack _ctrlSettingForce;
+private _ctrlSettingForce = _display ctrlCreate ["RscCheckBox", count _controls + IDC_OFFSET_SETTING, _ctrlOptionsGroup];
+_controls pushBack _ctrlSettingForce;
 
 _ctrlSettingForce ctrlSetPosition [
     POS_W(33),

--- a/addons/settings/gui_createMenu_list.sqf
+++ b/addons/settings/gui_createMenu_list.sqf
@@ -1,7 +1,7 @@
 // inline function, don't include script_component.hpp
 
-private _ctrlSetting = _display ctrlCreate ["RscCombo", count _contols + IDC_OFFSET_SETTING, _ctrlOptionsGroup];
-_contols pushBack _ctrlSetting;
+private _ctrlSetting = _display ctrlCreate ["RscCombo", count _controls + IDC_OFFSET_SETTING, _ctrlOptionsGroup];
+_controls pushBack _ctrlSetting;
 
 _ctrlSetting ctrlSetPosition [
     POS_W(16),
@@ -39,6 +39,11 @@ _ctrlSetting ctrlAddEventHandler ["LBSelChanged", {
 
     private _value = _data select _index;
     SET_TEMP_NAMESPACE_VALUE(_setting,_value,_source);
+
+    //If new setting is same as default value, grey out the default button
+    (_control getVariable QGVAR(linkedControls)) params ["", "_defaultControl"];
+    (_defaultControl getVariable QGVAR(data)) params ["", "", "_defaultValue"];
+    _defaultControl ctrlEnable (!(_value isEqualTo _defaultValue));
 }];
 
 _linkedControls pushBack _ctrlSetting;

--- a/addons/settings/gui_createMenu_slider.sqf
+++ b/addons/settings/gui_createMenu_slider.sqf
@@ -1,7 +1,7 @@
 // inline function, don't include script_component.hpp
 
-private _ctrlSetting = _display ctrlCreate ["RscXSliderH", count _contols + IDC_OFFSET_SETTING, _ctrlOptionsGroup];
-_contols pushBack _ctrlSetting;
+private _ctrlSetting = _display ctrlCreate ["RscXSliderH", count _controls + IDC_OFFSET_SETTING, _ctrlOptionsGroup];
+_controls pushBack _ctrlSetting;
 
 _ctrlSetting ctrlSetPosition [
     POS_W(16),
@@ -30,10 +30,15 @@ _ctrlSetting ctrlAddEventHandler ["SliderPosChanged", {
     _linkedControl ctrlSetText ([_value, 1, _trailingDecimals] call CBA_fnc_formatNumber);
 
     SET_TEMP_NAMESPACE_VALUE(_setting,_value,_source);
+    
+    //If new setting is same as default value, grey out the default button
+    (_control getVariable QGVAR(linkedControls)) params ["", "", "_defaultControl"];
+    (_defaultControl getVariable QGVAR(data)) params ["", "", "_defaultValue"];
+    _defaultControl ctrlEnable (!(_value isEqualTo _defaultValue));
 }];
 
-private _ctrlSettingEdit = _display ctrlCreate ["RscEdit", count _contols + IDC_OFFSET_SETTING, _ctrlOptionsGroup];
-_contols pushBack _ctrlSettingEdit;
+private _ctrlSettingEdit = _display ctrlCreate ["RscEdit", count _controls + IDC_OFFSET_SETTING, _ctrlOptionsGroup];
+_controls pushBack _ctrlSettingEdit;
 
 _ctrlSettingEdit ctrlSetPosition [
     POS_W(24),
@@ -59,6 +64,11 @@ _ctrlSettingEdit ctrlAddEventHandler ["KeyUp", {
 
     _value = sliderPosition _linkedControl;
     SET_TEMP_NAMESPACE_VALUE(_setting,_value,_source);
+
+    //If new setting is same as default value, grey out the default button
+    (_control getVariable QGVAR(linkedControls)) params ["", "", "_defaultControl"];
+    (_defaultControl getVariable QGVAR(data)) params ["", "", "_defaultValue"];
+    _defaultControl ctrlEnable (!(_value isEqualTo _defaultValue));
 }];
 
 _ctrlSettingEdit ctrlAddEventHandler ["KillFocus", {

--- a/addons/settings/gui_createMenu_slider.sqf
+++ b/addons/settings/gui_createMenu_slider.sqf
@@ -26,13 +26,12 @@ _ctrlSetting ctrlAddEventHandler ["SliderPosChanged", {
 
     (_control getVariable QGVAR(data)) params ["_setting", "_source", "_trailingDecimals"];
 
-    private _linkedControl = _control getVariable QGVAR(linkedControls) select 1;
+    (_control getVariable QGVAR(linkedControls)) params ["", "_linkedControl", "_defaultControl"];
     _linkedControl ctrlSetText ([_value, 1, _trailingDecimals] call CBA_fnc_formatNumber);
 
     SET_TEMP_NAMESPACE_VALUE(_setting,_value,_source);
     
     //If new setting is same as default value, grey out the default button
-    (_control getVariable QGVAR(linkedControls)) params ["", "", "_defaultControl"];
     (_defaultControl getVariable QGVAR(data)) params ["", "", "_defaultValue"];
     _defaultControl ctrlEnable (!(_value isEqualTo _defaultValue));
 }];
@@ -59,14 +58,13 @@ _ctrlSettingEdit ctrlAddEventHandler ["KeyUp", {
 
     private _value = parseNumber ctrlText _control;
 
-    private _linkedControl = _control getVariable QGVAR(linkedControls) select 0;
+    (_control getVariable QGVAR(linkedControls)) params ["_linkedControl", "", "_defaultControl"];
     _linkedControl sliderSetPosition _value;
 
     _value = sliderPosition _linkedControl;
     SET_TEMP_NAMESPACE_VALUE(_setting,_value,_source);
 
     //If new setting is same as default value, grey out the default button
-    (_control getVariable QGVAR(linkedControls)) params ["", "", "_defaultControl"];
     (_defaultControl getVariable QGVAR(data)) params ["", "", "_defaultValue"];
     _defaultControl ctrlEnable (!(_value isEqualTo _defaultValue));
 }];

--- a/addons/settings/gui_initDisplay.sqf
+++ b/addons/settings/gui_initDisplay.sqf
@@ -65,24 +65,27 @@ _ctrlButtonLoad ctrlEnable false;
 _ctrlButtonLoad ctrlShow false;
 _ctrlButtonLoad ctrlAddEventHandler ["ButtonClick", {[ctrlParent (_this select 0), "load"] call FUNC(gui_preset)}];
 
-// ----- create export and import buttons
-private _ctrlButtonImport = _display ctrlCreate ["RscButtonMenu", IDC_BTN_IMPORT];
+// copyFromClipboard has no effect in MP, so only add button in SP
+if (!isMultiplayer) then {
+    // ----- create export and import buttons
+    private _ctrlButtonImport = _display ctrlCreate ["RscButtonMenu", IDC_BTN_IMPORT];
 
-_ctrlButtonImport ctrlSetPosition [
-    POS_X(24.4),
-    POS_Y(20.5),
-    POS_W(6),
-    POS_H(1)
-];
+    _ctrlButtonImport ctrlSetPosition [
+        POS_X(24.4),
+        POS_Y(20.5),
+        POS_W(6),
+        POS_H(1)
+    ];
 
-_ctrlButtonImport ctrlCommit 0;
-_ctrlButtonImport ctrlSetText localize LSTRING(ButtonImport);
-_ctrlButtonImport ctrlSetTooltip localize LSTRING(ButtonImport_tooltip);
-_ctrlButtonImport ctrlEnable false;
-_ctrlButtonImport ctrlShow false;
-_ctrlButtonImport ctrlAddEventHandler ["ButtonClick", {[copyFromClipboard, uiNamespace getVariable QGVAR(source)] call FUNC(import)}];
+    _ctrlButtonImport ctrlCommit 0;
+    _ctrlButtonImport ctrlSetText localize LSTRING(ButtonImport);
+    _ctrlButtonImport ctrlSetTooltip localize LSTRING(ButtonImport_tooltip);
+    _ctrlButtonImport ctrlEnable false;
+    _ctrlButtonImport ctrlShow false;
+    _ctrlButtonImport ctrlAddEventHandler ["ButtonClick", {[copyFromClipboard, uiNamespace getVariable QGVAR(source)] call FUNC(import)}];
 
-uiNamespace setVariable [QGVAR(ctrlButtonImport), _ctrlButtonImport];
+    uiNamespace setVariable [QGVAR(ctrlButtonImport), _ctrlButtonImport];
+};
 
 private _ctrlButtonExport = _display ctrlCreate ["RscButtonMenu", IDC_BTN_EXPORT];
 


### PR DESCRIPTION
For CBA Settings, this will grey-out (`ctrlEnabled false`) the button for default settings if the setting is already set to the default value

I think this will make it easier to find settings that have been changed and easier to get all settings back to default.

Quick demo: https://www.youtube.com/watch?v=A90L1dy9dXE

Also disabled the Import button when in multiplayer as it did not work.