### PR TITLE
Add Timeout CBA_fnc_waitUntilAndExecute

### DIFF
--- a/addons/common/fnc_waitUntilAndExecute.sqf
+++ b/addons/common/fnc_waitUntilAndExecute.sqf
@@ -3,7 +3,7 @@ Function: CBA_fnc_waitUntilAndExecute
 
 Description:
     Executes a code once in unscheduled environment after a condition is true.
-    It's also possible to add a timeout, in which case a difference code is executed.
+    It's also possible to add a timeout, in which case a different code is executed.
 
 Parameters:
     _condition   - The function to evaluate as condition. <CODE>

--- a/addons/common/fnc_waitUntilAndExecute.sqf
+++ b/addons/common/fnc_waitUntilAndExecute.sqf
@@ -3,11 +3,14 @@ Function: CBA_fnc_waitUntilAndExecute
 
 Description:
     Executes a code once in unscheduled environment after a condition is true.
+    It's also possible to add a timeout, in which case a difference code is executed.
 
 Parameters:
-    _condition - The function to evaluate as condition. <CODE>
-    _statement - The function to run once the condition is true. <CODE>
-    _args      - Parameters passed to the functions (statement and condition) executing. (optional) <ANY>
+    _condition   - The function to evaluate as condition. <CODE>
+    _statement   - The function to run once the condition is true. <CODE>
+    _args        - Parameters passed to the functions (statement and condition) executing. (optional) <ANY>
+    _timeout     - Timeout for the condition in seconds. (optional) <NUMBER>
+    _timeoutCode - Will execute instead of _statement if the condition times out. (optional) <CODE>
 
 Passed Arguments:
     _this      - Parameters passed by this function. Same as '_args' above. <ANY>
@@ -25,8 +28,12 @@ Author:
 ---------------------------------------------------------------------------- */
 #include "script_component.hpp"
 
-params [["_condition", {}, [{}]], ["_statement", {}, [{}]], ["_args", []]];
+params [["_condition", {}, [{}]], ["_statement", {}, [{}]], ["_args", []], ["_timeout", 1E9, [0]], ["_timeoutCode", {}, [{}]]];
 
-GVAR(waitUntilAndExecArray) pushBack [_condition, _statement, _args];
+if (_timeout == 1E9) then {
+    GVAR(waitUntilAndExecArray) pushBack [_condition, _statement, _args];
+} else {
+    GVAR(waitUntilAndExecTimeoutArray) pushBack [_condition, _statement, _args, _timeout, _timeoutCode, time];
+};
 
 nil

--- a/addons/common/init_perFrameHandler.sqf
+++ b/addons/common/init_perFrameHandler.sqf
@@ -80,6 +80,22 @@ GVAR(waitUntilAndExecArray) = [];
     if (_delete) then {
         GVAR(waitUntilAndExecArray) = GVAR(waitUntilAndExecArray) - [objNull];
     };
+
+    // Execute the waitUntilAndExecTimeout functions:
+    _delete = false;
+    {
+        private _timeout = time - (_x select 5) > (_x select 3);
+        if (_timeout || {(_x select 2) call (_x select 0)}) then {
+            (_x select 2) call (_x select ([1, 4] select _timeout));
+
+            // Mark the element for deletion so it's not executed ever again
+            GVAR(waitUntilAndExecTimeoutArray) set [_forEachIndex, objNull];
+            _delete = true;
+        };
+    } forEach GVAR(waitUntilAndExecTimeoutArray);
+    if (_delete) then {
+        REM(GVAR(waitUntilAndExecTimeoutArray),objNull);
+    };
 }] call CBA_fnc_compileFinal;
 
 // fix for save games. subtract last tickTime from ETA of all PFHs after mission was loaded

--- a/addons/common/init_perFrameHandler.sqf
+++ b/addons/common/init_perFrameHandler.sqf
@@ -51,6 +51,7 @@ GVAR(waitUntilAndExecArray) = [];
     } forEach GVAR(waitAndExecArray);
     if (_delete) then {
         GVAR(waitAndExecArray) = GVAR(waitAndExecArray) - [objNull];
+        _delete = false;
     };
 
 
@@ -66,7 +67,6 @@ GVAR(waitUntilAndExecArray) = [];
 
 
     // Execute the waitUntilAndExec functions:
-    _delete = false;
     {
         // if condition is satisfied call statement
         if ((_x select 2) call (_x select 0)) then {
@@ -79,22 +79,6 @@ GVAR(waitUntilAndExecArray) = [];
     } forEach GVAR(waitUntilAndExecArray);
     if (_delete) then {
         GVAR(waitUntilAndExecArray) = GVAR(waitUntilAndExecArray) - [objNull];
-    };
-
-    // Execute the waitUntilAndExecTimeout functions:
-    _delete = false;
-    {
-        private _timeout = time - (_x select 5) > (_x select 3);
-        if (_timeout || {(_x select 2) call (_x select 0)}) then {
-            (_x select 2) call (_x select ([1, 4] select _timeout));
-
-            // Mark the element for deletion so it's not executed ever again
-            GVAR(waitUntilAndExecTimeoutArray) set [_forEachIndex, objNull];
-            _delete = true;
-        };
-    } forEach GVAR(waitUntilAndExecTimeoutArray);
-    if (_delete) then {
-        REM(GVAR(waitUntilAndExecTimeoutArray),objNull);
     };
 }] call CBA_fnc_compileFinal;
 


### PR DESCRIPTION
**When merged this pull request will:**
- Title
- Add `_timeout` and `_timeoutCode` params, put calls that use them in a new `GVAR(waitUntilAndExecTimeoutArray)` array to not add any overhead to the usual `GVAR(waitUntilAndExecArray)`.

Separating the calls with timeout and without timeout into different arrays seemed like a better option then to add an overhead to everything that currently uses CBA's main PFH.