### PR TITLE
Fix RETNIL macro for code

### DIFF
--- a/addons/common/test_ret.sqf
+++ b/addons/common/test_ret.sqf
@@ -28,4 +28,10 @@ TEST_TRUE(_result isEqualTo 1,_funcName);
 _result = RETNIL(_undefined);
 TEST_TRUE(isNil "_result",_funcName);
 
+_result = RETNIL(abs -1);
+TEST_TRUE(_result isEqualTo 1,_funcName);
+
+_result = RETNIL(abs _undefined);
+TEST_TRUE(isNil "_result",_funcName);
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -373,7 +373,7 @@ Example:
 Author:
     654wak654
 ------------------------------------------- */
-#define RETDEF(VARIABLE,DEFAULT_VALUE) (if (isNil QUOTE(VARIABLE)) then [{DEFAULT_VALUE}, {VARIABLE}])
+#define RETDEF(VARIABLE,DEFAULT_VALUE) (if (isNil {VARIABLE}) then [{DEFAULT_VALUE}, {VARIABLE}])
 
 /* -------------------------------------------
 Macro: RETNIL()


### PR DESCRIPTION
#576 broke TRACE macros such as 
`TRACE_2("",_unit,local _unit);` - due to `isNil "local _unit"` is true.
and
`TRACE_1("",QUOTE(ADDON));` - quotation problems

Using the `{}` version of `isNil` seems to work just as well and fixes these problems.