### PR TITLE
tweak ERROR(), 'CBA_fnc_error'

### DIFF
--- a/addons/diagnostic/fnc_error.sqf
+++ b/addons/diagnostic/fnc_error.sqf
@@ -4,7 +4,7 @@ Internal Function: CBA_fnc_error
 Description:
     Logs an error message to the RPT log.
 
-    Should not be used directly, but rather via macros (<ERROR_WITH_TITLE()>
+    Should not be used directly, but rather via macros (<ERROR()>, <ERROR_WITH_TITLE()>
     or the <Assertions>).
 
 Parameters:
@@ -49,7 +49,15 @@ disableSerialization;
 QGVAR(Error) cutRsc [QGVAR(Error), "PLAIN"];
 private _control = uiNamespace getVariable QGVAR(Error);
 
-private _compose = [lineBreak, parseText format ["<t align='center' size='1.65'>[%1] (%2) %3<\t>", _prefix, _component, _title], lineBreak];
+if (_message isEqualTo "") then {
+    _lines = [_title];
+    _title = "ERROR";
+};
+
+private _compose = [lineBreak, parseText format [
+    "<img align='center' size='1.65' image='\a3\3DEN\Data\Displays\Display3DEN\EntityMenu\functions_ca.paa' /><t align='center' size='1.65'>[%1] (%2) %3<\t>",
+    _prefix, _component, _title
+], lineBreak];
 
 {
     _compose append [lineBreak, format ["            %1", _x]];

--- a/addons/diagnostic/fnc_log.sqf
+++ b/addons/diagnostic/fnc_log.sqf
@@ -5,7 +5,6 @@ Description:
     Logs a message to the RPT log.
 
     Should not be used directly, but rather via macro (<LOG()>).
-    This function is unaffected by the debug level (<DEBUG_MODE_x>).
 
 Parameters:
     _message   - Message <STRING>
@@ -16,7 +15,6 @@ Returns:
 Author:
     Spooner, Rommel, commy2
 -----------------------------------------------------------------------------*/
-#define DEBUG_MODE_NORMAL
 #include "script_component.hpp"
 SCRIPT(log);
 

--- a/addons/diagnostic/gui.hpp
+++ b/addons/diagnostic/gui.hpp
@@ -4,7 +4,7 @@ class RscStructuredText;
 class RscTitles {
     class GVAR(Error) {
         idd = -1;
-        duration = 5;
+        duration = 10;
         fadeIn = 0;
         fadeOut = 0.5;
         movingEnable = 0;
@@ -16,10 +16,10 @@ class RscTitles {
                 font = "RobotoCondensedBold";
                 sizeEx = 0.55 * GUI_GRID_CENTER_H;
                 x =  0 * GUI_GRID_CENTER_W + GUI_GRID_CENTER_X;
-                y =  0 * GUI_GRID_CENTER_H + GUI_GRID_CENTER_Y;
+                y =  5 * GUI_GRID_CENTER_H + GUI_GRID_CENTER_Y;
                 w = 40 * GUI_GRID_CENTER_W;
                 h = 10 * GUI_GRID_CENTER_H;
-                colorBackground[] = {1,0.4,0,0.8};
+                colorBackground[] = {1,0.2,0,0.8};
             };
         };
     };

--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -222,7 +222,7 @@ Example:
 Author:
     Spooner
 ------------------------------------------- */
-#define ERROR(MESSAGE) LOG_SYS_FILELINENUMBERS('ERROR',MESSAGE)
+#define ERROR(MESSAGE) ['PREFIX', 'COMPONENT', MESSAGE, nil, __FILE__, __LINE__ + 1] call CBA_fnc_error
 
 /* -------------------------------------------
 Macro: ERROR_WITH_TITLE()


### PR DESCRIPTION
**When merged this pull request will:**
- Makes ERROR show the error pop up from ERROR_WITH_TITLE too (swaps around "title" and "message" for consistent result in RPT)

aesthetics:
- slightly darker
- adds math `fx` symbol from the 3den modifications
- move slightly downwards so it isn't blocked by 3den command bar on very large interface size combined with very low resolution
- extend display timeout from 5 to 10 seconds

![http://i.imgur.com/0Kf088A.png](http://i.imgur.com/0Kf088A.png)
