### PR TITLE
add optional pbo to load settings from userconfig file

### DIFF
--- a/addons/settings/fnc_import.sqf
+++ b/addons/settings/fnc_import.sqf
@@ -27,4 +27,6 @@ _info = _info call FUNC(parse);
     SET_TEMP_NAMESPACE_FORCED(_setting,_force,_source);
 } forEach _info;
 
-call FUNC(gui_refresh);
+if (!isNull (uiNamespace getVariable [QGVAR(display), displayNull])) then {
+    call FUNC(gui_refresh);
+};

--- a/optionals/auto_load_settings_file/$PBOPREFIX$
+++ b/optionals/auto_load_settings_file/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\cba\addons\auto_load_settings_file

--- a/optionals/auto_load_settings_file/CfgEventHandlers.hpp
+++ b/optionals/auto_load_settings_file/CfgEventHandlers.hpp
@@ -1,0 +1,6 @@
+
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};

--- a/optionals/auto_load_settings_file/XEH_preInit.sqf
+++ b/optionals/auto_load_settings_file/XEH_preInit.sqf
@@ -1,0 +1,12 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+// frame after preInit, but before postInit
+0 spawn {
+    {
+        #include "loadSettingsFile.sqf"
+    } call CBA_fnc_directCall;
+};
+
+ADDON = true;

--- a/optionals/auto_load_settings_file/config.cpp
+++ b/optionals/auto_load_settings_file/config.cpp
@@ -1,0 +1,17 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        author = "$STR_CBA_Author";
+        name = ECSTRING(settings,component);
+        url = "$STR_CBA_URL";
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"cba_settings"};
+        version = VERSION;
+        authors[] = {"commy2"};
+    };
+};
+
+#include "CfgEventHandlers.hpp"

--- a/optionals/auto_load_settings_file/loadSettingsFile.sqf
+++ b/optionals/auto_load_settings_file/loadSettingsFile.sqf
@@ -1,0 +1,9 @@
+
+if (isFilePatchingEnabled) then {
+	private _source = ["client", "server"] select (isMultiplayer && isServer);
+
+    [loadFile PATH_SETTINGS_FILE, _source] call FUNC(import);
+    diag_log text "[CBA] (settings): Settings file loaded.";
+} else {
+    diag_log text "[CBA] (settings): Cannot load settings file. File patching disabled. Use -filePatching flag.";
+};

--- a/optionals/auto_load_settings_file/loadSettingsFile.sqf
+++ b/optionals/auto_load_settings_file/loadSettingsFile.sqf
@@ -4,7 +4,7 @@ if (isFilePatchingEnabled) then {
     private _file = loadFile PATH_SETTINGS_FILE;
 
     if (_file != "") then {
-        [_file, _source] call FUNC(import);
+        [_file, _source] call EFUNC(settings,import);
         diag_log text "[CBA] (settings): Settings file loaded.";
     } else {
         diag_log text "[CBA] (settings): Settings file not loaded. File empty or does not exist.";

--- a/optionals/auto_load_settings_file/loadSettingsFile.sqf
+++ b/optionals/auto_load_settings_file/loadSettingsFile.sqf
@@ -1,9 +1,14 @@
 
 if (isFilePatchingEnabled) then {
-	private _source = ["client", "server"] select (isMultiplayer && isServer);
+    private _source = ["client", "server"] select (isMultiplayer && isServer);
+    private _file = loadFile PATH_SETTINGS_FILE;
 
-    [loadFile PATH_SETTINGS_FILE, _source] call FUNC(import);
-    diag_log text "[CBA] (settings): Settings file loaded.";
+    if (_file != "") then {
+        [_file, _source] call FUNC(import);
+        diag_log text "[CBA] (settings): Settings file loaded.";
+    } else {
+        diag_log text "[CBA] (settings): Settings file not loaded. File empty or does not exist.";
+    };
 } else {
     diag_log text "[CBA] (settings): Cannot load settings file. File patching disabled. Use -filePatching flag.";
 };

--- a/optionals/auto_load_settings_file/script_component.hpp
+++ b/optionals/auto_load_settings_file/script_component.hpp
@@ -1,0 +1,16 @@
+#define COMPONENT auto_load_settings_file
+#include "\x\cba\addons\main\script_mod.hpp"
+
+//#define DEBUG_ENABLED_AUTO_LOAD_SETTINGS_FILE
+
+#ifdef DEBUG_ENABLED_AUTO_LOAD_SETTINGS_FILE
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_AUTO_LOAD_SETTINGS_FILE
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_AUTO_LOAD_SETTINGS_FILE
+#endif
+
+#include "\x\cba\addons\main\script_macros.hpp"
+
+#define PATH_SETTINGS_FILE "userconfig\cba\settings.sqf"


### PR DESCRIPTION
- Adds optional PBO that auto loads settings from a settings file
- Can be used on dedicated servers to have settings that not have to be set via gui (e.g. when the mod is only server side and the settings wouldn't show up for the clients)

`userconfig\cba\settings.sqf`

