### PR TITLE
Function headers with debugging callstack

### DIFF
--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -871,13 +871,28 @@ Author:
 
 //#define PREP(var1) PREP_SYS(PREFIX,COMPONENT_F,var1)
 
-#ifdef DISABLE_COMPILE_CACHE
-    #define PREP(var1) TRIPLES(ADDON,fnc,var1) = compile preProcessFileLineNumbers 'PATHTO_SYS(PREFIX,COMPONENT_F,DOUBLES(fnc,var1))'
-    #define PREPMAIN(var1) TRIPLES(PREFIX,fnc,var1) = compile preProcessFileLineNumbers 'PATHTO_SYS(PREFIX,COMPONENT_F,DOUBLES(fnc,var1))'
+#ifndef DISABLE_COMPILE_CACHE
+    #define ENABLE_CACHING true
 #else
-    #define PREP(var1) ['PATHTO_SYS(PREFIX,COMPONENT_F,DOUBLES(fnc,var1))', 'TRIPLES(ADDON,fnc,var1)'] call SLX_XEH_COMPILE_NEW
-    #define PREPMAIN(var1) ['PATHTO_SYS(PREFIX,COMPONENT_F,DOUBLES(fnc,var1))', 'TRIPLES(PREFIX,fnc,var1)'] call SLX_XEH_COMPILE_NEW
+    #define ENABLE_CACHING false
 #endif
+
+#ifdef DEBUG_MODE_FULL
+    #define ENABLE_CALLSTACK true
+#else
+    #define ENABLE_CALLSTACK false
+#endif
+
+#define PREP(var1) ['PATHTO_SYS(PREFIX,COMPONENT_F,DOUBLES(fnc,var1))', 'TRIPLES(ADDON,fnc,var1)', ENABLE_CACHING, ENABLE_CALLSTACK] call CBA_fnc_compileFunction
+#define PREPMAIN(var1) ['PATHTO_SYS(PREFIX,COMPONENT_F,DOUBLES(fnc,var1))', 'TRIPLES(PREFIX,fnc,var1)', ENABLE_CACHING, ENABLE_CALLSTACK] call CBA_fnc_compileFunction
+
+// Be aware that the RETURN macro only works with functions compiled with CBA_fnc_compileFunction!
+#define RETURN breakOut "CBA_ROOT_SCOPE"
+#define RETURN(var1) if (isNil {var1}) then { \
+        breakOut "CBA_ROOT_SCOPE" \
+    } else { \
+        (var1) breakOut "CBA_ROOT_SCOPE" \
+    }
 
 #ifdef RECOMPILE
     #undef RECOMPILE

--- a/addons/xeh/CfgFunctions.hpp
+++ b/addons/xeh/CfgFunctions.hpp
@@ -36,6 +36,10 @@ class CfgFunctions {
                 description = "Compiles a function into mission namespace and into ui namespace for caching purposes.";
                 file = PATHTOF(fnc_compileFunction.sqf);
             };
+            class dumpCallstack {
+                description = "Dumps the current callstack to the RPT.";
+                file = PATHTOF(fnc_dumpCallstack.sqf);
+            };
             class preStart {
                 preStart = 1;
                 description = "Occurs once during game start.";

--- a/addons/xeh/fnc_dumpCallstack.sqf
+++ b/addons/xeh/fnc_dumpCallstack.sqf
@@ -1,0 +1,53 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_dumpCallstack
+
+Description:
+    Dumps the current callstack to the RPT.
+
+Parameters:
+    None
+
+Returns:
+    None
+
+Examples:
+    (begin example)
+        [] call CBA_fnc_dumpCallstack;
+    (end)
+
+Author:
+    BaerMitUmlaut
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+if (isNil "CBA_callstack") exitWith {};
+
+private _tab = "    ";
+private _nl = toString [13, 10];
+private _indentation = "";
+private _indentationMemory = [];
+_indentationMemory resize count CBA_callstack;
+private _lastHandle = -1;
+
+private _output = "Dumping callstack:" + _nl;
+{
+    _x params ["_currentHandle", "_parent", "_parentHandle"];
+    private _current = CBA_functionHandles select _currentHandle;
+
+    if (_parentHandle != _lastHandle) then {
+        _indentation = _indentationMemory select _parentHandle;
+    };
+
+    if (_parent == (CBA_functionHandles param [_parentHandle, ""])) then {
+        _output = _output + _indentation + format ["-> %1", _current] + _nl;
+    } else {
+        if (_current == _parent) then {
+            _parent = "unknown function";
+        };
+        _output = _output + _indentation + format ["-> %1 (via %2)", _current, _parent] + _nl;
+    };
+
+    _indentation = _indentation + _tab;
+    _indentationMemory set [_currentHandle, _indentation];
+} forEach CBA_callstack;
+
+diag_log text _output;

--- a/addons/xeh/fnc_test_prep.sqf
+++ b/addons/xeh/fnc_test_prep.sqf
@@ -1,0 +1,9 @@
+if (_this == 0) exitWith {
+    RETURN("test");
+};
+
+if (_this == 3) then {
+    [missionNamespace getVariable _fnc_scriptName, _this - 1] call CBA_fnc_directCall;
+};
+
+(_this - 1) call (missionNamespace getVariable _fnc_scriptName);

--- a/addons/xeh/script_header.hpp
+++ b/addons/xeh/script_header.hpp
@@ -1,0 +1,4 @@
+scopeName "CBA_ROOT_SCOPE";
+private _fnc_scriptNameParent = if (isNil "_fnc_scriptName") then {"%1"} else {_fnc_scriptName};
+private _fnc_scriptName = "%1";
+scriptName _fnc_scriptName;

--- a/addons/xeh/script_header_callstack.hpp
+++ b/addons/xeh/script_header_callstack.hpp
@@ -1,0 +1,16 @@
+private _CBA_lastHandle = _CBA_functionHandle;
+private _CBA_functionHandle = CBA_functionHandles pushBack _fnc_scriptName;
+
+if (isNil "_CBA_lastHandle") then {
+    [] call CBA_fnc_dumpCallstack;
+
+    CBA_functionHandles = [_fnc_scriptName];
+    _CBA_functionHandle = 0;
+    CBA_callstack = [[_CBA_functionHandle, _fnc_scriptNameParent, -1]];
+} else {
+    CBA_callstack pushBack [_CBA_functionHandle, _fnc_scriptNameParent, _CBA_lastHandle];
+};
+
+if (canSuspend) then {
+    diag_log formatText ["Warning: %1 was called in scheduled environment which is not supported by the CBA callstack.", _fnc_scriptName];
+};


### PR DESCRIPTION
**When merged this pull request will:**
- Add a small header to each compiled function, very similar to what BI does in `initFunctions.sqf`, but with an added root scope
- Make it possible to use a `RETURN`/`RETURN(value)` macro
- Add callstack logging and dumping when `DEBUG_MODE_FULL` is defined

The callstack logging and dumping happens automatically. It's a bit of overhead, but since it's only used for debugging I think that's fine. It's also not fully compatible with functions running in the scheduled environment, but there's nothing you can really do about that.

I've included a [test function](https://github.com/BaerMitUmlaut/CBA_A3/blob/compile-headers/addons/xeh/fnc_test_prep.sqf). When it was compiled with the callstack header and you run this code:

```
diag_log (5 call cba_xeh_fnc_test_prep);
call CBA_fnc_dumpCallstack;
```

The follwing will get dumped into your RPT file:

```
20:17:21 "test"
20:17:21 Dumping callstack:
-> cba_xeh_fnc_test_prep (via unknown function)
    -> cba_xeh_fnc_test_prep
        -> cba_xeh_fnc_test_prep
            -> cba_xeh_fnc_test_prep (via CBA_fnc_directCall)
                -> cba_xeh_fnc_test_prep
                    -> cba_xeh_fnc_test_prep
            -> cba_xeh_fnc_test_prep
                -> cba_xeh_fnc_test_prep
                    -> cba_xeh_fnc_test_prep
```

As you can see the formatting enables you to see which function called which and it's not just a simple list (which is especially useful with recursive functions like this one).
