### PR TITLE
Make validation scripts work with Python 2

### DIFF
--- a/tools/config_style_checker.py
+++ b/tools/config_style_checker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import fnmatch
 import os
@@ -6,6 +6,10 @@ import re
 import ntpath
 import sys
 import argparse
+
+if sys.version_info.major == 2
+    import codecs
+    open = codecs.open
 
 def check_config_style(filepath):
     bad_count_file = 0

--- a/tools/config_style_checker.py
+++ b/tools/config_style_checker.py
@@ -7,7 +7,7 @@ import ntpath
 import sys
 import argparse
 
-if sys.version_info.major == 2
+if sys.version_info.major == 2:
     import codecs
     open = codecs.open
 

--- a/tools/sqf_validator.py
+++ b/tools/sqf_validator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import fnmatch
 import os
@@ -6,6 +6,10 @@ import re
 import ntpath
 import sys
 import argparse
+
+if sys.version_info.major == 2:
+    import codecs
+    open = codecs.open
 
 def validKeyWordAfterCode(content, index):
     keyWords = ["for", "do", "count", "each", "forEach", "else", "and", "not", "isEqualTo", "in", "call", "spawn", "execVM", "catch", "param", "select", "apply"];


### PR DESCRIPTION
**When merged this pull request will:**

- Make it possible to run the config and sqf validation scripts with Python 2

With Python 2, use the codecs module to read UTF-8 files.