### PR TITLE
Add function to filter hashes

### DIFF
--- a/addons/hashes/CfgFunctions.hpp
+++ b/addons/hashes/CfgFunctions.hpp
@@ -23,7 +23,7 @@ class CfgFunctions
             };
             class hashFilter
             {
-                description = "Iterate through all keys and values in a Hash. Code must return a bool, if true then key is removed";
+                description = "Iterate through all keys and values in a Hash. Code must return a bool, if false then key is removed";
                 file = "\x\cba\addons\hashes\fnc_hashFilter.sqf";
             };
             // CBA_fnc_hashGet

--- a/addons/hashes/CfgFunctions.hpp
+++ b/addons/hashes/CfgFunctions.hpp
@@ -21,6 +21,11 @@ class CfgFunctions
                 description = "Iterate through all keys and values in a Hash.";
                 file = "\x\cba\addons\hashes\fnc_hashEachPair.sqf";
             };
+            class hashFilter
+            {
+                description = "Iterate through all keys and values in a Hash. Code must return a bool, if true then key is removed";
+                file = "\x\cba\addons\hashes\fnc_hashFilter.sqf";
+            };
             // CBA_fnc_hashGet
             class hashGet
             {

--- a/addons/hashes/fnc_hashFilter.sqf
+++ b/addons/hashes/fnc_hashFilter.sqf
@@ -3,7 +3,7 @@ Function: CBA_fnc_hashFilter
 
 Description:
     Iterate through all keys and values in a Hash.
-    If function returns true, the key is removed from the hash.
+    If function returns false, the key is removed from the hash (just like `[] select {}`)
 
     Data passed to the function on each iteration,
     * _key - Key from the Hash.
@@ -13,7 +13,7 @@ Description:
 
 Parameters:
     _hash - Hash to iterate [Array which is a Hash structure]
-    _code - Function to call with each pair which returns a bool (true will remove key from hash) [Code]
+    _code - Function to call with each pair which returns a bool (false will remove key from hash) [Code]
 
 Returns:
     Number of removed entrys [Number]
@@ -23,7 +23,7 @@ Example:
     _hash = [[["A1", 1], ["A2", 1], ["B", 2], ["C", 3], ["D1", 4], ["D2", 4], ["E1", 5], ["E2", 5]]] call CBA_fnc_hashCreate;
     _removeOddValues = {
         diag_log format ["Key: %1, Value: %2", _key, _value];
-        ((_value % 2) == 1)
+        ((_value % 2) == 0)
     };
     _removedCount = [_hash, _removeOddValues] call CBA_fnc_hashFilter;
     (end)
@@ -48,7 +48,7 @@ private _removedKeys = 0;
     private _key = _x;
     private _index = _forEachIndex - _removedKeys;
     private _value = _values select _index;
-    if (call _code) then { // If code returns true, delete the key/value from hash
+    if (!(call _code)) then { // If code returns false, delete the key/value from hash
         _keys deleteAt _index;
         _values deleteAt _index;
         _removedKeys = _removedKeys + 1;

--- a/addons/hashes/fnc_hashFilter.sqf
+++ b/addons/hashes/fnc_hashFilter.sqf
@@ -1,0 +1,59 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_hashFilter
+
+Description:
+    Iterate through all keys and values in a Hash.
+    If function returns true, the key is removed from the hash.
+
+    Data passed to the function on each iteration,
+    * _key - Key from the Hash.
+    * _value - The value from the Hash corresponding to _key.
+
+    See <CBA_fnc_hashCreate>.
+
+Parameters:
+    _hash - Hash to iterate [Array which is a Hash structure]
+    _code - Function to call with each pair which returns a bool (true will remove key from hash) [Code]
+
+Returns:
+    Number of removed entrys [Number]
+
+Example:
+    (begin example)
+    _hash = [[["A1", 1], ["A2", 1], ["B", 2], ["C", 3], ["D1", 4], ["D2", 4], ["E1", 5], ["E2", 5]]] call CBA_fnc_hashCreate;
+    _removeOddValues = {
+        diag_log format ["Key: %1, Value: %2", _key, _value];
+        ((_value % 2) == 1)
+    };
+    _removedCount = [_hash, _removeOddValues] call CBA_fnc_hashFilter;
+    (end)
+
+Author:
+    PabstMirror
+---------------------------------------------------------------------------- */
+//#define DEBUG_MODE_FULL
+#include "script_component.hpp"
+#include "script_hashes.hpp"
+
+SCRIPT(hashFilter);
+
+// -----------------------------------------------------------------------------
+params [["_hash", [], [[]]], ["_code", {}, [{}]]];
+
+_hash params ["", "_keys", "_values"];
+
+private _removedKeys = 0;
+
+{
+    private _key = _x;
+    private _index = _forEachIndex - _removedKeys;
+    private _value = _values select _index;
+    if (call _code) then { // If code returns true, delete the key/value from hash
+        _keys deleteAt _index;
+        _values deleteAt _index;
+        _removedKeys = _removedKeys + 1;
+    };
+    nil
+} forEach +_keys; // Create copy of _keys as the original can be modified during iteration
+
+_removedKeys // Return.

--- a/addons/hashes/test.sqf
+++ b/addons/hashes/test.sqf
@@ -5,7 +5,7 @@
 #define DEBUG_MODE_FULL
 #include "script_component.hpp"
 
-#define TESTS ["hashEachPair", "hashes", "parseYaml"]
+#define TESTS ["hashEachPair", "hashes", "parseYaml", "hashFilter"]
 
 SCRIPT(test-hashes);
 

--- a/addons/hashes/test_hashFilter.sqf
+++ b/addons/hashes/test_hashFilter.sqf
@@ -24,7 +24,7 @@ _totalIterations = 0;
     ADD(_sumKeys,_key);
     ADD(_sumValues,_value);
     INC(_totalIterations);
-    false
+    true
 }] call CBA_fnc_hashFilter;
 
 _expected = 6;
@@ -43,7 +43,7 @@ _totalIterations = 0;
 _removeOddValues = {
     ADD(_sumValues,_value);
     INC(_totalIterations);
-    ((_value % 2) == 1)
+    ((_value % 2) == 0)
 };
 _ret = [_hash, _removeOddValues] call CBA_fnc_hashFilter;
 

--- a/addons/hashes/test_hashFilter.sqf
+++ b/addons/hashes/test_hashFilter.sqf
@@ -1,0 +1,60 @@
+// ----------------------------------------------------------------------------
+#define DEBUG_MODE_FULL
+#include "script_component.hpp"
+
+SCRIPT(test_hashFilter);
+
+// ----------------------------------------------------------------------------
+
+private ["_hash", "_expected", "_sumKeys", "_sumValues", "_totalIterations", "_removeOddValues"];
+
+_fn = "CBA_fnc_hashFilter";
+LOG("Testing " + _fn);
+
+TEST_DEFINED("CBA_fnc_hashFilter","");
+
+_hash = [[[1, 12], [5, 25]], 88] call CBA_fnc_hashCreate;
+
+_sumKeys = 0;
+_sumValues = 0;
+_totalIterations = 0;
+
+[_hash,
+{
+    ADD(_sumKeys,_key);
+    ADD(_sumValues,_value);
+    INC(_totalIterations);
+    false
+}] call CBA_fnc_hashFilter;
+
+_expected = 6;
+TEST_OP(_sumKeys,==,_expected,"");
+_expected = 37;
+TEST_OP(_sumValues,==,_expected,"");
+_expected = 2;
+TEST_OP(_totalIterations,==,_expected,"");
+
+
+_hash = [[["A1", 1], ["A2", 1], ["B", 2], ["C", 3], ["D1", 4], ["D2", 4], ["E1", 5], ["E2", 5]]] call CBA_fnc_hashCreate;
+
+_sumValues = 0;
+_totalIterations = 0;
+
+_removeOddValues = {
+    ADD(_sumValues,_value);
+    INC(_totalIterations);
+    ((_value % 2) == 1)
+};
+_ret = [_hash, _removeOddValues] call CBA_fnc_hashFilter;
+
+_expected = 5;
+TEST_OP(_ret,isEqualTo,_expected,"");
+_expected = ["B", "D1", "D2"];
+TEST_OP(_hash select 1,isEqualTo,_expected,"");
+_expected = [2, 4, 4];
+TEST_OP(_hash select 2,isEqualTo,_expected,"");
+_expected = 25;
+TEST_OP(_sumValues,==,_expected,"");
+_expected = 8;
+TEST_OP(_totalIterations,==,_expected,"");
+


### PR DESCRIPTION
CBA_fnc_hashEachPair fails when removing keys from within the loop.

```
theHash = [[["aa", 11], ["bb", 22], ["cc", 33], ["dd", 44], ["ee", 55], ["ff", 66]]] call CBA_fnc_hashCreate;  
_dumpHash = { 
    diag_log format ["Key: %1, Value: %2", _key, _value]; 
    [theHash, _key] call CBA_fnc_hashRem; 
};
[theHash, _dumpHash] call CBA_fnc_hashEachPair; 
```
"Key: aa, Value: 11"
"Key: cc, Value: 33"
"Key: ee, Value: 55"
theHash = ["#CBA_HASH#",["bb","dd","ff"],[22,44,66],any]

We could replace instead of creating a new function, but the new version is a bit slower than the old one.

Ref: https://github.com/acemod/ACE3/pull/4171
