### PR TITLE
Expliclty add modifyer settings for Shift/Ctrl/Alt

### DIFF
--- a/addons/keybinding/fnc_addKeybind.sqf
+++ b/addons/keybinding/fnc_addKeybind.sqf
@@ -71,6 +71,13 @@ if (count _defaultKeybind == 4) then {
     _defaultKeybind = [_defaultKeybind select 0, _modifiers];
 };
 
+// Make sure modifer is set to true, if base key is a modifier
+// This can happen with script added keybinds AND from the rebinding code (fnc_onLBDblClick)
+_defaultKeybind params ["_keyNumber", "_keyParams"];
+if (_keyNumber in [42, 54]) then {TRACE_1("setting shift", _keyParams); _keyParams set [0, true];};
+if (_keyNumber in [29, 157]) then {TRACE_1("setting ctrl", _keyParams); _keyParams set [1, true];};
+if (_keyNumber in [56, 184]) then {TRACE_1("setting alt", _keyParams); _keyParams set [2, true];};
+
 _keybind = nil;
 
 // Get a local copy of the keybind registry.

--- a/addons/keybinding/fnc_addKeybind.sqf
+++ b/addons/keybinding/fnc_addKeybind.sqf
@@ -74,9 +74,9 @@ if (count _defaultKeybind == 4) then {
 // Make sure modifer is set to true, if base key is a modifier
 // This can happen with script added keybinds AND from the rebinding code (fnc_onLBDblClick)
 _defaultKeybind params ["_keyNumber", "_keyParams"];
-if (_keyNumber in [42, 54]) then {TRACE_1("setting shift", _keyParams); _keyParams set [0, true];};
-if (_keyNumber in [29, 157]) then {TRACE_1("setting ctrl", _keyParams); _keyParams set [1, true];};
-if (_keyNumber in [56, 184]) then {TRACE_1("setting alt", _keyParams); _keyParams set [2, true];};
+if (_keyNumber in [DIK_LSHIFT, DIK_RSHIFT]) then {TRACE_1("setting shift", _keyParams); _keyParams set [0, true];};
+if (_keyNumber in [DIK_LCONTROL, DIK_RCONTROL]) then {TRACE_1("setting ctrl", _keyParams); _keyParams set [1, true];};
+if (_keyNumber in [DIK_LMENU, DIK_RMENU]) then {TRACE_1("setting alt", _keyParams); _keyParams set [2, true];};
 
 _keybind = nil;
 

--- a/addons/keybinding/script_component.hpp
+++ b/addons/keybinding/script_component.hpp
@@ -2,6 +2,8 @@
 #include "\x\cba\addons\main\script_mod.hpp"
 #include "\x\cba\addons\main\script_macros.hpp"
 
+#include "\a3\ui_f\hpp\defineDIKCodes.inc"
+
 //#define DEBUG_ENABLED_KEYBINDING
 
 #ifdef DEBUG_ENABLED_KEYBINDING


### PR DESCRIPTION
Ref https://github.com/acemod/ACE3/issues/4822
ACE was adding a keybind of `[29, [false, false, false]]` // 29 = CTRL/STRG key
But CBA keyhandler expects the control param bool to also be true `[29, [false, true, false]]`

The same problem also exists in the code that handles rebinding. 
It would only add the base key with all modfiers set to false.

That code calls fnc_addKeybind, so we can solve both problems with this fix.