### PR TITLE
State machine enhancements

### DIFF
--- a/addons/statemachine/XEH_PREP.hpp
+++ b/addons/statemachine/XEH_PREP.hpp
@@ -1,8 +1,11 @@
+PREP(addEventTransition);
 PREP(addState);
 PREP(addTransition);
 PREP(clockwork);
 PREP(create);
 PREP(createFromConfig);
 PREP(delete);
+PREP(getCurrentState);
+PREP(manualTransition);
 PREP(toString);
 PREP(updateList);

--- a/addons/statemachine/example.hpp
+++ b/addons/statemachine/example.hpp
@@ -26,6 +26,12 @@ class MyAddon_Statemachine {
                 _x setSkill ['spotTime',     ((_x skill 'spotTime')     * 1.5) min 1]; \
             } forEach (units _this);";
         };
+
+        // Event transitions get triggered by CBA events
+        class Alarm: InCombat {
+            events[] = {"MyAddon_AlarmRaised"};
+            condition = "true";
+        };
     };
 
     // Empty classes will also work if the state contains no transitions or onState code.

--- a/addons/statemachine/example.sqf
+++ b/addons/statemachine/example.sqf
@@ -24,6 +24,13 @@ private _stateMachine = [{allGroups select {!isPlayer leader _x}}, true] call CB
     } forEach (units _this);
 }, "InCombat"] call CBA_statemachine_fnc_addTransition;
 
+[_stateMachine, "Initial", "Alert", ["MyAddon_AlarmRaised"], {true}, {
+    {
+        _x setSkill ["spotDistance", ((_x skill "spotDistance") * 1.5) min 1];
+        _x setSkill ["spotTime",     ((_x skill "spotTime")     * 1.5) min 1];
+    } forEach (units _this);
+}, "Alarm"] call CBA_statemachine_fnc_addEventTransition;
+
 // This makes sure you can execute this through the debug console
 _stateMachine spawn {
     sleep 0.1;

--- a/addons/statemachine/fnc_addEventTransition.sqf
+++ b/addons/statemachine/fnc_addEventTransition.sqf
@@ -1,0 +1,88 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_statemachine_fnc_addEventTransition
+
+Description:
+    Creates a transition between two states.
+
+Parameters:
+    _stateMachine   - a state machine <LOCATION>
+    _originalState  - state the transition origins from <STRING>
+    _targetState    - state the transition goes to <STRING>
+    _events         - list of events that can trigger the transition <ARRAY>
+    _condition      - additional condition required for the transition to
+                      trigger <CODE>
+    _onTransition   - code that gets executed once transition happens <CODE>
+                      (Default: {})
+    _name           - name for this specific transition <STRING>
+                      (Default: "NONAME")
+
+Returns:
+    _wasCreated     - check if the transition was created <BOOL>
+
+Examples:
+    (begin example)
+        [_stateMachine, "initial", "end", ["end_statemachine"], {true}, {
+            systemChat format [
+                "%1 transitioned from %2 to %3 via %4.",
+                _this, _thisOrigin, _thisTarget, _thisTransition
+            ];
+        }, "dummyTransition"] call CBA_statemachine_fnc_addEventTransition;
+    (end)
+
+Author:
+    BaerMitUmlaut
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+SCRIPT(addEventTransition);
+params [
+    ["_stateMachine", locationNull, [locationNull]],
+    ["_originalState", "", [""]],
+    ["_targetState", "", [""]],
+    ["_events", [], [[]]],
+    ["_condition", {}, [{}, ""]],
+    ["_onTransition", {}, [{}]],
+    ["_name", "NONAME", [""]]
+];
+
+private _states = _stateMachine getVariable QGVAR(states);
+
+if (isNull _stateMachine
+    || {!(_originalState in _states)}
+    || {!(_targetState in _states)}
+    || {!(_events isEqualTypeAll "")}
+) exitWith {false};
+
+if (_condition isEqualTo {}) then {
+    _condition = {true};
+};
+
+{
+    [_x, {
+        params ["_listItem"];
+        // The condition needs to be able to access these variables
+        _thisArgs params [
+            "_condition",
+            "_stateMachine",
+            "_thisOrigin",
+            "_thisTarget",
+            "",
+            "_thisTransition"
+        ];
+        private _thisState = _thisOrigin;
+
+        if (([_listItem, _stateMachine] call FUNC(getCurrentState)) != _thisState) exitWith {};
+
+        if (_listItem call _condition) then {
+            // Replace condition with listItem for params
+            private _args =+ _thisArgs;
+            _args set [0, _listItem];
+            _args call FUNC(manualTransition);
+        };
+    }, [_condition, _stateMachine, _originalState, _targetState, _onTransition, _name]] call CBA_fnc_addEventHandlerArgs;
+} forEach _events;
+
+private _eventTransitions = _stateMachine getVariable EVENTTRANSITIONS(_originalState);
+_eventTransitions pushBack [_name, _events, _condition, _targetState, _onTransition];
+_stateMachine setVariable [EVENTTRANSITIONS(_originalState), _eventTransitions];
+
+true

--- a/addons/statemachine/fnc_addState.sqf
+++ b/addons/statemachine/fnc_addState.sqf
@@ -57,6 +57,7 @@ _stateMachine setVariable [ONSTATE(_name), _onState];
 _stateMachine setVariable [ONSTATEENTERED(_name), _onStateEntered];
 _stateMachine setVariable [ONSTATELEAVING(_name), _onStateLeaving];
 _stateMachine setVariable [TRANSITIONS(_name), []];
+_stateMachine setVariable [EVENTTRANSITIONS(_name), []];
 
 // First state added is always the intial state
 if (isNil {_stateMachine getVariable QGVAR(initialState)}) then {

--- a/addons/statemachine/fnc_createFromConfig.sqf
+++ b/addons/statemachine/fnc_createFromConfig.sqf
@@ -32,9 +32,9 @@ private _stateMachine = [_list, _skipNull] call FUNC(create);
 
 {
     private _state = configName _x;
-    private _onState = compile getText (_x >> "onState");
-    private _onStateEntered = compile getText (_x >> "onStateEntered");
-    private _onStateLeaving = compile getText (_x >> "onStateLeaving");
+    GET_FUNCTION(_onState,_x >> "onState");
+    GET_FUNCTION(_onStateEntered,_x >> "onStateEntered");
+    GET_FUNCTION(_onStateLeaving,_x >> "onStateLeaving");
     [_stateMachine, _onState, _onStateEntered, _onStateLeaving, _state] call FUNC(addState);
 
     false
@@ -46,10 +46,15 @@ private _stateMachine = [_list, _skipNull] call FUNC(create);
     {
         private _transition = configName _x;
         private _targetState = getText (_x >> "targetState");
-        private _condition = compile getText (_x >> "condition");
-        private _onTransition = compile getText (_x >> "onTransition");
+        GET_FUNCTION(_condition,_x >> "condition");
+        GET_FUNCTION(_onTransition,_x >> "onTransition");
+        private _events = getArray (_x >> "events");
 
-        [_stateMachine, _state, _targetState, _condition, _onTransition, _transition] call FUNC(addTransition);
+        if (_events isEqualTo []) then {
+            [_stateMachine, _state, _targetState, _condition, _onTransition, _transition] call FUNC(addTransition);
+        } else {
+            [_stateMachine, _state, _targetState, _events, _condition, _onTransition, _transition] call FUNC(addEventTransition);
+        };
 
         false
     } count (configProperties [_x, "isClass _x", true]);

--- a/addons/statemachine/fnc_getCurrentState.sqf
+++ b/addons/statemachine/fnc_getCurrentState.sqf
@@ -1,0 +1,30 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_statemachine_fnc_getCurrentState
+
+Description:
+    Manually triggers a transition.
+
+Parameters:
+    _listItem       - item to get the state of <any namespace type>
+    _stateMachine   - state machine <LOCATION>
+
+Returns:
+    _currentState   - state of the given item <STRING>
+
+Examples:
+    (begin example)
+        _currentState = [player, _stateMachine] call CBA_statemachine_fnc_getCurrentState;
+    (end)
+
+Author:
+    BaerMitUmlaut
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+SCRIPT(getCurrentState);
+params [
+    ["_listItem", objNull, [missionNamespace, objNull, grpNull, teamMemberNull, taskNull, locationNull]],
+    ["_stateMachine", locationNull, [locationNull]]
+];
+
+private _id = _stateMachine getVariable QGVAR(ID);
+[_listItem getVariable (QGVAR(state) + str _id)] param [0, _stateMachine getVariable QGVAR(initialState)];

--- a/addons/statemachine/fnc_manualTransition.sqf
+++ b/addons/statemachine/fnc_manualTransition.sqf
@@ -1,0 +1,49 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_statemachine_fnc_manualTransition
+
+Description:
+    Manually triggers a transition.
+
+Parameters:
+    _listItem       - the item which should transition <any namespace type>
+    _stateMachine   - a state machine <LOCATION>
+    _thisOrigin     - state the transition origins from <STRING>
+    _thisTarget     - state the transition goes to <STRING>
+    _onTransition   - code that gets executed once transition happens <CODE>
+                      (Default: {})
+    _thisTransition - name for this specific transition <STRING>
+                      (Default: "MANUAL")
+
+Returns:
+    Nothing
+
+Examples:
+    (begin example)
+        [_stateMachine, "initial", "end", {
+            systemChat format [
+                "%1 transitioned from %2 to %3 manually.",
+                _this, _thisOrigin, _thisTarget
+            ];
+        }, "dummyTransition"] call CBA_statemachine_fnc_manualTransition;
+    (end)
+
+Author:
+    BaerMitUmlaut
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+SCRIPT(manualTransition);
+params [
+    ["_listItem", objNull, [missionNamespace, objNull, grpNull, teamMemberNull, taskNull, locationNull]],
+    ["_stateMachine", locationNull, [locationNull]],
+    ["_thisOrigin", "", [""]],
+    ["_thisTarget", "", [""]],
+    ["_onTransition", {}, [{}]],
+    ["_thisTransition", "MANUAL", [""]]
+];
+private _thisState = _thisOrigin;
+private _id = _stateMachine getVariable QGVAR(ID);
+
+_listItem call (_stateMachine getVariable ONSTATELEAVING(_thisOrigin));
+_listItem call _onTransition;
+_listItem setVariable [QGVAR(state) + str _id, _thisTarget];
+_listItem call (_stateMachine getVariable ONSTATEENTERED(_thisTarget));

--- a/addons/statemachine/fnc_toString.sqf
+++ b/addons/statemachine/fnc_toString.sqf
@@ -59,10 +59,11 @@ _output = _output + "States: " + _nli;
     } else {
         _output = _output + _x + _nli;
     };
+
     {
         _x params ["_name", "_condition", "_targetState", "_onTransition"];
         if (_outputCode) then {
-            _output = _output + "        " + format ["Transition %1:%2", _name, _nli3];
+            _output = _output + "    " + format ["Transition %1:%2", _name, _nli3];
             _output = _output + "Condition: " + str _condition + _nli3;
             _output = _output + "Target: " + _targetState + _nli3;
             _output = _output + "onTransition: " + str _onTransition + _nli;
@@ -72,6 +73,21 @@ _output = _output + "States: " + _nli;
 
         false
     } count (_stateMachine getVariable TRANSITIONS(_x));
+
+    {
+        _x params ["_name", "_events", "_condition", "_targetState", "_onTransition"];
+        if (_outputCode) then {
+            _output = _output + "    " + format ["Event transition %1:%2", _name, _nli3];
+            _output = _output + "Events: " + (_events joinString ", ") + _nli3;
+            _output = _output + "Condition: " + str _condition + _nli3;
+            _output = _output + "Target: " + _targetState + _nli3;
+            _output = _output + "onTransition: " + str _onTransition + _nli;
+        } else {
+            _output = _output + "    " + format ["%1 -> %2%3", _name, _targetState, _nli];
+        };
+
+        false
+    } count (_stateMachine getVariable EVENTTRANSITIONS(_x));
 
     false
 } count (_stateMachine getVariable QGVAR(states));

--- a/addons/statemachine/script_component.hpp
+++ b/addons/statemachine/script_component.hpp
@@ -14,6 +14,13 @@
 #include "\x\cba\addons\main\script_macros.hpp"
 
 #define TRANSITIONS(var) (var + "_transitions")
+#define EVENTTRANSITIONS(var) (var + "_eventTransitions")
 #define ONSTATE(var) (var + "_onState")
 #define ONSTATEENTERED(var) (var + "_onStateEntered")
 #define ONSTATELEAVING(var) (var + "_onStateLeaving")
+#define GET_FUNCTION(var,cfg) private var = getText (cfg); \
+    if (isNil var) then { \
+        var = compile var; \
+    } else { \
+        var = missionNamespace getVariable var;\
+    }


### PR DESCRIPTION
**When merged this pull request will:**
- Add event transitions (transitions that can only trigger when a CBA event is raised)
- Add manual transitions by function call
- Add a current state getter that returns the current state of a list item within a given state machine
- Simplify config by allowing config like `onState = QFUNC(handleState);` (removes the necessity of using call)