### PR TITLE
Update xeh macros

### DIFF
--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -1528,6 +1528,7 @@ Author:
 
 // XEH Specific
 #define XEH_CLASS CBA_Extended_EventHandlers
+#define XEH_CLASS_BASE DOUBLES(XEH_CLASS,base)
 #define XEH_DISABLED class EventHandlers { class XEH_CLASS {}; }; SLX_XEH_DISABLED = 1
 #define XEH_ENABLED class EventHandlers { class XEH_CLASS { EXTENDED_EVENTHANDLERS }; }; SLX_XEH_DISABLED = 0
 

--- a/addons/xeh/CfgEventHandlers.hpp
+++ b/addons/xeh/CfgEventHandlers.hpp
@@ -1,12 +1,12 @@
 
-class DOUBLES(XEH_CLASS,base) {
+class XEH_CLASS_BASE {
     EXTENDED_EVENTHANDLERS
 };
 
-class XEH_CLASS: DOUBLES(XEH_CLASS,base) {}; // bwc
+class XEH_CLASS: XEH_CLASS_BASE {}; // bwc
 
 class DefaultEventhandlers {
-    class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
+    class XEH_CLASS: XEH_CLASS_BASE {};
 };
 
 // The PreStart handlers run once when the game is started

--- a/addons/xeh/CfgVehicles.hpp
+++ b/addons/xeh/CfgVehicles.hpp
@@ -155,85 +155,85 @@ class CfgVehicles {
     };
     class Land_Pod_Heli_Transport_04_ammo_F: Pod_Heli_Transport_04_base_F {
         class EventHandlers: EventHandlers {
-            class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
+            class XEH_CLASS: XEH_CLASS_BASE {};
         };
     };
 
     class Land_Pod_Heli_Transport_04_bench_F: Pod_Heli_Transport_04_crewed_base_F {
         class EventHandlers: EventHandlers {
-            class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
+            class XEH_CLASS: XEH_CLASS_BASE {};
         };
     };
 
     class Land_Pod_Heli_Transport_04_box_F: Pod_Heli_Transport_04_base_F {
         class EventHandlers: EventHandlers {
-            class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
+            class XEH_CLASS: XEH_CLASS_BASE {};
         };
     };
 
     class Land_Pod_Heli_Transport_04_covered_F: Pod_Heli_Transport_04_crewed_base_F {
         class EventHandlers: EventHandlers {
-            class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
+            class XEH_CLASS: XEH_CLASS_BASE {};
         };
     };
 
     class Land_Pod_Heli_Transport_04_fuel_F: Pod_Heli_Transport_04_base_F {
         class EventHandlers: EventHandlers {
-            class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
+            class XEH_CLASS: XEH_CLASS_BASE {};
         };
     };
 
     class Land_Pod_Heli_Transport_04_medevac_F: Pod_Heli_Transport_04_crewed_base_F {
         class EventHandlers: EventHandlers {
-            class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
+            class XEH_CLASS: XEH_CLASS_BASE {};
         };
     };
 
     class Land_Pod_Heli_Transport_04_repair_F: Pod_Heli_Transport_04_base_F {
         class EventHandlers: EventHandlers {
-            class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
+            class XEH_CLASS: XEH_CLASS_BASE {};
         };
     };
 
     class Land_Pod_Heli_Transport_04_ammo_black_F: Land_Pod_Heli_Transport_04_ammo_F {
         class EventHandlers: EventHandlers {
-            class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
+            class XEH_CLASS: XEH_CLASS_BASE {};
         };
     };
 
     class Land_Pod_Heli_Transport_04_bench_black_F: Land_Pod_Heli_Transport_04_bench_F {
         class EventHandlers: EventHandlers {
-            class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
+            class XEH_CLASS: XEH_CLASS_BASE {};
         };
     };
 
     class Land_Pod_Heli_Transport_04_box_black_F: Land_Pod_Heli_Transport_04_box_F {
         class EventHandlers: EventHandlers {
-            class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
+            class XEH_CLASS: XEH_CLASS_BASE {};
         };
     };
 
     class Land_Pod_Heli_Transport_04_covered_black_F: Land_Pod_Heli_Transport_04_covered_F {
         class EventHandlers: EventHandlers {
-            class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
+            class XEH_CLASS: XEH_CLASS_BASE {};
         };
     };
 
     class Land_Pod_Heli_Transport_04_fuel_black_F: Land_Pod_Heli_Transport_04_fuel_F {
         class EventHandlers: EventHandlers {
-            class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
+            class XEH_CLASS: XEH_CLASS_BASE {};
         };
     };
 
     class Land_Pod_Heli_Transport_04_medevac_black_F: Land_Pod_Heli_Transport_04_medevac_F {
         class EventHandlers: EventHandlers {
-            class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
+            class XEH_CLASS: XEH_CLASS_BASE {};
         };
     };
 
     class Land_Pod_Heli_Transport_04_repair_black_F: Land_Pod_Heli_Transport_04_repair_F {
         class EventHandlers: EventHandlers {
-            class XEH_CLASS: DOUBLES(XEH_CLASS,base) {};
+            class XEH_CLASS: XEH_CLASS_BASE {};
         };
     };
 

--- a/addons/xeh/script_component.hpp
+++ b/addons/xeh/script_component.hpp
@@ -41,7 +41,7 @@
 #define XEH_MAIN_CONFIGS [configFile, campaignConfigFile, missionConfigFile]
 
 #undef XEH_ENABLED
-#define XEH_ENABLED class EventHandlers { class XEH_CLASS: XEH_CLASS {}; }; SLX_XEH_DISABLED = 0
+#define XEH_ENABLED class EventHandlers { class XEH_CLASS: XEH_CLASS_BASE {}; }; SLX_XEH_DISABLED = 0
 
 #define XEH_EVENTS \
     "AnimChanged", \


### PR DESCRIPTION
**When merged this pull request will:**
- adds a easier to read `XEH_CLASS_BASE` macro (== `DOUBLES(XEH_CLASS,base)`)
- uses that for `XEH_ENABLED` in xeh component
- see conversation slack