### PR TITLE
Fix keybind tooltips

### DIFF
--- a/addons/keybinding/gui/fnc_updateGUI.sqf
+++ b/addons/keybinding/gui/fnc_updateGUI.sqf
@@ -111,7 +111,8 @@ if !(isNull _display) then {
 
                     // Add the row.
                     _lbCount = _lnb lnbAddRow [_actionName, _keyString];
-                    _lnb lbSetTooltip [_lbCount, _toolTip];
+                    _lnb lbSetTooltip [2*_lbCount, _toolTip];
+                    _lnb lbSetTooltip [2*_lbCount + 1, _toolTip];
 
                     // Format the array containing the indexes referred to by the action name.
                     // It is stored as a string.


### PR DESCRIPTION
I think this is from the mixed use of lnb/lb commands (there is no lnbSetTooltip).
So the index needed is based on each row having 2 elements.