### PR TITLE
playerEH - Optional call function if player defined

### DIFF
--- a/addons/events/fnc_addPlayerEventHandler.sqf
+++ b/addons/events/fnc_addPlayerEventHandler.sqf
@@ -17,7 +17,7 @@ Description:
 Parameters:
     _type      - Event handler type. <STRING>
     _function  - Function to add to event. <CODE>
-    _autoCall  - Call function immediately if player is defined already <BOOL>
+    _applyRetroactively - Call function immediately if player is defined already (optional, default: false) <BOOL>
 
 Returns:
     _id - The ID of the event handler. <NUMBER>
@@ -35,55 +35,55 @@ SCRIPT(addPlayerEventHandler);
 
 if (!hasInterface) exitWith {-1};
 
-params [["_type", "", [""]], ["_function", {}, [{}]], ["_autoCall", false, [false]]];
+params [["_type", "", [""]], ["_function", {}, [{}]], ["_applyRetroactively", false, [false]]];
 
 _type = toLower _type;
 
 private _id = switch (_type) do {
 case ("unit"): {
-    if (_autoCall && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
+    if (_applyRetroactively && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
         [GVAR(oldUnit), objNull] call _function;
     };
     [QGVAR(unitEvent), _function] call CBA_fnc_addEventHandler // return id
 };
 case ("weapon"): {
-    if (_autoCall && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
+    if (_applyRetroactively && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
         [GVAR(oldUnit), currentWeapon GVAR(oldUnit)] call _function;
     };
     [QGVAR(weaponEvent), _function] call CBA_fnc_addEventHandler // return id
 };
 case ("loadout"): {
-    if (_autoCall && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
+    if (_applyRetroactively && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
         [GVAR(oldUnit), getUnitLoadout GVAR(oldUnit)] call _function;
     };
     [QGVAR(loadoutEvent), _function] call CBA_fnc_addEventHandler // return id
 };
 case ("vehicle"): {
-    if (_autoCall && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
+    if (_applyRetroactively && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
         [GVAR(oldUnit), vehicle GVAR(oldUnit)] call _function;
     };
     [QGVAR(vehicleEvent), _function] call CBA_fnc_addEventHandler // return id
 };
 case ("turret"): {
-    if (_autoCall && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
+    if (_applyRetroactively && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
         [GVAR(oldUnit), GVAR(oldUnit) call CBA_fnc_turretPath] call _function;
     };
     [QGVAR(turretEvent), _function] call CBA_fnc_addEventHandler // return id
 };
 case ("visionmode"): {
-    if (_autoCall && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
+    if (_applyRetroactively && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
         [GVAR(oldUnit), currentVisionMode GVAR(oldUnit)] call _function;
     };
     [QGVAR(visionModeEvent), _function] call CBA_fnc_addEventHandler // return id
 };
 case ("cameraview"): {
-    if (_autoCall && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
+    if (_applyRetroactively && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
         [GVAR(oldUnit), cameraView] call _function;
     };
     [QGVAR(cameraViewEvent), _function] call CBA_fnc_addEventHandler // return id
 };
 case ("visiblemap"): {
-    if (_autoCall && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
+    if (_applyRetroactively && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
         [GVAR(oldUnit), visibleMap] call _function;
     };
     [QGVAR(visibleMapEvent), _function] call CBA_fnc_addEventHandler // return id

--- a/addons/events/fnc_addPlayerEventHandler.sqf
+++ b/addons/events/fnc_addPlayerEventHandler.sqf
@@ -17,6 +17,7 @@ Description:
 Parameters:
     _type      - Event handler type. <STRING>
     _function  - Function to add to event. <CODE>
+    _autoCall  - Call function immediately if player is defined already <BOOL>
 
 Returns:
     _id - The ID of the event handler. <NUMBER>
@@ -34,33 +35,57 @@ SCRIPT(addPlayerEventHandler);
 
 if (!hasInterface) exitWith {-1};
 
-params [["_type", "", [""]], ["_function", {}, [{}]]];
+params [["_type", "", [""]], ["_function", {}, [{}]], ["_autoCall", false, [false]]];
 
 _type = toLower _type;
 
 private _id = switch (_type) do {
 case ("unit"): {
+    if (_autoCall && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
+        [GVAR(oldUnit), objNull] call _function;
+    };
     [QGVAR(unitEvent), _function] call CBA_fnc_addEventHandler // return id
 };
 case ("weapon"): {
+    if (_autoCall && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
+        [GVAR(oldUnit), currentWeapon GVAR(oldUnit)] call _function;
+    };
     [QGVAR(weaponEvent), _function] call CBA_fnc_addEventHandler // return id
 };
 case ("loadout"): {
+    if (_autoCall && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
+        [GVAR(oldUnit), getUnitLoadout GVAR(oldUnit)] call _function;
+    };
     [QGVAR(loadoutEvent), _function] call CBA_fnc_addEventHandler // return id
 };
 case ("vehicle"): {
+    if (_autoCall && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
+        [GVAR(oldUnit), vehicle GVAR(oldUnit)] call _function;
+    };
     [QGVAR(vehicleEvent), _function] call CBA_fnc_addEventHandler // return id
 };
 case ("turret"): {
+    if (_autoCall && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
+        [GVAR(oldUnit), GVAR(oldUnit) call CBA_fnc_turretPath] call _function;
+    };
     [QGVAR(turretEvent), _function] call CBA_fnc_addEventHandler // return id
 };
 case ("visionmode"): {
+    if (_autoCall && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
+        [GVAR(oldUnit), currentVisionMode GVAR(oldUnit)] call _function;
+    };
     [QGVAR(visionModeEvent), _function] call CBA_fnc_addEventHandler // return id
 };
 case ("cameraview"): {
+    if (_autoCall && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
+        [GVAR(oldUnit), cameraView] call _function;
+    };
     [QGVAR(cameraViewEvent), _function] call CBA_fnc_addEventHandler // return id
 };
 case ("visiblemap"): {
+    if (_autoCall && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
+        [GVAR(oldUnit), visibleMap] call _function;
+    };
     [QGVAR(visibleMapEvent), _function] call CBA_fnc_addEventHandler // return id
 };
 default {-1};


### PR DESCRIPTION
- Adds optional param to call event handler function if player is already defined.

This makes it simpler to use `addPlayerEventHandler` by adding an option to guarantee the function will be run even if the changed xxxEvent has already happened. 

Example use:
```
[] spawn {
    // Dummy playerEH - represents some other mod has already installed the player EH system
    ["unit", {}] call CBA_fnc_addPlayerEventHandler;
    sleep 0.1;

    // This will not print out anything as the unitEvent has already happened:
    ["unit", {systemChat format ["unit eh (False) - %1",_this]}] call CBA_fnc_addPlayerEventHandler;

    // This will print right away
    ["unit", {systemChat format ["unit eh (True) - %1",_this]}, true] call CBA_fnc_addPlayerEventHandler;
};
```

Ref https://github.com/acemod/ACE3/pull/4289