### PR TITLE
Use fast static array for default param

### DIFF
--- a/addons/hashes/fnc_hashHasKey.sqf
+++ b/addons/hashes/fnc_hashHasKey.sqf
@@ -23,6 +23,6 @@ Author:
 SCRIPT(hashHasKey);
 
 // -----------------------------------------------------------------------------
-params [["_hash", [] call CBA_fnc_hashCreate, [[]]], "_key"];
+params [["_hash", [[], []], [[]]], "_key"];
 
 _key in (_hash select HASH_KEYS); // Return.


### PR DESCRIPTION
Minor performance improvment from #503

```
AAA = {
    params [["_hash", [] call CBA_fnc_hashCreate, [[]]], "_key"];
    _key in (_hash select 1); 
};
BBB = {
    params [["_hash", [[], []], [[]]], "_key"];
    _key in (_hash select 1); 
};
hash = ["#CBA_HASH#",["A","B","C","D","E"],[1,2,3,4,5],nil];

return = [hash, "A"] call AAA;
return = [hash, "B"] call AAA;
return = [hash, "C"] call AAA;
return = [hash, "D"] call AAA;
return = [hash, "E"] call AAA;
return = [hash, "F"] call AAA;
return = [hash, "G"] call AAA;
return = [hash, "H"] call AAA;
return = [hash, "I"] call AAA;
return = [hash, "J"] call AAA;
// 0.167224 ms

return = [hash, "A"] call BBB;
return = [hash, "B"] call BBB;
return = [hash, "C"] call BBB;
return = [hash, "D"] call BBB;
return = [hash, "E"] call BBB;
return = [hash, "F"] call BBB;
return = [hash, "G"] call BBB;
return = [hash, "H"] call BBB;
return = [hash, "I"] call BBB;
return = [hash, "J"] call BBB;
// 0.0507 ms
```