### PR TITLE
add a function to customize preprocessing

### DIFF
--- a/addons/statemachine/fnc_create.sqf
+++ b/addons/statemachine/fnc_create.sqf
@@ -30,6 +30,14 @@ params [
     ["_skipNull", false, [true]]
 ];
 
+#define LOG_TEST(var) QUOTE(#CBA diag_log text str var #\CBA)
+
+LOG_TEST(1);
+
+
+
+
+
 if (isNil QGVAR(stateMachines)) then {
     GVAR(stateMachines) = [];
     GVAR(nextUniqueID) = 0;

--- a/addons/xeh/config.cpp
+++ b/addons/xeh/config.cpp
@@ -29,3 +29,4 @@ class CfgPatches {
 #include "CfgFunctions.hpp"
 
 #include "CfgVehicles.hpp"
+#include "gui.hpp"

--- a/addons/xeh/fnc_compileFunction.sqf
+++ b/addons/xeh/fnc_compileFunction.sqf
@@ -3,6 +3,7 @@ Function: CBA_fnc_compileFunction
 
 Description:
     Compiles a function into mission namespace and into ui namespace for caching purposes.
+
     Recompiling can be enabled by insterting the CBA_cache_disable.pbo from the optionals folder.
 
 Parameters:
@@ -27,11 +28,11 @@ params [["_funcFile", "", [""]], ["_funcName", "", [""]]];
 private _cachedFunc = uiNamespace getVariable _funcName;
 
 if (isNil "_cachedFunc") then {
-    uiNamespace setVariable [_funcName, compileFinal preprocessFileLineNumbers _funcFile];
+    uiNamespace setVariable [_funcName, compileFinal (_funcFile call CBA_fnc_preprocessFunction)];
     missionNamespace setVariable [_funcName, uiNamespace getVariable _funcName];
 } else {
     if (["compile"] call CBA_fnc_isRecompileEnabled) then {
-        missionNamespace setVariable [_funcName, compileFinal preprocessFileLineNumbers _funcFile];
+        missionNamespace setVariable [_funcName, compileFinal (_funcFile call CBA_fnc_preprocessFunction)];
     } else {
         missionNamespace setVariable [_funcName, _cachedFunc];
     };

--- a/addons/xeh/fnc_isRecompileEnabled.sqf
+++ b/addons/xeh/fnc_isRecompileEnabled.sqf
@@ -28,7 +28,7 @@ if (isNil "_return") then {
     private _config = configFile >> "CfgSettings" >> "CBA" >> "caching" >> _compileType;
     private _missionConfig = missionConfigFile >> "CfgSettings" >> "CBA" >> "caching" >> _compileType;
 
-    _return = (isNumber _config && {getNumber _config == 0}) || {isNumber _missionConfig && {getNumber _missionConfig == 0}};
+    _return = (isNumber _config && {getNumber _config == 0}) || {isNumber _missionConfig && {getNumber _missionConfig == 0}} || {uiNamespace getVariable [QGVAR(debugEnabled), false]};
     missionNamespace setVariable [(format [QGVAR(isRecompileEnabled_%1), _compileType]), _return];
 
     // Normally, full caching is enabled. If not, log an informative message.

--- a/addons/xeh/fnc_preInit.sqf
+++ b/addons/xeh/fnc_preInit.sqf
@@ -49,6 +49,11 @@ SLX_XEH_MACHINE = [ // backwards compatibility, deprecated
     3 // 15 - Product+Version, always Arma 3
 ];
 
+CBA_fnc_preprocessFunction = uiNamespace getVariable ([
+    "CBA_fnc_preprocessFunction",
+    "CBA_fnc_preprocessFunction_debug"
+] select (uiNamespace getVariable [QGVAR(debugEnabled), false]));
+
 CBA_isHeadlessClient = !hasInterface && !isDedicated;
 
 // make case insensitive list of all supported events

--- a/addons/xeh/fnc_preStart.sqf
+++ b/addons/xeh/fnc_preStart.sqf
@@ -29,6 +29,9 @@ with uiNamespace do {
     SLX_XEH_COMPILE = compileFinal "compile preprocessFileLineNumbers _this"; //backwards comps
     SLX_XEH_COMPILE_NEW = CBA_fnc_compileFunction; //backwards comp
 
+    CBA_fnc_preprocessFunction = compileFinal preprocessFileLineNumbers QPATHTOF(fnc_preprocessFunction.sqf);
+    CBA_fnc_preprocessFunction_debug = compileFinal preprocessFileLineNumbers QPATHTOF(fnc_preprocessFunction_debug.sqf);
+
     // call PreStart events
     {
         private _eventFunc = "";

--- a/addons/xeh/fnc_preprocessFunction.sqf
+++ b/addons/xeh/fnc_preprocessFunction.sqf
@@ -1,0 +1,40 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_preprocessFunction
+
+Description:
+    Preprocess a function and remove various logging and debug keywords.
+
+Parameters:
+    0: _function - Path to function sqf file <STRING>
+
+Returns:
+    Preprocessed function. <STRING>
+
+Examples:
+    (begin example)
+        [_file] call CBA_fnc_preprocessFunction;
+    (end)
+
+Author:
+    commy2
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+
+params [["_function", "", [""]]];
+
+_function = preprocessFileLineNumbers _function;
+
+private "_startPos";
+
+while {
+    _startPos = _function find """#CBA ";
+    !(_startPos isEqualTo -1)
+} do {
+    private _tail = _function select [_startPos + 6];
+    private _endPos = _tail find " #\CBA""";
+
+    // remove custom macro
+    _function = (_function select [0, _startPos]) + (_tail select [_endPos + 7]);
+};
+
+_function

--- a/addons/xeh/fnc_preprocessFunction_debug.sqf
+++ b/addons/xeh/fnc_preprocessFunction_debug.sqf
@@ -1,0 +1,40 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_preprocessFunction
+
+Description:
+    Preprocess a function and insert various logging and debug code.
+
+Parameters:
+    0: _function - Path to function sqf file <STRING>
+
+Returns:
+    Preprocessed function. <STRING>
+
+Examples:
+    (begin example)
+        [_file] call CBA_fnc_preprocessFunction;
+    (end)
+
+Author:
+    commy2
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+
+params [["_function", "", [""]]];
+
+_function = preprocessFileLineNumbers _function;
+
+private "_startPos";
+
+while {
+    _startPos = _function find """#CBA ";
+    !(_startPos isEqualTo -1)
+} do {
+    private _tail = _function select [_startPos + 6];
+    private _endPos = _tail find " #\CBA""";
+
+    // insert custom macro
+    _function = (_function select [0, _startPos]) + (_tail select [0, _endPos]) + (_tail select [_endPos + 7]);
+};
+
+_function

--- a/addons/xeh/gui.hpp
+++ b/addons/xeh/gui.hpp
@@ -1,0 +1,48 @@
+
+class RscControlsGroup;
+class RscText;
+class RscCheckBox;
+
+class RscDisplayGameOptions {
+    class controls {
+        class GeneralGroup: RscControlsGroup {
+            class controls {
+                class CBA_EnableDebugText: RscText {
+                    style = 1;
+                    idc = IDC_ENABLE_DEBUG_TEXT;
+                    text = "Debug Mode:";
+                    x = 18 * GUI_GRID_W;
+                    y = 16 * GUI_GRID_H;
+                    w = 9.5 * GUI_GRID_W;
+                    h = 1 * GUI_GRID_H;
+                };
+                class CBA_EnableDebugOption: RscCheckBox {
+                    onLoad = QUOTE(\
+                        params ['_control'];\
+                        _control cbSetChecked (uiNamespace getVariable [ARR_2('GVAR(debugEnabled)',false)]);\
+                        private _ctrlBtnOK = ctrlParent _control displayCtrl 999;\
+                        _ctrlBtnOK ctrlAddEventHandler [ARR_2('ButtonClick',{\
+                            params ['_ctrlBtnOK'];\
+                            private _control = ctrlParent _ctrlBtnOK displayCtrl IDC_ENABLE_DEBUG_OPTION;\
+                            private _state = _control getVariable [ARR_2('GVAR(debugEnabled)',false)];\
+                            if (!isNil '_state') then {\
+                                uiNamespace setVariable [ARR_2('GVAR(debugEnabled)',_state)];\
+                            };\
+                        })];\
+                    );
+                    onCheckedChanged = QUOTE(\
+                        params [ARR_2('_control','_state')];\
+                        _state = _state == 1;\
+                        _control setVariable [ARR_2('GVAR(debugEnabled)',_state)];\
+                    );
+                    idc = IDC_ENABLE_DEBUG_OPTION;
+                    x = 29.5 * GUI_GRID_W;
+                    y = 16 * GUI_GRID_H;
+                    w = 1 * GUI_GRID_W;
+                    h = 1 * GUI_GRID_H;
+                    tooltip = "";
+                };
+            };
+        };
+    };
+};

--- a/addons/xeh/script_component.hpp
+++ b/addons/xeh/script_component.hpp
@@ -14,6 +14,8 @@
 
 #include "\x\cba\addons\main\script_macros.hpp"
 
+#include "\a3\ui_f\hpp\defineCommonGrids.inc"
+
 #define XEH_LOG(msg) if (!SLX_XEH_DisableLogging) then { diag_log [diag_frameNo, diag_tickTime, time, msg] }
 
 #define SYS_EVENTHANDLERS(type,class) format [QGVAR(%1:%2), type, class]
@@ -88,3 +90,6 @@
     "WeaponDeployed", \
     "WeaponRested", \
     "Reloaded"
+
+#define IDC_ENABLE_DEBUG_TEXT 110000
+#define IDC_ENABLE_DEBUG_OPTION 110001


### PR DESCRIPTION
experimental

This adds a function to preprocess files, `CBA_fnc_preprocessFile`, which can be used to manually insert or remove debug macros. This way we can add logging to PREP'd functions that have zero overhead after function compile.

Also adds a "DEBUG MODE" option to the Game Options tab
![http://i.imgur.com/1HFProa.png](http://i.imgur.com/1HFProa.png)

- in debug mode, functions will always get recompiled at mission start and the debug version of `CBA_fnc_preprocessFile` is used
- the setting is temporary, so it will reset after game restart

todo:
- make those macros
- security?
