### PR TITLE
pass short functions to addXEventHandler to reduce compile times

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -2,7 +2,7 @@
 #include "script_component.hpp"
 
 //Install PFEH:
-addMissionEventHandler ["EachFrame", FUNC(onFrame)];
+addMissionEventHandler ["EachFrame", {call FUNC(onFrame)}];
 
 LOG(MSG_INIT);
 

--- a/addons/events/fnc_addPlayerEventHandler.sqf
+++ b/addons/events/fnc_addPlayerEventHandler.sqf
@@ -106,7 +106,8 @@ if (_id != -1) then {
         GVAR(oldCameraView) = "";
         GVAR(oldVisibleMap) = false;
 
-        GVAR(playerEHInfo) pushBack addMissionEventHandler ["EachFrame", {
+        GVAR(playerEHInfo) pushBack addMissionEventHandler ["EachFrame", {call FUNC(playerEH_EachFrame)}];
+        [QFUNC(playerEH_EachFrame), {
             private _player = call CBA_fnc_currentUnit;
 
             private _data = currentWeapon _player;
@@ -153,9 +154,10 @@ if (_id != -1) then {
                 GVAR(oldCameraView) = _data;
                 [QGVAR(cameraViewEvent), [_player, _data]] call CBA_fnc_localEvent;
             };
-        }];
+        }] call CBA_fnc_compileFinal;
 
-        GVAR(playerEHInfo) pushBack addMissionEventHandler ["PlayerViewChanged", {
+        GVAR(playerEHInfo) pushBack addMissionEventHandler ["PlayerViewChanged", {call FUNC(playerEH_ViewChanged)}];
+        [QFUNC(playerEH_ViewChanged), {
             private _player = call CBA_fnc_currentUnit;
 
             if !(_player isEqualTo GVAR(oldUnit)) then {
@@ -168,16 +170,17 @@ if (_id != -1) then {
                 GVAR(oldVehicle) = _data;
                 [QGVAR(vehicleEvent), [_player, _data]] call CBA_fnc_localEvent;
             };
-        }];
+        }] call CBA_fnc_compileFinal;
 
-        GVAR(playerEHInfo) pushBack addMissionEventHandler ["Map", {
+        GVAR(playerEHInfo) pushBack addMissionEventHandler ["Map", {call FUNC(playerEH_Map)}];
+        [QFUNC(playerEH_Map), {
             params ["_data"]; //visibleMap is updated one frame later
 
             if !(_data isEqualTo GVAR(oldVisibleMap)) then {
                 GVAR(oldVisibleMap) = _data;
                 [QGVAR(visibleMapEvent), [call CBA_fnc_currentUnit, _data]] call CBA_fnc_localEvent;
             };
-        }];
+        }] call CBA_fnc_compileFinal;
 
         // emulate change to first value from default one frame later
         // using spawn-dc to not having to wait for postInit to complete


### PR DESCRIPTION
**When merged this pull request will:**
- According to @dedmen 's findings, functions passed directly to any `addXEventHandler` are stored internally as strings and have to be compiled every time the event handler is executed.
- This takes longer than the additional `call` command, so it's worth to replace them with short `{call <FUNCTION>}` functions.
- I don't use `_this call`, because the unary syntax of `call` doesn't overwrite `_this` anyway, so it's the same result, but even faster while only being slightly less readable (arguably).