### PR TITLE
randPos - Don't modify input array

### DIFF
--- a/addons/common/fnc_randPos.sqf
+++ b/addons/common/fnc_randPos.sqf
@@ -27,7 +27,7 @@ params [
     ["_radius", 0, [0]]
 ];
 
-private _position = _entity call CBA_fnc_getPos;
+private _position = +(_entity call CBA_fnc_getPos); // copy so we don't modify the input array
 
 _position set [0, (_position select 0) + (_radius - 2 * random _radius)];
 _position set [1, (_position select 1) + (_radius - 2 * random _radius)];


### PR DESCRIPTION
Fix #584

Looks like we removed the copy at one point because we switched to `vectorAdd`, 
but went back to `set` because it needs to work with 2d arrays.