### PR TITLE
simplify and fix 'CBA_fnc_setVarNet' and 'CBA_fnc_publicVariable'

### DIFF
--- a/addons/network/fnc_publicVariable.sqf
+++ b/addons/network/fnc_publicVariable.sqf
@@ -1,19 +1,19 @@
-/*
+/* ----------------------------------------------------------------------------
 Function: CBA_fnc_publicVariable
 
 Description:
-    CBA_fnc_publicVariable does only broadcast the new value if it doesn't exist in missionNamespace or the new value is different to the one in missionNamespace.
+    Broadcast a variables value to all machines. Used to reduce network traffic.
 
-    Checks also for different types. Nil as value gets always broadcasted.
-
-    Should reduce network traffic.
+    Does only broadcast the new value if it doesn't exist in missionNamespace or
+    if the new value is different to the one in missionNamespace.
+    Nil as value gets always broadcasted.
 
 Parameters:
-    _pv - Name of the publicVariable [String]
-    _value - Value to check and broadcast if it is not the same as the previous one, code will always be broadcasted [Any]
+    _varName - Name of the public variable <STRING>
+    _value   - Value to broadcast <ANY>
 
 Returns:
-    True if if broadcasted, otherwise false [Boolean]
+    True if if broadcasted, otherwise false <BOOLEAN>
 
 Example:
     (begin example)
@@ -22,57 +22,26 @@ Example:
     (end)
 
 Author:
-    Xeno
-*/
-// #define DEBUG_MODE_FULL
+    Xeno, commy2
+---------------------------------------------------------------------------- */
+#define DEBUG_MODE_FULL
 #include "script_component.hpp"
 
-params ["_pv","_value"];
+params [["_varName", "", [""]], "_value"];
 
-if (typeName _pv != typeName "") exitWith {
-    WARNING("The first parameter is not of type string!");
+if (_varName isEqualTo "") exitWith {
+    WARNING("Variable name is wrong type or undefined");
     false
 };
 
-private ["_var","_s"];
-_var = missionNamespace getVariable _pv;
+private _currentValue = missionNamespace getVariable _varName;
 
-if (isNil "_var") exitWith {
-    TRACE_2("Broadcasting",_pv,_value);
-    missionNamespace setVariable [_pv, _value];
-    publicVariable _pv;
-    true
-};
-
-_s = if (typeName _value != typeName _var) then {
-    TRACE_2("Different typenames",_var,_value);
-    false
+if (isNil "_currentValue" || {!(_value isEqualTo _currentValue)}) then {
+    TRACE_2("Broadcasting",_varName,_value);
+    missionNamespace setVariable [_varName, _value];
+    publicVariable _varName;
+    true // return
 } else {
-    switch (typename _value) do {
-        case "BOOL": {
-            ((_var && {_value}) || {(!_var && {!_value})})
-        };
-        case "ARRAY": {
-            (_var isEqualTo _value)
-        };
-        case "CODE": {
-            false
-        };
-        case "SCRIPT": {
-            false
-        };
-        default {
-            (_var == _value)
-        };
-    }
+    TRACE_2("Not broadcasting. Current and new value are equal",_currentValue,_value);
+    false // return
 };
-if (_s) exitwith {
-    TRACE_2("Not broadcasting, _var and _value are equal",_var,_value);
-    false
-};
-
-TRACE_2("Broadcasting",_pv,_value);
-missionNamespace setVariable [_pv, _value];
-publicVariable _pv;
-
-true

--- a/addons/network/fnc_publicVariable.sqf
+++ b/addons/network/fnc_publicVariable.sqf
@@ -36,12 +36,31 @@ if (_varName isEqualTo "") exitWith {
 
 private _currentValue = missionNamespace getVariable _varName;
 
-if (isNil "_currentValue" || {!(_value isEqualTo _currentValue)}) then {
-    TRACE_2("Broadcasting",_varName,_value);
-    missionNamespace setVariable [_varName, _value];
-    publicVariable _varName;
-    true // return
+if (isNil "_currentValue") then {
+    if (isNil "_value") then {
+        TRACE_1("Not broadcasting. Current and new value are undefined",_varName);
+        false // return
+    } else {
+        TRACE_2("Broadcasting previously undefined value",_varName,_value);
+        missionNamespace setVariable [_varName, _value];
+        publicVariable _varName;
+        true // return
+    };
 } else {
-    TRACE_2("Not broadcasting. Current and new value are equal",_currentValue,_value);
-    false // return
+    if (isNil "_value") then {
+        TRACE_1("Broadcasting nil",_varName);
+        missionNamespace setVariable [_varName, nil];
+        publicVariable _varName;
+        true // return
+    } else {
+        if (_value isEqualTo _currentValue) then {
+            TRACE_3("Not broadcasting. Current and new value are equal",_varName,_currentValue,_value);
+            false // return
+        } else {
+            TRACE_2("Broadcasting",_varName,_value);
+            missionNamespace setVariable [_varName, _value];
+            publicVariable _varName;
+            true // return
+        };
+    };
 };

--- a/addons/network/fnc_publicVariable.sqf
+++ b/addons/network/fnc_publicVariable.sqf
@@ -24,7 +24,7 @@ Example:
 Author:
     Xeno, commy2
 ---------------------------------------------------------------------------- */
-#define DEBUG_MODE_FULL
+//#define DEBUG_MODE_FULL
 #include "script_component.hpp"
 
 params [["_varName", "", [""]], "_value"];

--- a/addons/network/fnc_setVarNet.sqf
+++ b/addons/network/fnc_setVarNet.sqf
@@ -9,7 +9,7 @@ Description:
     Nil as value gets always broadcasted.
 
 Parameters:
-    _object   - Object namespace <OBJECT, GROUP>
+    _object  - Object namespace <OBJECT, GROUP>
     _varName - Name of the public variable <STRING>
     _value   - Value to broadcast <ANY>
 
@@ -28,7 +28,7 @@ Author:
 //#define DEBUG_MODE_FULL
 #include "script_component.hpp"
 
-params [["_object", objNull, [objNull, grpNull]], ["_variable", "", [""]], "_value"];
+params [["_object", objNull, [objNull, grpNull]], ["_varName", "", [""]], "_value"];
 
 if (isNull _object) exitWith {
     WARNING("Object wrong type, undefined or null");
@@ -42,11 +42,28 @@ if (_varName isEqualTo "") exitWith {
 
 private _currentValue = _object getVariable _varName;
 
-if (isNil "_currentValue" || {!(_value isEqualTo _currentValue)}) then {
-    TRACE_3("Broadcasting",_object,_variable,_value);
-    _object setVariable [_variable, _value, true];
-    true // return
+if (isNil "_currentValue") then {
+    if (isNil "_value") then {
+        TRACE_2("Not broadcasting. Current and new value are undefined",_object,_varName);
+        false // return
+    } else {
+        TRACE_3("Broadcasting previously undefined value",_object,_varName,_value);
+        _object setVariable [_varName, _value, true];
+        true // return
+    };
 } else {
-    TRACE_2("Not broadcasting. Current and new value are equal",_currentValue,_value);
-    false // return
+    if (isNil "_value") then {
+        TRACE_2("Broadcasting nil",_object,_varName);
+        _object setVariable [_varName, nil, true];
+        true // return
+    } else {
+        if (_value isEqualTo _currentValue) then {
+            TRACE_4("Not broadcasting. Current and new value are equal",_object,_varName,_currentValue,_value);
+            false // return
+        } else {
+            TRACE_3("Broadcasting",_object,_varName,_value);
+            _object setVariable [_varName, _value, true];
+            true // return
+        };
+    };
 };

--- a/addons/network/fnc_setVarNet.sqf
+++ b/addons/network/fnc_setVarNet.sqf
@@ -25,7 +25,7 @@ Example:
 Author:
     Xeno, commy2
 ---------------------------------------------------------------------------- */
-#define DEBUG_MODE_FULL
+//#define DEBUG_MODE_FULL
 #include "script_component.hpp"
 
 params [["_object", objNull, [objNull, grpNull]], ["_variable", "", [""]], "_value"];

--- a/addons/network/fnc_setVarNet.sqf
+++ b/addons/network/fnc_setVarNet.sqf
@@ -1,20 +1,20 @@
-/*
+/* ----------------------------------------------------------------------------
 Function: CBA_fnc_setVarNet
 
 Description:
-    Same as setVariable ["name",var, true] but only broadcasts when the value of var is different to the one which is already saved in the variable space.
+    Broadcast a object variable value to all machines. Used to reduce network traffic.
 
-    Checks also for different types. Nil as value gets always broadcasted.
-
-    Should reduce network traffic.
+    Does only broadcast the new value if it doesn't exist in the object namespace or
+    if the new value is different to the one in object namespace.
+    Nil as value gets always broadcasted.
 
 Parameters:
-    _object - Name of a marker [Object, Group]
-    _variable - Name of the variable in variable space [String]
-    _value - Value to check and broadcast if it is not the same as the previous one, code will always be broadcasted [Any]
+    _object   - Object namespace <OBJECT, GROUP>
+    _varName - Name of the public variable <STRING>
+    _value   - Value to broadcast <ANY>
 
 Returns:
-    True if broadcasted, otherwise false [Boolean]
+    True if if broadcasted, otherwise false <BOOLEAN>
 
 Example:
     (begin example)
@@ -23,57 +23,30 @@ Example:
     (end)
 
 Author:
-    Xeno
-*/
-//#define DEBUG_MODE_FULL
+    Xeno, commy2
+---------------------------------------------------------------------------- */
+#define DEBUG_MODE_FULL
 #include "script_component.hpp"
 
-params ["_object","_variable","_value"];
+params [["_object", objNull, [objNull, grpNull]], ["_variable", "", [""]], "_value"];
 
-// does setVariable public also work for other types ??
-if (typeName _object != "OBJECT" && {typeName _object != "GROUP"}) exitWith {
-    WARNING("The first parameter is not of type object or group!");
+if (isNull _object) exitWith {
+    WARNING("Object wrong type, undefined or null");
     false
 };
 
-private ["_var","_s"];
+if (_varName isEqualTo "") exitWith {
+    WARNING("Variable name is wrong type or undefined");
+    false
+};
 
-_var = _object getVariable _variable;
+private _currentValue = _object getVariable _varName;
 
-if (isNil "_var") exitWith {
+if (isNil "_currentValue" || {!(_value isEqualTo _currentValue)}) then {
     TRACE_3("Broadcasting",_object,_variable,_value);
     _object setVariable [_variable, _value, true];
-    true
-};
-
-_s = if (typeName _value != typeName _var) then {
-    TRACE_2("Different typenames",_var,_value);
-    false
+    true // return
 } else {
-    switch (typename _value) do {
-        case "BOOL": {
-            ((_var && {_value}) || {(!_var && {!_value})})
-        };
-        case "ARRAY": {
-            (_var isEqualTo _value)
-        };
-        case "CODE": {
-            false
-        };
-        case "SCRIPT": {
-            false
-        };
-        default {
-            (_var == _value)
-        };
-    }
+    TRACE_2("Not broadcasting. Current and new value are equal",_currentValue,_value);
+    false // return
 };
-if (_s) exitwith {
-    TRACE_2("Not broadcasting, _var and _value are equal",_var,_value);
-    false
-};
-
-TRACE_3("Broadcasting",_object,_variable,_value);
-_object setVariable [_variable, _value, true];
-
-true

--- a/addons/network/test_network.sqf
+++ b/addons/network/test_network.sqf
@@ -1,0 +1,66 @@
+#include "script_component.hpp"
+SCRIPT(test_network);
+
+// 0 spawn compile preprocessFileLineNumbers "\x\cba\addons\network\test_network.sqf";
+
+private ["_funcName", "_result"];
+
+_funcName = "CBA_fnc_publicVariable";
+LOG("Testing " + _funcName);
+
+TEST_DEFINED("CBA_fnc_publicVariable","");
+
+_result = ["X1", nil] call CBA_fnc_publicVariable;
+TEST_FALSE(_result,_funcName);
+
+_result = ["X1", 1] call CBA_fnc_publicVariable;
+TEST_TRUE(_result,_funcName);
+
+_result = ["X1", 2] call CBA_fnc_publicVariable;
+TEST_TRUE(_result,_funcName);
+
+_result = ["X1", 2] call CBA_fnc_publicVariable;
+TEST_FALSE(_result,_funcName);
+
+_result = ["X2", 2] call CBA_fnc_publicVariable;
+TEST_TRUE(_result,_funcName);
+
+_result = ["X1", nil] call CBA_fnc_publicVariable;
+TEST_TRUE(_result,_funcName);
+
+_result = ["X1", nil] call CBA_fnc_publicVariable;
+TEST_FALSE(_result,_funcName);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+_funcName = "CBA_fnc_setVarNet";
+LOG("Testing " + _funcName);
+
+TEST_DEFINED("CBA_fnc_setVarNet","");
+
+_result = [objNull, "X1", 1] call CBA_fnc_setVarNet;
+TEST_FALSE(_result,_funcName);
+
+_result = [player, "X1", nil] call CBA_fnc_setVarNet;
+TEST_FALSE(_result,_funcName);
+
+_result = [player, "X1", 1] call CBA_fnc_setVarNet;
+TEST_TRUE(_result,_funcName);
+
+_result = [player, "X1", 2] call CBA_fnc_setVarNet;
+TEST_TRUE(_result,_funcName);
+
+_result = [player, "X1", 2] call CBA_fnc_setVarNet;
+TEST_FALSE(_result,_funcName);
+
+_result = [cba_logic, "X1", 2] call CBA_fnc_setVarNet;
+TEST_TRUE(_result,_funcName);
+
+_result = [player, "X2", 2] call CBA_fnc_setVarNet;
+TEST_TRUE(_result,_funcName);
+
+_result = [player, "X1", nil] call CBA_fnc_setVarNet;
+TEST_TRUE(_result,_funcName);
+
+_result = [player, "X1", nil] call CBA_fnc_setVarNet;
+TEST_FALSE(_result,_funcName);

--- a/addons/network/test_network.sqf
+++ b/addons/network/test_network.sqf
@@ -2,6 +2,7 @@
 SCRIPT(test_network);
 
 // 0 spawn compile preprocessFileLineNumbers "\x\cba\addons\network\test_network.sqf";
+// test has to be done with an existing "player" object (not 3den!!)
 
 private ["_funcName", "_result"];
 
@@ -9,6 +10,9 @@ _funcName = "CBA_fnc_publicVariable";
 LOG("Testing " + _funcName);
 
 TEST_DEFINED("CBA_fnc_publicVariable","");
+
+X1 = nil;
+X2 = nil;
 
 _result = ["X1", nil] call CBA_fnc_publicVariable;
 TEST_FALSE(_result,_funcName);
@@ -37,6 +41,11 @@ _funcName = "CBA_fnc_setVarNet";
 LOG("Testing " + _funcName);
 
 TEST_DEFINED("CBA_fnc_setVarNet","");
+
+player setVariable ["X1", nil];
+player setVariable ["X2", nil];
+cba_logic setVariable ["X1", nil];
+cba_logic setVariable ["X2", nil];
 
 _result = [objNull, "X1", 1] call CBA_fnc_setVarNet;
 TEST_FALSE(_result,_funcName);


### PR DESCRIPTION
**When merged this pull request will:**
- title
- adjust function headers to standard
- add warning if varName in setVarNet is not a string instead of error out
- make functions safe to be executed in scheduled environment.

