### PR TITLE
remove 'File:' and 'Line:' from log macros/functions

### DIFF
--- a/addons/diagnostic/fnc_error.sqf
+++ b/addons/diagnostic/fnc_error.sqf
@@ -36,7 +36,7 @@ params [
 _prefix = toUpper _prefix;
 
 // RPT log
-diag_log text format ["[%1] (%2) ERROR: %3 File: %4 Line: %5", _prefix, _component, _title, _file, _lineNum];
+diag_log text format ["[%1] (%2) ERROR: %3 %4:%5", _prefix, _component, _title, _file, _lineNum];
 
 private _lines = [_message, "\n"] call CBA_fnc_split;
 

--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -142,7 +142,7 @@ Author:
 #define LOG_SYS(LEVEL,MESSAGE) LOG_SYS_FORMAT(LEVEL,MESSAGE) call CBA_fnc_log
 #endif
 
-#define LOG_SYS_FILELINENUMBERS(LEVEL,MESSAGE) LOG_SYS(LEVEL,format [ARR_4('%1 File: %2 Line: %3',MESSAGE,__FILE__,__LINE__ + 1)])
+#define LOG_SYS_FILELINENUMBERS(LEVEL,MESSAGE) LOG_SYS(LEVEL,format [ARR_4('%1 %2:%3',MESSAGE,__FILE__,__LINE__ + 1)])
 
 /* -------------------------------------------
 Macro: LOG()
@@ -286,8 +286,6 @@ Macro: ERROR_WITH_TITLE()
 
     The title can be specified (in <ERROR()> the heading is always just "ERROR")
     Newlines (\n) in the MESSAGE will be put on separate lines.
-
-    TODO: Popup an error dialog & throw an exception.
 
 Parameters:
     TITLE - Title of error message <STRING>


### PR DESCRIPTION
**When merged this pull request will:**
- Shortens custom RPT messages:
```
before - after:
[CBA] (diagnostic) ERROR: example title File: x\cba\addons\diagnostic\fnc_initExtendedDebug.sqf Line: 123
[CBA] (diagnostic) ERROR: example title x\cba\addons\diagnostic\fnc_initExtendedDebug.sqf:123
```
- also removes an obsolete TODO