### PR TITLE
Add param for slider setting to only be whole numbers

### DIFF
--- a/addons/settings/fnc_check.sqf
+++ b/addons/settings/fnc_check.sqf
@@ -31,8 +31,8 @@ switch (toUpper _settingType) do {
         _value in _values
     };
     case ("SLIDER"): {
-        _settingData params ["_min", "_max"];
-        _value isEqualType 0 && {_value >= _min} && {_value <= _max}
+        _settingData params ["_min", "_max", "_trailingDecimals"];
+        _value isEqualType 0 && {_value >= _min} && {_value <= _max} && {(_trailingDecimals >= 0) || {(round _value) == _value}}
     };
     case ("COLOR"): {
         _value isEqualType [] && {count _value == count _defaultValue} && {_value isEqualTypeAll 0} && {{_x < 0 || _x > 1} count _value == 0}

--- a/addons/settings/gui_createMenu_slider.sqf
+++ b/addons/settings/gui_createMenu_slider.sqf
@@ -25,6 +25,7 @@ _ctrlSetting ctrlAddEventHandler ["SliderPosChanged", {
     params ["_control", "_value"];
 
     (_control getVariable QGVAR(data)) params ["_setting", "_source", "_trailingDecimals"];
+    if (_trailingDecimals < 0) then {_value = round _value};
 
     (_control getVariable QGVAR(linkedControls)) params ["", "_linkedControl", "_defaultControl"];
     _linkedControl ctrlSetText ([_value, 1, _trailingDecimals] call CBA_fnc_formatNumber);
@@ -62,6 +63,7 @@ _ctrlSettingEdit ctrlAddEventHandler ["KeyUp", {
     _linkedControl sliderSetPosition _value;
 
     _value = sliderPosition _linkedControl;
+    if (_trailingDecimals < 0) then {_value = round _value};
     SET_TEMP_NAMESPACE_VALUE(_setting,_value,_source);
 
     //If new setting is same as default value, grey out the default button


### PR DESCRIPTION
Setting `_trailingDecimals` to be less than 0 will only allow whole numbers to be allowed.

E.G.

```
["Test_Setting_3", "SLIDER",   ["-test slider-",   "-tooltip-"], "My Category", [0, 10, 5, -1]] call cba_settings_fnc_init;
```

Useful for settings where the value needs to be an integer.
Like a max number of objects or a `for "_i" from 0 to Test_Setting_3 {`
