### PR TITLE
Add macros 'PATHTO_FNC ' and 'RECOMPILE'

### DIFF
--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -834,7 +834,7 @@ Author:
     dixon13, commy2
  ------------------------------------------- */
 #define PATHTO_FNC(func) class func {\
-    file = QUOTE(PATHTOF(DOUBLES(fnc,func).sqf));\
+    file = QPATHTOF(DOUBLES(fnc,func).sqf);\
     RECOMPILE;\
 }
 

--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -804,8 +804,37 @@ Author:
     #define RECOMPILE recompile = 0
 #endif
 
+/* -------------------------------------------
+Macro: PATHTO_FNC()
+
+Description:
+    Defines a function inside CfgFunctions.
+
+    Full file path in addons:
+        '\MAINPREFIX\PREFIX\SUBPREFIX\COMPONENT\fnc_<FNC>.sqf'
+    Define 'RECOMPILE' to enable recompiling.
+
+Parameters:
+    FUNCTION NAME - Name of the function, unquoted <STRING>
+
+Examples:
+    (begin example)
+        // file name: fnc_addPerFrameHandler.sqf
+        class CfgFunctions {
+            class CBA {
+                class Misc {
+                    PATHTO_FNC(addPerFrameHandler);
+                };
+            };
+        };
+        // -> CBA_fnc_addPerFrameHandler
+    (end)
+
+Author:
+    dixon13, commy2
+ ------------------------------------------- */
 #define PATHTO_FNC(func) class func {\
-    file = QUOTE(PATHTOF(DOUBLES(fnc,func).sqf));\ // \MAINPREFIX\PREFIX\SUBPREFIX\COMPONENT\fnc_func.sqf
+    file = QUOTE(PATHTOF(DOUBLES(fnc,func).sqf));\
     RECOMPILE;\
 }
 

--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -550,7 +550,7 @@ Author:
 /* -------------------------------------------
 Macro: FILTER()
 Description:
-    Filters an array based on given code, then assigns the resulting array 
+    Filters an array based on given code, then assigns the resulting array
     to the original
 Parameters:
     ARRAY - Array to be filtered
@@ -795,6 +795,17 @@ Author:
     #define PREP(var1) ['PATHTO_SYS(PREFIX,COMPONENT_F,DOUBLES(fnc,var1))', 'TRIPLES(ADDON,fnc,var1)'] call SLX_XEH_COMPILE_NEW
     #define PREPMAIN(var1) ['PATHTO_SYS(PREFIX,COMPONENT_F,DOUBLES(fnc,var1))', 'TRIPLES(PREFIX,fnc,var1)'] call SLX_XEH_COMPILE_NEW
 #endif
+
+#ifdef RECOMPILE
+    #define RECOMPILE recompile = 1
+#else
+    #define RECOMPILE recompile = 0
+#endif
+
+#define F_FILEPATH(func) class func {\
+    file = QUOTE(PATHTOF(DOUBLES(fnc,func).sqf));\
+    RECOMPILE;\
+}
 
 #define FUNC(var1) TRIPLES(ADDON,fnc,var1)
 #define FUNCMAIN(var1) TRIPLES(PREFIX,fnc,var1)

--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -797,12 +797,14 @@ Author:
 #endif
 
 #ifdef RECOMPILE
+    #undef RECOMPILE
     #define RECOMPILE recompile = 1
 #else
+    #undef RECOMPILE
     #define RECOMPILE recompile = 0
 #endif
 
-#define F_FILEPATH(func) class func {\
+#define PATHTO_FNC(func) class func {\
     file = QUOTE(PATHTOF(DOUBLES(fnc,func).sqf));\ // \MAINPREFIX\PREFIX\SUBPREFIX\COMPONENT\fnc_func.sqf
     RECOMPILE;\
 }

--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -803,7 +803,7 @@ Author:
 #endif
 
 #define F_FILEPATH(func) class func {\
-    file = QUOTE(PATHTOF(DOUBLES(fnc,func).sqf));\
+    file = QUOTE(PATHTOF(DOUBLES(fnc,func).sqf));\ // \MAINPREFIX\PREFIX\SUBPREFIX\COMPONENT\fnc_func.sqf
     RECOMPILE;\
 }
 

--- a/addons/main/script_macros_mission.hpp
+++ b/addons/main/script_macros_mission.hpp
@@ -53,7 +53,6 @@
     #define PATHTOF2_SYS(var1,var2,var3) ##var1\##var2\##var3
 #endif
 
-
 /************************** REMOVAL OF MACROS ***********************/
 
 #undef MAINPREFIX
@@ -75,3 +74,9 @@
 #undef XEH_POST_INIT
 #undef XEH_POST_CINIT
 #undef XEH_POST_SINIT
+
+#undef PATHTO_FNC
+#define PATHTO_FNC(func) class func {\
+    file = QUOTE(DOUBLES(fnc,func).sqf);\
+    RECOMPILE;\
+}

--- a/tools/build.py
+++ b/tools/build.py
@@ -46,15 +46,15 @@ def main():
     failed = 0
     skipped = 0
     removed = 0
-    
+
     for file in os.listdir(addonspath):
         if os.path.isfile(file):
             if check_for_obsolete_pbos(addonspath, file):
                 removed += 1
                 print("  Removing obsolete file => " + file)
                 os.remove(file)
-    print("")        
-    
+    print("")
+
     for p in os.listdir(addonspath):
         path = os.path.join(addonspath, p)
         if not os.path.isdir(path):


### PR DESCRIPTION
**When merged this pull request will:**
- Add the macros `PATHTO_FNC ` and `RECOMPILE`
- Argument for `PATHTO_FNC ` is the name of a function that is located at `\MAINPREFIX\PREFIX\SUBPREFIX\COMPONENT\` and the name of the file is `fnc_func.sqf` where 'func' is the name of you're function. `func` will be the argument for `PATHTO_FNC `
- `RECOMPILE` does not accept an argument. If `RECOMPILE` is defined before including `script_macros_common.hpp` in you're component, then the functions defined with `PATHTO_FNC ` will be recompiled at mission start. (For debug purposes)

These macros emulate the below...
```
class CfgFunctions {
    class func {
        file = "\MAINPREFIX\PREFIX\SUBPREFIX\COMPONENT\fnc_func.sqf";
        recompile = 0; //if RECOMPILE defined before including script_macros_common.hpp then recompile = 1
    };
};
```

The macro 'PATHTO_FNC ' can be found already in the components `common` and `settings`. Just making it official :)

#### Ignore the edits to `build.py`. I guess I removed some spaces or something but no edits to any of the code.