### PR TITLE
Revert nearPlayer.sqf to use CBA_fnc_players

### DIFF
--- a/addons/common/fnc_nearPlayer.sqf
+++ b/addons/common/fnc_nearPlayer.sqf
@@ -31,6 +31,6 @@ private _return = false;
     if (_position distance _x < _distance) exitWith {
         _return = true;
     };
-} forEach allPlayers;
+} forEach ([] call CBA_fnc_players);
 
 _return


### PR DESCRIPTION
**When merged this pull request will:**

Was changed in commit 5ba5885 #291 due to CBA_fnc_players being deprecated. CBA_fnc_players is back and doesn't report HC's (and works early on). This PR reverts to the old and expected behaviour.