### PR TITLE
Quit 'CBA_fnc_addKeybind' on headless clients, fix #467

### DIFF
--- a/addons/keybinding/fnc_addKeybind.sqf
+++ b/addons/keybinding/fnc_addKeybind.sqf
@@ -41,7 +41,7 @@ Author:
 #include "\x\cba\addons\keybinding\script_component.hpp"
 
 // Clients only.
-if (isDedicated) exitWith {};
+if (!hasInterface) exitWith {};
 
 _nullKeybind = [-1, [false,false,false]];
 


### PR DESCRIPTION
**When merged this pull request will:**
- `GVAR(activeMods)`, the controls and displays and possibly more stuff is undefined on machines without display
- Fixes error message on headless clients: #467