### PR TITLE
Fix default value

### DIFF
--- a/addons/ai/Cfg3DEN.hpp
+++ b/addons/ai/Cfg3DEN.hpp
@@ -9,7 +9,7 @@ class Cfg3DEN {
                         control = QGVAR(Stance);
                         displayName = "$STR_3DEN_Object_Attribute_Stance_displayName";
                         expression = "_this setUnitPos _value";
-                        defaultValue = "false";
+                        defaultValue = "'auto'";
                         wikiType = "[[String]]";
                     };
                 };


### PR DESCRIPTION
Fix default value, so we don't get an extra custom attributes per unit, even when the unit's stance hasn't changed

Helps keep the files size down on large missions/frameworks.