### PR TITLE
make 'CBA_fnc_error' safe in scheduled environment again

### DIFF
--- a/addons/diagnostic/fnc_error.sqf
+++ b/addons/diagnostic/fnc_error.sqf
@@ -45,6 +45,7 @@ private _lines = [_message, "\n"] call CBA_fnc_split;
 } forEach _lines;
 
 // error pop up
+disableSerialization;
 QGVAR(Error) cutRsc [QGVAR(Error), "PLAIN"];
 private _control = uiNamespace getVariable QGVAR(Error);
 


### PR DESCRIPTION
**When merged this pull request will:**
- Arma doesn't like storing \<CONTROL\> and \<DISPLAY\> in non-array variables in serialized scheduled environment scripts (does not support serialization-pop up), so we disable serialization.
