### PR TITLE
fix default value of 'CBA_fnc_hashHasKey', close #502

### DIFF
--- a/addons/hashes/fnc_hashHasKey.sqf
+++ b/addons/hashes/fnc_hashHasKey.sqf
@@ -23,6 +23,6 @@ Author:
 SCRIPT(hashHasKey);
 
 // -----------------------------------------------------------------------------
-params [["_hash", [], [[]]], "_key"];
+params [["_hash", [] call CBA_fnc_hashCreate, [[]]], "_key"];
 
 _key in (_hash select HASH_KEYS); // Return.


### PR DESCRIPTION
**When merged this pull request will:**
- Default value should be an empty hash and not an empty array. Otherwise `(_hash select 1)` will error out.
- closes #502