### PR TITLE
Re-run xeh preInit after terrain switch in Threeden

### DIFF
--- a/addons/xeh/fnc_preInit.sqf
+++ b/addons/xeh/fnc_preInit.sqf
@@ -21,6 +21,13 @@ if (ISPROCESSED(missionNamespace)) exitWith {
 };
 SETPROCESSED(missionNamespace);
 
+add3DENEventHandler ["OnTerrainNew", { // switching terrains in 3den will reset missionNamespace
+    if (!ISPROCESSED(missionNamespace)) then { 
+        diag_log text "[XEH]: Re-running preInit after 3den terrain switch";
+        [] call CBA_fnc_preInit;
+    };
+}];
+
 SLX_XEH_DisableLogging = uiNamespace getVariable ["SLX_XEH_DisableLogging", false]; // get from preStart
 
 XEH_LOG("XEH: PreInit started. v" + getText (configFile >> "CfgPatches" >> "cba_common" >> "version"));


### PR DESCRIPTION
Switching terrains in 3den will reset missionNamespace.  
(either creating a new mission on a new map or loading a save on a new map) 

This breaks addons that count on pre-init functions being available in 3den as well as CBA Settings.

On first load into VR
Check var `cba_settings` is `true` and cba settings open's normaly.

Switch maps to Stratis:
Check var `cba_settings` is `nil` and cba settings opens weird and does not function:

One minor downside to this fix is it stacks a new event handler each run of preInit.
It shouldn't matter because it checks `ISPROCESSED`, but there might be a better way to do this?

Edit: this is what cba settings opens as after terrain switch
![20161203131303_1](https://cloud.githubusercontent.com/assets/9376747/20861689/eba68fcc-b95b-11e6-9ef6-f25a8c5aa382.jpg)
