### PR TITLE
align CBA debug/warning/error messages to ACE versions

### DIFF
--- a/addons/diagnostic/config.cpp
+++ b/addons/diagnostic/config.cpp
@@ -17,3 +17,4 @@ class CfgPatches {
 #include "CfgEventHandlers.hpp"
 
 #include "CfgDisplay3DEN.hpp"
+#include "gui.hpp"

--- a/addons/diagnostic/fnc_log.sqf
+++ b/addons/diagnostic/fnc_log.sqf
@@ -1,65 +1,45 @@
 /* ----------------------------------------------------------------------------
-Function: CBA_fnc_log
+Internal Function: CBA_fnc_log
 
 Description:
     Logs a message to the RPT log.
 
     Should not be used directly, but rather via macro (<LOG()>).
-
     This function is unaffected by the debug level (<DEBUG_MODE_x>).
 
 Parameters:
-    _file - File error occurred in [String]
-    _lineNum - Line number error occurred on (starting from 0) [Number]
-    _message - Message [String]
+    _message   - Message <STRING>
 
 Returns:
     nil
 
 Author:
-    Spooner and Rommel
+    Spooner, Rommel, commy2
 -----------------------------------------------------------------------------*/
 #define DEBUG_MODE_NORMAL
 #include "script_component.hpp"
-
 SCRIPT(log);
 
-// ----------------------------------------------------------------------------
+params [["_message", "", [""]]];
 
-#ifndef DEBUG_SYNCHRONOUS
-    if (isNil "CBA_LOG_ARRAY") then { CBA_LOG_ARRAY = [] };
-    private ["_msg"];
-    _msg = [_this select 0, _this select 1, _this select 2, diag_frameNo, diag_tickTime, time]; // Save it here because we want to know when it was happening, not when it is outputted
-    CBA_LOG_ARRAY pushBack _msg;
+if (isNil QGVAR(logArray)) then {
+    GVAR(logArray) = [];
+    GVAR(logScript) = scriptNull;
+};
 
-    if (isNil "CBA_LOG_VAR") then
-    {
-        CBA_LOG_VAR = true;
-        SLX_XEH_STR spawn
-        {
-            _fnc_log =
-            {
-                params ["_file","_lineNum","_message","_frameNo","_tickTime","_gameTime"];
-                // TODO: Add log message to trace log
-                diag_log [_frameNo,
-                    _tickTime, _gameTime, //[_tickTime, "H:MM:SS.mmm"] call CBA_fnc_formatElapsedTime, [_gameTime, "H:MM:SS.mmm"] call CBA_fnc_formatElapsedTime,
-                    _file + ":"+str(_lineNum + 1), _message];
-            };
+GVAR(logArray) pushBack text _message;
 
-            _selected = "";
-            while {_selected = CBA_LOG_ARRAY deleteAt 0; !isNil "_selected"} do
-            {
-                _selected call _fnc_log;
-            };
-            CBA_LOG_VAR = nil;
+if (scriptDone GVAR(logScript)) then {
+    GVAR(logScript) = 0 spawn {
+        private "_selected";
+
+        while {
+            _selected = GVAR(logArray) deleteAt 0;
+            !isNil "_selected"
+        } do {
+            diag_log _selected;
         };
     };
-#else
-    params ["_file","_lineNum","_message"];
-    // TODO: Add log message to trace log
-    diag_log [diag_frameNo,
-        diag_tickTime, time, // [diag_tickTime, "H:MM:SS.mmm"] call CBA_fnc_formatElapsedTime, [time, "H:MM:SS.mmm"] call CBA_fnc_formatElapsedTime
-        _file + ":"+str(_lineNum + 1), _message];
-#endif
+};
 
-nil;
+nil

--- a/addons/diagnostic/gui.hpp
+++ b/addons/diagnostic/gui.hpp
@@ -1,0 +1,26 @@
+
+class RscStructuredText;
+
+class RscTitles {
+    class GVAR(Error) {
+        idd = -1;
+        duration = 5;
+        fadeIn = 0;
+        fadeOut = 0.5;
+        movingEnable = 0;
+
+        class Controls {
+            class GVAR(Error): RscStructuredText {
+                onLoad = QUOTE(uiNamespace setVariable [ARR_2('GVAR(Error)',_this select 0)]);
+                idc = -1;
+                font = "RobotoCondensedBold";
+                sizeEx = 0.55 * GUI_GRID_CENTER_H;
+                x =  0 * GUI_GRID_CENTER_W + GUI_GRID_CENTER_X;
+                y =  0 * GUI_GRID_CENTER_H + GUI_GRID_CENTER_Y;
+                w = 40 * GUI_GRID_CENTER_W;
+                h = 10 * GUI_GRID_CENTER_H;
+                colorBackground[] = {1,0.4,0,0.8};
+            };
+        };
+    };
+};

--- a/addons/diagnostic/script_component.hpp
+++ b/addons/diagnostic/script_component.hpp
@@ -12,3 +12,4 @@
 #include "\x\cba\addons\main\script_macros.hpp"
 
 #include "\a3\ui_f\hpp\defineDIKCodes.inc"
+#include "\a3\ui_f\hpp\defineCommonGrids.inc"

--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -134,20 +134,24 @@ Author:
 #define DEBUG_MODE_MINIMAL
 #endif
 
-#ifdef THIS_FILE
-#define THIS_FILE_ 'THIS_FILE'
+#define LOG_SYS_FORMAT(LEVEL,MESSAGE) format ['[%1] (%2) %3: %4', toUpper 'PREFIX', 'COMPONENT', LEVEL, MESSAGE]
+
+#ifdef DEBUG_SYNCHRONOUS
+#define LOG_SYS(LEVEL,MESSAGE) diag_log text LOG_SYS_FORMAT(LEVEL,MESSAGE)
 #else
-#define THIS_FILE_ __FILE__
+#define LOG_SYS(LEVEL,MESSAGE) LOG_SYS_FORMAT(LEVEL,MESSAGE) call CBA_fnc_log
 #endif
+
+#define LOG_SYS_FILELINENUMBERS(LEVEL,MESSAGE) LOG_SYS(LEVEL,format [ARR_4('%1 File: %2 Line: %3',MESSAGE,__FILE__,__LINE__ + 1)])
 
 /* -------------------------------------------
 Macro: LOG()
-    Log a timestamped message into the RPT log.
+    Log a debug message into the RPT log.
 
-    Only run if <DEBUG_MODE_FULL> or higher is defined.
+    Only run if <DEBUG_MODE_FULL> is defined.
 
 Parameters:
-    MESSAGE - Message to record [String]
+    MESSAGE - Message to record <STRING>
 
 Example:
     (begin example)
@@ -158,19 +162,36 @@ Author:
     Spooner
 ------------------------------------------- */
 #ifdef DEBUG_MODE_FULL
-#define LOG(MESSAGE) [THIS_FILE_, __LINE__, MESSAGE] call CBA_fnc_log
+#define LOG(MESSAGE) LOG_SYS_FILELINENUMBERS('LOG',MESSAGE)
 #else
 #define LOG(MESSAGE) /* disabled */
 #endif
 
 /* -------------------------------------------
+Macro: INFO()
+    Record a message without file and line number in the RPT log.
+
+Parameters:
+    MESSAGE - Message to record <STRING>
+
+Example:
+    (begin example)
+        INFO("Mod X is loaded, do Y");
+    (end)
+
+Author:
+    commy2
+------------------------------------------- */
+#define INFO(MESSAGE) LOG_SYS('INFO',MESSAGE)
+
+/* -------------------------------------------
 Macro: WARNING()
-    Record a timestamped, non-critical error in the RPT log.
+    Record a non-critical error in the RPT log.
 
     Only run if <DEBUG_MODE_NORMAL> or higher is defined.
 
 Parameters:
-    MESSAGE - Message to record [String]
+    MESSAGE - Message to record <STRING>
 
 Example:
     (begin example)
@@ -181,21 +202,17 @@ Author:
     Spooner
 ------------------------------------------- */
 #ifdef DEBUG_MODE_NORMAL
-#define WARNING(MESSAGE) [THIS_FILE_, __LINE__, ('WARNING: ' + MESSAGE)] call CBA_fnc_log
+#define WARNING(MESSAGE) LOG_SYS_FILELINENUMBERS('WARNING',MESSAGE)
 #else
 #define WARNING(MESSAGE) /* disabled */
 #endif
 
 /* -------------------------------------------
 Macro: ERROR()
-    Record a timestamped, critical error in the RPT log.
-
-    The heading is "ERROR" (use <ERROR_WITH_TITLE()> for a specific title).
-
-    TODO: Popup an error dialog & throw an exception.
+    Record a critical error in the RPT log.
 
 Parameters:
-    MESSAGE -  Message to record [String]
+    MESSAGE -  Message to record <STRING>
 
 Example:
     (begin example)
@@ -205,12 +222,11 @@ Example:
 Author:
     Spooner
 ------------------------------------------- */
-#define ERROR(MESSAGE) \
-    [THIS_FILE_, __LINE__, "ERROR", MESSAGE] call CBA_fnc_error;
+#define ERROR(MESSAGE) LOG_SYS_FILELINENUMBERS('ERROR',MESSAGE)
 
 /* -------------------------------------------
 Macro: ERROR_WITH_TITLE()
-    Record a timestamped, critical error in the RPT log.
+    Record a critical error in the RPT log.
 
     The title can be specified (in <ERROR()> the heading is always just "ERROR")
     Newlines (\n) in the MESSAGE will be put on separate lines.
@@ -218,8 +234,8 @@ Macro: ERROR_WITH_TITLE()
     TODO: Popup an error dialog & throw an exception.
 
 Parameters:
-    TITLE - Title of error message [String]
-    MESSAGE -  Body of error message [String]
+    TITLE - Title of error message <STRING>
+    MESSAGE -  Body of error message <STRING>
 
 Example:
     (begin example)
@@ -229,16 +245,15 @@ Example:
 Author:
     Spooner
 ------------------------------------------- */
-#define ERROR_WITH_TITLE(TITLE,MESSAGE) \
-    [THIS_FILE_, __LINE__, TITLE, MESSAGE] call CBA_fnc_error;
+#define ERROR_WITH_TITLE(TITLE,MESSAGE) ['PREFIX', 'COMPONENT', TITLE, MESSAGE, __FILE__, __LINE__ + 1] call CBA_fnc_error
 
 /* -------------------------------------------
 Macro: MESSAGE_WITH_TITLE()
-    Record a single line, timestamped log entry in the RPT log.
+    Record a single line in the RPT log.
 
 Parameters:
-    TITLE - Title of log message [String]
-    MESSAGE -  Body of message [String]
+    TITLE - Title of log message <STRING>
+    MESSAGE -  Body of message <STRING>
 
 Example:
     (begin example)
@@ -248,8 +263,7 @@ Example:
 Author:
     Killswitch
 ------------------------------------------- */
-#define MESSAGE_WITH_TITLE(TITLE,MESSAGE) \
-    [THIS_FILE_, __LINE__, TITLE + ': ' + (MESSAGE)] call CBA_fnc_log;
+#define MESSAGE_WITH_TITLE(TITLE,MESSAGE) LOG_SYS_FILELINENUMBERS(TITLE,MESSAGE)
 
 /* -------------------------------------------
 Macro: RETNIL()
@@ -327,35 +341,16 @@ Author:
 
 
 #ifdef DEBUG_MODE_FULL
-#define TRACE_1(MESSAGE,A) \
-    [THIS_FILE_, __LINE__, PFORMAT_1(MESSAGE,A)] call CBA_fnc_log
-
-#define TRACE_2(MESSAGE,A,B) \
-    [THIS_FILE_, __LINE__, PFORMAT_2(MESSAGE,A,B)] call CBA_fnc_log
-
-#define TRACE_3(MESSAGE,A,B,C) \
-    [THIS_FILE_, __LINE__, PFORMAT_3(MESSAGE,A,B,C)] call CBA_fnc_log
-
-#define TRACE_4(MESSAGE,A,B,C,D) \
-    [THIS_FILE_, __LINE__, PFORMAT_4(MESSAGE,A,B,C,D)] call CBA_fnc_log
-
-#define TRACE_5(MESSAGE,A,B,C,D,E) \
-    [THIS_FILE_, __LINE__, PFORMAT_5(MESSAGE,A,B,C,D,E)] call CBA_fnc_log
-
-#define TRACE_6(MESSAGE,A,B,C,D,E,F) \
-    [THIS_FILE_, __LINE__, PFORMAT_6(MESSAGE,A,B,C,D,E,F)] call CBA_fnc_log
-
-#define TRACE_7(MESSAGE,A,B,C,D,E,F,G) \
-    [THIS_FILE_, __LINE__, PFORMAT_7(MESSAGE,A,B,C,D,E,F,G)] call CBA_fnc_log
-
-#define TRACE_8(MESSAGE,A,B,C,D,E,F,G,H) \
-    [THIS_FILE_, __LINE__, PFORMAT_8(MESSAGE,A,B,C,D,E,F,G,H)] call CBA_fnc_log
-
-#define TRACE_9(MESSAGE,A,B,C,D,E,F,G,H,I) \
-    [THIS_FILE_, __LINE__, PFORMAT_9(MESSAGE,A,B,C,D,E,F,G,H,I)] call CBA_fnc_log
-
+#define TRACE_1(MESSAGE,A) LOG_SYS_FILELINENUMBERS('TRACE',PFORMAT_1(str diag_frameNo + ' ' + (MESSAGE),A))
+#define TRACE_2(MESSAGE,A,B) LOG_SYS_FILELINENUMBERS('TRACE',PFORMAT_2(str diag_frameNo + ' ' + (MESSAGE),A,B))
+#define TRACE_3(MESSAGE,A,B,C) LOG_SYS_FILELINENUMBERS('TRACE',PFORMAT_3(str diag_frameNo + ' ' + (MESSAGE),A,B,C))
+#define TRACE_4(MESSAGE,A,B,C,D) LOG_SYS_FILELINENUMBERS('TRACE',PFORMAT_4(str diag_frameNo + ' ' + (MESSAGE),A,B,C,D))
+#define TRACE_5(MESSAGE,A,B,C,D,E) LOG_SYS_FILELINENUMBERS('TRACE',PFORMAT_5(str diag_frameNo + ' ' + (MESSAGE),A,B,C,D,E))
+#define TRACE_6(MESSAGE,A,B,C,D,E,F) LOG_SYS_FILELINENUMBERS('TRACE',PFORMAT_6(str diag_frameNo + ' ' + (MESSAGE),A,B,C,D,E,F))
+#define TRACE_7(MESSAGE,A,B,C,D,E,F,G) LOG_SYS_FILELINENUMBERS('TRACE',PFORMAT_7(str diag_frameNo + ' ' + (MESSAGE),A,B,C,D,E,F,G))
+#define TRACE_8(MESSAGE,A,B,C,D,E,F,G,H) LOG_SYS_FILELINENUMBERS('TRACE',PFORMAT_8(str diag_frameNo + ' ' + (MESSAGE),A,B,C,D,E,F,G,H))
+#define TRACE_9(MESSAGE,A,B,C,D,E,F,G,H,I) LOG_SYS_FILELINENUMBERS('TRACE',PFORMAT_9(str diag_frameNo + ' ' + (MESSAGE),A,B,C,D,E,F,G,H,I))
 #else
-
 #define TRACE_1(MESSAGE,A) /* disabled */
 #define TRACE_2(MESSAGE,A,B) /* disabled */
 #define TRACE_3(MESSAGE,A,B,C) /* disabled */
@@ -365,7 +360,6 @@ Author:
 #define TRACE_7(MESSAGE,A,B,C,D,E,F,G) /* disabled */
 #define TRACE_8(MESSAGE,A,B,C,D,E,F,G,H) /* disabled */
 #define TRACE_9(MESSAGE,A,B,C,D,E,F,G,H,I) /* disabled */
-
 #endif
 
 /* -------------------------------------------

--- a/addons/settings/XEH_postInit.sqf
+++ b/addons/settings/XEH_postInit.sqf
@@ -3,7 +3,7 @@
 // --- refresh all settings after postInit to guarantee that events are added and settings are recieved from server
 {
     if (isNil QGVAR(serverSettings)) then {
-        diag_log text "[CBA] (settings): No server settings after postInit phase.";
+        ERROR("No server settings after postInit phase.");
     };
 
     //Event to read modules
@@ -14,7 +14,7 @@
         [QGVAR(refreshSetting), _x] call CBA_fnc_localEvent;
     } forEach GVAR(allSettings);
 
-    diag_log text format ["[CBA] (settings): Settings Initialized"];
+    LOG("Settings Initialized");
     ["CBA_settingsInitialized", []] call CBA_fnc_localEvent;
 } call CBA_fnc_execNextFrame;
 

--- a/addons/settings/XEH_preInit.sqf
+++ b/addons/settings/XEH_preInit.sqf
@@ -49,9 +49,9 @@ addMissionEventHandler ["Loaded", {
 ["CBA_SettingChanged", {
     params ["_setting", "_value"];
 
-    private _message = format ["[CBA] (settings): %1 = %2", _setting, _value];
+    private _message = format ["%1 = %2", _setting, _value];
     systemChat _message;
-    diag_log text _message;
+    LOG(_message);
 }] call CBA_fnc_addEventHandler;
 #endif
 
@@ -68,10 +68,12 @@ if (isServer) then {
     params ["_setting", "_value", ["_forced", false, [false]]];
 
     if ([_setting, "mission"] call FUNC(isForced)) exitWith {
-        diag_log text format ["[CBA] (settings): Setting %1 already forced, ignoring setSettingMission.", _setting];
+        private _message = format ["Setting %1 already forced, ignoring setSettingMission.", str _setting];
+        LOG(_message);
     };
     if (!([_setting, _value] call FUNC(check))) exitWith {
-        diag_log text format ["[CBA] (settings): Value %1 is invalid for setting %2.", _value, _setting];
+        private _message = format ["Value %1 is invalid for setting %2.", _value, str _setting];
+        WARNING(_message);
     };
 
     GVAR(missionSettings) setVariable [_setting, [_value, _forced]];

--- a/addons/settings/fnc_init.sqf
+++ b/addons/settings/fnc_init.sqf
@@ -130,7 +130,8 @@ if (!isNil "_settingInfo") then {
     if !([_setting, _value] call FUNC(check)) then {
         _value = [_setting, "default"] call FUNC(get);
         [_setting, _value, _forced, "client"] call FUNC(set);
-        diag_log text format ["[CBA] (settings): Invalid value for setting %1. Fall back to default value.", str _setting];
+        private _message = format ["Invalid value for setting %1. Fall back to default value.", str _setting];
+        WARNING(_message);
     };
 
     GVAR(clientSettings) setVariable [_setting, [_value, _forced]];

--- a/addons/settings/fnc_parse.sqf
+++ b/addons/settings/fnc_parse.sqf
@@ -98,12 +98,14 @@ private _result = [];
         private _currentValue = [_setting, "default"] call FUNC(get);
 
         if (isNil "_currentValue") then {
-            diag_log text format ["[CBA] (settings): Error parsing settings file. Setting %1 does not exist.", str _setting];
+            private _message = format ["Error parsing settings file. Setting %1 does not exist.", str _setting];
+            ERROR(_message);
         } else {
             if ([_setting, _value] call FUNC(check)) then {
                 _result pushBack [_setting, _value, _force];
             } else {
-                diag_log text format ["[CBA] (settings): Error parsing settings file. Value %1 is invalid for setting %2.", _value, str _setting];
+                private _message = format ["Error parsing settings file. Value %1 is invalid for setting %2.", _value, str _setting];
+                ERROR(_message);
             };
         };
     };

--- a/addons/settings/fnc_set.sqf
+++ b/addons/settings/fnc_set.sqf
@@ -33,7 +33,8 @@ Author:
 params [["_setting", "", [""]], "_value", ["_forced", nil, [false]], ["_source", "client", [""]]];
 
 if (!isNil "_value" && {!([_setting, _value] call FUNC(check))}) exitWith {
-    diag_log text format ["[CBA] (settings): Value %1 is invalid for setting %2.", _value, str _setting];
+    private _message = format ["Value %1 is invalid for setting %2.", _value, str _setting];
+    WARNING(_message);
     1
 };
 

--- a/optionals/auto_load_settings_file/loadSettingsFile.sqf
+++ b/optionals/auto_load_settings_file/loadSettingsFile.sqf
@@ -12,10 +12,10 @@ if (isFilePatchingEnabled) then {
             [_setting, _value, _force, _source] call EFUNC(settings,set);
         } forEach _info;
 
-        diag_log text "[CBA] (settings): Settings file loaded.";
+        LOG("Settings file loaded.");
     } else {
-        diag_log text "[CBA] (settings): Settings file not loaded. File empty or does not exist.";
+        WARNING("Settings file not loaded. File empty or does not exist.");
     };
 } else {
-    diag_log text "[CBA] (settings): Cannot load settings file. File patching disabled. Use -filePatching flag.";
+    WARNING("Cannot load settings file. File patching disabled. Use -filePatching flag.");
 };

--- a/template/static_settings_addon/loadSettingsFile.sqf
+++ b/template/static_settings_addon/loadSettingsFile.sqf
@@ -13,4 +13,4 @@ _info = _info call EFUNC(settings,parse);
     [_setting, _value, _force, _source] call EFUNC(settings,set);
 } forEach _info;
 
-diag_log text "[CBA] (settings): Settings file loaded from PBO.";
+LOG("Settings file loaded from PBO.");


### PR DESCRIPTION
**When merged this pull request will:**
- This PR will align the format of the CBA logging macros (`LOG()`, `WARNING()`, `ERROR()`, `TRACE()`) to the format used ACE
- streamline `CBA_fnc_log` and `CBA_fnc_error`
- adds `INFO()` macro that does not print file and line number (meant for end user)

All messages will be displayed as:
`[<PREFIX>] (<COMPONENT>) <LEVEL>: <MESSAGE> File: <FILE_PATH> Line: <LINE_NUMBER>`

```
    INFO("my info message");
    LOG("my log message");
    WARNING("my warning message");
    ERROR("my error message");
    MESSAGE_WITH_TITLE("CUSTOM","my custom message");
    ERROR_WITH_TITLE("my error","line1\nline2\nline3");
```
->
```
[CBA] (diagnostic) INFO: my info message
[CBA] (diagnostic) LOG: my log message File: x\cba\addons\diagnostic\XEH_preInit.sqf Line: 39
[CBA] (diagnostic) WARNING: my warning message File: x\cba\addons\diagnostic\XEH_preInit.sqf Line: 40
[CBA] (diagnostic) ERROR: my error message File: x\cba\addons\diagnostic\XEH_preInit.sqf Line: 41
[CBA] (diagnostic) CUSTOM: my custom message File: x\cba\addons\diagnostic\XEH_preInit.sqf Line: 42
[CBA] (diagnostic) ERROR: my error File: x\cba\addons\diagnostic\XEH_preInit.sqf Line: 42
            line1
            line2
            line3
```

- adds error pop up to `CBA_fnc_error` (ancient todo)
![http://i.imgur.com/UrqYX2V.png](http://i.imgur.com/UrqYX2V.png)

@ todo:
- [ ] write doc for https://github.com/CBATeam/CBA_A3/wiki