### PR TITLE
Use new entities syntax to improve xeh speed

### DIFF
--- a/addons/xeh/fnc_addClassEventHandler.sqf
+++ b/addons/xeh/fnc_addClassEventHandler.sqf
@@ -55,7 +55,6 @@ if (_applyInitRetroactively && {!(_eventName in ["init", "initpost"])}) then {
 };
 
 // add events to already existing objects
-private _entities = entities [[], [], true, true];
 private _eventVarName = format [QGVAR(%1), _eventName];
 
 {
@@ -75,7 +74,8 @@ private _eventVarName = format [QGVAR(%1), _eventName];
             };
         };
     };
-} forEach _entities;
+    true
+} count (entities [[], [], true, true]);
 
 // define for units that are created later
 private _events = EVENTHANDLERS(_eventName,_className);

--- a/addons/xeh/fnc_addClassEventHandler.sqf
+++ b/addons/xeh/fnc_addClassEventHandler.sqf
@@ -55,7 +55,7 @@ if (_applyInitRetroactively && {!(_eventName in ["init", "initpost"])}) then {
 };
 
 // add events to already existing objects
-private _entities = entities "" + allUnits;
+private _entities = entities [[], [], true, true];
 private _eventVarName = format [QGVAR(%1), _eventName];
 
 {
@@ -75,7 +75,7 @@ private _eventVarName = format [QGVAR(%1), _eventName];
             };
         };
     };
-} forEach (_entities arrayIntersect _entities); // filter duplicates
+} forEach _entities;
 
 // define for units that are created later
 private _events = EVENTHANDLERS(_eventName,_className);

--- a/addons/xeh/fnc_startFallbackLoop.sqf
+++ b/addons/xeh/fnc_startFallbackLoop.sqf
@@ -28,12 +28,12 @@ GVAR(fallbackRunning) = true;
 {
     // don't run init and initPost event handlers on objects that already exist
     SETINITIALIZED(_x);
-} forEach (entities "" + allUnits);
+} forEach (entities [[], [], true, true]);
 
 GVAR(entities) = [];
 
 [{
-    private _entities = entities "" + allUnits;
+    private _entities = entities [[], [], true, true];
 
     if !(_entities isEqualTo GVAR(entities)) then {
         GVAR(entities) = _entities;

--- a/addons/xeh/fnc_startFallbackLoop.sqf
+++ b/addons/xeh/fnc_startFallbackLoop.sqf
@@ -28,7 +28,8 @@ GVAR(fallbackRunning) = true;
 {
     // don't run init and initPost event handlers on objects that already exist
     SETINITIALIZED(_x);
-} forEach (entities [[], [], true, true]);
+    true
+} count (entities [[], [], true, true]);
 
 GVAR(entities) = [];
 


### PR DESCRIPTION
new 0.0429 ms 
`private _entities = entities [[], [], true, true]`
old 3.02719 ms
`_entities = entities "" + allUnits;_entities arrayIntersect _entities;`

I'm bored u know.
Was commy's Idea and I made a PR before he could.