### PR TITLE
check data type of the arguments of 'CBA_fnc_addKeybind'

### DIFF
--- a/addons/keybinding/fnc_addKeybind.sqf
+++ b/addons/keybinding/fnc_addKeybind.sqf
@@ -48,7 +48,7 @@ _nullKeybind = [-1, [false,false,false]];
 params [
     ["_modName", "", [""]],
     ["_actionId", "", [""]],
-    ["_displayName", "", [""]],
+    ["_displayName", "", ["", []]],
     "_downCode",
     "_upCode",
     ["_defaultKeybind", _nullKeybind],
@@ -56,6 +56,14 @@ params [
     ["_holdDelay", 0],
     ["_overwrite", false]
 ];
+
+_displayName params [["_name", "", [""]], ["_tooltip", "", [""]]];
+
+if (_tooltip isEqualTo "") then {
+    _displayName = _name;
+} else {
+    _displayName = [_name, _tooltip];
+};
 
 if (count _defaultKeybind == 4) then {
     _msg = format ["%1: %2 - Wrong format for the default keybind parameter. Use [DIK, [shift, ctrl, alt]]", _modName, _actionId];

--- a/addons/keybinding/fnc_addKeybind.sqf
+++ b/addons/keybinding/fnc_addKeybind.sqf
@@ -45,7 +45,17 @@ if (!hasInterface) exitWith {};
 
 _nullKeybind = [-1, [false,false,false]];
 
-params ["_modName","_actionId","_displayName","_downCode","_upCode", ["_defaultKeybind", _nullKeybind], ["_holdKey",true], ["_holdDelay",0], ["_overwrite",false]];
+params [
+    ["_modName", "", [""]],
+    ["_actionId", "", [""]],
+    ["_displayName", "", [""]],
+    "_downCode",
+    "_upCode",
+    ["_defaultKeybind", _nullKeybind],
+    ["_holdKey", true],
+    ["_holdDelay", 0],
+    ["_overwrite", false]
+];
 
 if (count _defaultKeybind == 4) then {
     _msg = format ["%1: %2 - Wrong format for the default keybind parameter. Use [DIK, [shift, ctrl, alt]]", _modName, _actionId];


### PR DESCRIPTION
**When merged this pull request will:**
- @Nathan423 was using the function like this:
`["United Operations", "Admin Console", ["player", [], -10, "_this call uo_fnc_selfInteractMenu", "main"], [DIK_APPS, [false, false, false]], false, "keydown"] call cba_fnc_addKeybind;`,
but the third argument is meant to be a string.

- This is a really nasty error, because that array is stored in the profile and will lead to the following persistent error message:
```
17:05:28 Error in expression <aram [_forEachIndex, []];
 
_actionEntry params [["_displayName", "", ["", []]], >
17:05:28   Error position: <params [["_displayName", "", ["", []]], >
17:05:28   Error Params: Type String, expected Array
17:05:28 File x\cba\addons\help\XEH_postClientInit.sqf, line 79
```

- The only way to remove this error is to clear the keybinding variable from the profile.
- This PR makes it so the function checks the input to prevent errors like this in future.