### PR TITLE
Improve removeXCargo functions to retain readded items properly

### DIFF
--- a/addons/common/CfgFunctions.hpp
+++ b/addons/common/CfgFunctions.hpp
@@ -9,6 +9,7 @@ class CfgFunctions {
             PATHTO_FNC(getWeaponModes);
             PATHTO_FNC(inheritsFrom);
             PATHTO_FNC(getTurret);
+            PATHTO_FNC(getNoLinkedItemsClass);
         };
 
         class Entities {

--- a/addons/common/CfgFunctions.hpp
+++ b/addons/common/CfgFunctions.hpp
@@ -9,7 +9,7 @@ class CfgFunctions {
             PATHTO_FNC(getWeaponModes);
             PATHTO_FNC(inheritsFrom);
             PATHTO_FNC(getTurret);
-            PATHTO_FNC(getNoLinkedItemsClass);
+            PATHTO_FNC(getNonPresetClass);
         };
 
         class Entities {

--- a/addons/common/fnc_getNoLinkedItemsClass.sqf
+++ b/addons/common/fnc_getNoLinkedItemsClass.sqf
@@ -1,0 +1,55 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_getNoLinkedItemsClass
+
+Description:
+    Get ancestor class of a weapon or container which has no LinkedItems sub-class (preset attachments/contents).
+
+Parameters:
+    _item       - Classname of weapon/container <STRING>
+    _configRoot - Root config ("CfgWeapons", "CfgVehicles", ...) <STRING> (Default: "CfgWeapons")
+
+Returns:
+    Ancestor class without LinkedItems sub-class on success, "" otherwise <STRING>
+
+Examples:
+    (begin example)
+        // Get parent class without LinkedItems of a weapon (returns "arifle_MX_F")
+        _ancestorClass = ["arifle_MX_ACO_pointer_F"] call CBA_fnc_getNoLinkedItemsClass;
+    (end)
+
+Author:
+    Jonpas
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+SCRIPT(getNoLinkedItemsClass);
+
+params [["_class", "", [""]], ["_rootConfig", "CfgWeapons", [""]]];
+
+private _config = configFile >> _rootConfig >> _class;
+
+// Invalid class/root config
+if (!isClass _config) exitWith {
+    _class
+};
+
+// Return current class - has no LinkedItems
+if (
+    // CfgWeapons
+    (configProperties [_config >> "LinkedItems", "isClass _x", true] isEqualTo []) &&
+    // CfgVehicles
+    {configProperties [_config >> "TransportItems", "isClass _x", true] isEqualTo []} &&
+    {configProperties [_config >> "TransportMagazines", "isClass _x", true] isEqualTo []} &&
+    {configProperties [_config >> "TransportWeapons", "isClass _x", true] isEqualTo []}
+) exitWith {
+    _class
+};
+
+// Check parent
+private _parent = inheritsFrom _config;
+if (_parent isEqualTo configNull) then {
+    // We reached configNull, stuff must be invalid, return empty string
+    ""
+} else {
+    // Recursively search the ancestor tree
+    [configName _parent, _rootConfig] call CBA_fnc_getNoLinkedItemsClass;
+};

--- a/addons/common/fnc_getNoLinkedItemsClass.sqf
+++ b/addons/common/fnc_getNoLinkedItemsClass.sqf
@@ -2,18 +2,18 @@
 Function: CBA_fnc_getNoLinkedItemsClass
 
 Description:
-    Get ancestor class of a weapon or container which has no LinkedItems sub-class (preset attachments/contents).
+    Get ancestor class of a weapon or container which has no preset attachments/contents.
 
 Parameters:
     _item       - Classname of weapon/container <STRING>
     _configRoot - Root config ("CfgWeapons", "CfgVehicles", ...) <STRING> (Default: "CfgWeapons")
 
 Returns:
-    Ancestor class without LinkedItems sub-class on success, "" otherwise <STRING>
+    Ancestor class without preset attachments/contents sub-class on success, "" otherwise <STRING>
 
 Examples:
     (begin example)
-        // Get parent class without LinkedItems of a weapon (returns "arifle_MX_F")
+        // Get parent class without preset attachments of a weapon (returns "arifle_MX_F")
         _ancestorClass = ["arifle_MX_ACO_pointer_F"] call CBA_fnc_getNoLinkedItemsClass;
     (end)
 
@@ -32,7 +32,7 @@ if (!isClass _config) exitWith {
     _class
 };
 
-// Return current class - has no LinkedItems
+// Return current class - has no preset attachments/contents
 if (
     // CfgWeapons
     (configProperties [_config >> "LinkedItems", "isClass _x", true] isEqualTo []) &&

--- a/addons/common/fnc_getNonPresetClass.sqf
+++ b/addons/common/fnc_getNonPresetClass.sqf
@@ -28,16 +28,14 @@ params [["_class", "", [""]], ["_rootConfig", "CfgWeapons", [""]]];
 private _config = configFile >> _rootConfig >> _class;
 
 // Invalid class/root config
-if (!isClass _config) exitWith {
-    ""
-};
+if (!isClass _config) exitWith {""};
 
 // Use CBA_fnc_weaponComponents if weapon
 if (_rootConfig == "CfgWeapons") exitWith {
     (_class call CBA_fnc_weaponComponents) select 0
 };
 
-
+// Containers
 // Create cache if it doesn't exist yet
 if (isNil QGVAR(nonPresetClassesCache)) then {
     GVAR(nonPresetClassesCache) = [] call CBA_fnc_createNamespace;
@@ -47,11 +45,10 @@ private _cachedAncestor = GVAR(nonPresetClassesCache) getVariable _class;
 
 if (isNil "_cachedAncestor") then {
     _cachedAncestor = "";
-    while {isClass _config && {getNumber (_config >> "scope") == 2}} do {
-        if (count (_config >> "TransportItems") == 0 && {count (_config >> "TransportMagazines") == 0} && {count (_config >> "TransportWeapons") == 0}) then {
+    while {isClass _config && {getNumber (_config >> "scope") > 0}} do { // Some preset backpacks are scope = 1
+        if (count (_config >> "TransportItems") == 0 && {count (_config >> "TransportMagazines") == 0} && {count (_config >> "TransportWeapons") == 0}) exitWith {
             _cachedAncestor = configName _config;
         };
-
         _config = inheritsFrom _config;
     };
 

--- a/addons/common/fnc_getNonPresetClass.sqf
+++ b/addons/common/fnc_getNonPresetClass.sqf
@@ -29,7 +29,7 @@ private _config = configFile >> _rootConfig >> _class;
 
 // Invalid class/root config
 if (!isClass _config) exitWith {
-    _class
+    ""
 };
 
 // Return current class - has no preset attachments/contents
@@ -46,8 +46,8 @@ if (
 
 // Check parent
 private _parent = inheritsFrom _config;
-if (_parent isEqualTo configNull) then {
-    // We reached configNull, stuff must be invalid, return empty string
+if (isNull _parent) then {
+    // We reached configNull, stuff must be invalid
     ""
 } else {
     // Recursively search the ancestor tree

--- a/addons/common/fnc_getNonPresetClass.sqf
+++ b/addons/common/fnc_getNonPresetClass.sqf
@@ -46,26 +46,15 @@ if (isNil QGVAR(nonPresetClassesCache)) then {
 private _cachedAncestor = GVAR(nonPresetClassesCache) getVariable _class;
 
 if (isNil "_cachedAncestor") then {
-    private _fnc_findValidAncestor = {
-        params ["_class", "_config"];
-
-        if (configProperties [_config >> "TransportItems", "isClass _x", true] isEqualTo [] &&
-            {configProperties [_config >> "TransportMagazines", "isClass _x", true] isEqualTo []} &&
-            {configProperties [_config >> "TransportWeapons", "isClass _x", true] isEqualTo []}
-        ) then {
-            _class // Return current class - has no preset contents
-        } else {
-            // Check parent
-            private _parent = inheritsFrom _config;
-            if (isNull _parent) then {
-                "" // We reached configNull, stuff must be invalid
-            } else {
-                [configName _parent, _rootConfig] call CBA_fnc_getNonPresetClass; // Recursively search the ancestor tree
-            };
+    _cachedAncestor = "";
+    while {isClass _config && {getNumber (_config >> "scope") == 2}} do {
+        if (count (_config >> "TransportItems") == 0 && {count (_config >> "TransportMagazines") == 0} && {count (_config >> "TransportWeapons") == 0}) then {
+            _cachedAncestor = configName _config;
         };
+
+        _config = inheritsFrom _config;
     };
 
-    _cachedAncestor = [_class, _config] call _fnc_findValidAncestor;
     GVAR(nonPresetClassesCache) setVariable [_class, _cachedAncestor];
 };
 

--- a/addons/common/fnc_getNonPresetClass.sqf
+++ b/addons/common/fnc_getNonPresetClass.sqf
@@ -1,5 +1,5 @@
 /* ----------------------------------------------------------------------------
-Function: CBA_fnc_getNoLinkedItemsClass
+Function: CBA_fnc_getNonPresetClass
 
 Description:
     Get ancestor class of a weapon or container which has no preset attachments/contents.
@@ -14,14 +14,14 @@ Returns:
 Examples:
     (begin example)
         // Get parent class without preset attachments of a weapon (returns "arifle_MX_F")
-        _ancestorClass = ["arifle_MX_ACO_pointer_F"] call CBA_fnc_getNoLinkedItemsClass;
+        _ancestorClass = ["arifle_MX_ACO_pointer_F"] call CBA_fnc_getNonPresetClass;
     (end)
 
 Author:
     Jonpas
 ---------------------------------------------------------------------------- */
 #include "script_component.hpp"
-SCRIPT(getNoLinkedItemsClass);
+SCRIPT(getNonPresetClass);
 
 params [["_class", "", [""]], ["_rootConfig", "CfgWeapons", [""]]];
 
@@ -51,5 +51,5 @@ if (_parent isEqualTo configNull) then {
     ""
 } else {
     // Recursively search the ancestor tree
-    [configName _parent, _rootConfig] call CBA_fnc_getNoLinkedItemsClass;
+    [configName _parent, _rootConfig] call CBA_fnc_getNonPresetClass;
 };

--- a/addons/common/fnc_getNonPresetClass.sqf
+++ b/addons/common/fnc_getNonPresetClass.sqf
@@ -30,12 +30,6 @@ private _config = configFile >> _rootConfig >> _class;
 // Invalid class/root config
 if (!isClass _config) exitWith {""};
 
-// Use CBA_fnc_weaponComponents if weapon
-if (_rootConfig == "CfgWeapons") exitWith {
-    (_class call CBA_fnc_weaponComponents) select 0
-};
-
-// Containers
 // Create cache if it doesn't exist yet
 if (isNil QGVAR(nonPresetClassesCache)) then {
     GVAR(nonPresetClassesCache) = [] call CBA_fnc_createNamespace;
@@ -43,13 +37,21 @@ if (isNil QGVAR(nonPresetClassesCache)) then {
 
 private _cachedAncestor = GVAR(nonPresetClassesCache) getVariable _class;
 
+
 if (isNil "_cachedAncestor") then {
     _cachedAncestor = "";
-    while {isClass _config && {getNumber (_config >> "scope") > 0}} do { // Some preset backpacks are scope = 1
-        if (count (_config >> "TransportItems") == 0 && {count (_config >> "TransportMagazines") == 0} && {count (_config >> "TransportWeapons") == 0}) exitWith {
-            _cachedAncestor = configName _config;
+
+    if (_rootConfig == "CfgWeapons") then {
+        // Use CBA_fnc_weaponComponents if weapon
+        _cachedAncestor = (_class call CBA_fnc_weaponComponents) select 0;
+    } else {
+        // Containers
+        while {isClass _config && {getNumber (_config >> "scope") > 0}} do { // Some preset backpacks are scope = 1
+            if (count (_config >> "TransportItems") == 0 && {count (_config >> "TransportMagazines") == 0} && {count (_config >> "TransportWeapons") == 0}) exitWith {
+                _cachedAncestor = configName _config;
+            };
+            _config = inheritsFrom _config;
         };
-        _config = inheritsFrom _config;
     };
 
     GVAR(nonPresetClassesCache) setVariable [_class, _cachedAncestor];

--- a/addons/common/fnc_removeBackpackCargo.sqf
+++ b/addons/common/fnc_removeBackpackCargo.sqf
@@ -76,7 +76,7 @@ clearBackpackCargoGlobal _container;
         private _addedBackpacks = everyBackpack _container;
 
         // Readd
-        private _backpack = [_backpackClass, "CfgVehicles"] call CBA_fnc_getNoLinkedItemsClass;
+        private _backpack = [_backpackClass, "CfgVehicles"] call CBA_fnc_getNonPresetClass;
         _container addBackpackCargoGlobal [_backpack, 1];
 
         // Find just added backpack and add contents (no command returns reference when adding)
@@ -103,7 +103,7 @@ clearBackpackCargoGlobal _container;
                 _magazineGL = "";
             };
 
-            private _weapon = [_weapon] call CBA_fnc_getNoLinkedItemsClass;
+            private _weapon = [_weapon] call CBA_fnc_getNonPresetClass;
             _backpack addWeaponCargoGlobal [_weapon, 1];
 
             _backpack addItemCargoGlobal [_muzzle, 1];

--- a/addons/common/fnc_removeBackpackCargo.sqf
+++ b/addons/common/fnc_removeBackpackCargo.sqf
@@ -111,10 +111,10 @@ clearBackpackCargoGlobal _container;
             _backpack addItemCargoGlobal [_optic, 1];
             _backpack addItemCargoGlobal [_bipod, 1];
 
-            _magazine params ["_magazineClass", "_magazineAmmoCount"];
+            _magazine params [["_magazineClass", ""], ["_magazineAmmoCount", ""]];
             _backpack addMagazineAmmoCargo [_magazineClass, 1, _magazineAmmoCount];
 
-            _magazineGL params ["_magazineGLClass", "_magazineGLAmmoCount"];
+            _magazineGL params [["_magazineGLClass", ""], ["_magazineGLAmmoCount", ""]];
             _backpack addMagazineAmmoCargo [_magazineGLClass, 1, _magazineGLAmmoCount];
         } forEach _weaponsItemsCargo;
     };

--- a/addons/common/fnc_removeBackpackCargo.sqf
+++ b/addons/common/fnc_removeBackpackCargo.sqf
@@ -15,13 +15,13 @@ Returns:
     true on success, false otherwise <BOOLEAN>
 
 Examples:
-   (begin example)
-    // Remove 1 Kitbag Tan backpack locally from a box
-   _success = [myCoolBackpackBox, "B_Kitbag_cbr"] call CBA_fnc_removeBackpackCargo;
+    (begin example)
+    // Remove 1 Kitbag Tan backpack from a box
+    _success = [myCoolBackpackBox, "B_Kitbag_cbr"] call CBA_fnc_removeBackpackCargo;
 
-   // Remove 2 Carryall Desert Camo backpacks locally from a box
-   _success = [myCoolBackpackBox, "B_Carryall_ocamo", 2] call CBA_fnc_removeBackpackCargo;
-   (end)
+    // Remove 2 Carryall Desert Camo backpacks from a box
+    _success = [myCoolBackpackBox, "B_Carryall_ocamo", 2] call CBA_fnc_removeBackpackCargo;
+    (end)
 
 Author:
     Jonpas

--- a/addons/common/fnc_removeItemCargo.sqf
+++ b/addons/common/fnc_removeItemCargo.sqf
@@ -63,15 +63,14 @@ clearItemCargoGlobal _container;
 {
     private _itemCount = _allItemsCount select _forEachIndex;
 
-    if (_x == _item) then {
+    if (_count != 0 && {_x == _item}) then {
         // Process removal
-        _count = 0;
-
         _itemCount = _itemCount - _count;
         if (_itemCount > 0) then {
             // Add with new count
             _container addItemCargoGlobal [_x, _itemCount];
         };
+        _count = 0;
     } else {
         // Readd only
         _container addItemCargoGlobal [_x, _itemCount];

--- a/addons/common/fnc_removeItemCargo.sqf
+++ b/addons/common/fnc_removeItemCargo.sqf
@@ -29,28 +29,26 @@ SCRIPT(removeItemCargo);
 
 params [["_container", objNull, [objNull]], ["_item", "", [""]], ["_count", 1, [0]]];
 
-private _return = false;
-
 if (isNull _container) exitWith {
     TRACE_2("Container not Object or null",_container,_item);
-    _return
+    false
 };
 
 if (_item isEqualTo "") exitWith {
     TRACE_2("Item not String or empty",_container,_item);
-    _return
+    false
 };
 
 private _config = _item call CBA_fnc_getItemConfig;
 
 if (isNull _config || {getNumber (_config >> "scope") < 1}) exitWith {
     TRACE_2("Item does not exist in Config",_container,_item);
-    _return
+    false
 };
 
 if (_count <= 0) exitWith {
     TRACE_3("Count is not a positive number",_container,_item,_count);
-    _return
+    false
 };
 
 // Ensure proper count
@@ -67,7 +65,7 @@ clearItemCargoGlobal _container;
 
     if (_x == _item) then {
         // Process removal
-        _return = true;
+        _count = 0;
 
         _itemCount = _itemCount - _count;
         if (_itemCount > 0) then {
@@ -80,4 +78,4 @@ clearItemCargoGlobal _container;
     };
 } forEach _allItemsType;
 
-_return
+(_count == 0)

--- a/addons/common/fnc_removeItemCargo.sqf
+++ b/addons/common/fnc_removeItemCargo.sqf
@@ -13,13 +13,13 @@ Returns:
     true on success, false otherwise <BOOLEAN>
 
 Examples:
-   (begin example)
-    // Remove 1 GPS locally from a box
-   _success = [myCoolItemBox, "ItemGPS"] call CBA_fnc_removeItemCargo;
+    (begin example)
+    // Remove 1 GPS from a box
+    _success = [myCoolItemBox, "ItemGPS"] call CBA_fnc_removeItemCargo;
 
-   // Remove 2 Compasses locally from a box
-   _success = [myCoolItemBox, "ItemCompass", 2] call CBA_fnc_removeItemCargo;
-   (end)
+    // Remove 2 Compasses from a box
+    _success = [myCoolItemBox, "ItemCompass", 2] call CBA_fnc_removeItemCargo;
+    (end)
 
 Author:
     Jonpas

--- a/addons/common/fnc_removeMagazineCargo.sqf
+++ b/addons/common/fnc_removeMagazineCargo.sqf
@@ -64,17 +64,16 @@ private _magazinesAmmo = magazinesAmmoCargo _container;
 // Clear cargo space and readd the items as long it's not the type in question
 clearMagazineCargoGlobal _container;
 
-private _removed = 0;
 {
     _x params ["_magazineClass", "_magazineAmmo"];
 
-    if (_removed != _count && {_magazineClass == _item} && {_ammo < 0 || {_magazineAmmo == _ammo}}) then {
+    if (_count != 0 && {_magazineClass == _item} && {_ammo < 0 || {_magazineAmmo == _ammo}}) then {
         // Process removal
-        _removed = _removed + 1;
+        _count = _count - 1;
     } else {
         // Readd
         _container addMagazineAmmoCargo [_magazineClass, 1, _magazineAmmo];
     };
 } forEach _magazinesAmmo;
 
-(_removed == _count)
+(_count == 0)

--- a/addons/common/fnc_removeMagazineCargo.sqf
+++ b/addons/common/fnc_removeMagazineCargo.sqf
@@ -60,9 +60,6 @@ if (_count <= 0) exitWith {
 // Ensure proper count
 _count = round _count;
 
-// Returns array containing arrays: [[type1, ammo1], [type2, ammo2], ...]
-private _magazinesCargo = magazinesAmmoCargo _container;
-
 // Clear cargo space and readd the items as long it's not the type in question
 clearMagazineCargoGlobal _container;
 
@@ -80,6 +77,6 @@ private _removed = 0;
         // Readd only
         _container addMagazineAmmoCargo [_magazineClass, 1, _magazineAmmo];
     };
-} forEach _magazinesCargo;
+} forEach (magazinesAmmoCargo _container); // [[type1, ammo1], [type2, ammo2], ...]
 
 _return

--- a/addons/common/fnc_removeMagazineCargo.sqf
+++ b/addons/common/fnc_removeMagazineCargo.sqf
@@ -33,32 +33,33 @@ SCRIPT(removeMagazineCargo);
 
 params [["_container", objNull, [objNull]], ["_item", "", [""]], ["_count", 1, [0]], ["_ammo", -1, [0]]];
 
-private _return = false;
-
 if (isNull _container) exitWith {
     TRACE_2("Container not Object or null",_container,_item);
-    _return
+    false
 };
 
 if (_item isEqualTo "") exitWith {
     TRACE_2("Item not String or empty",_container,_item);
-    _return
+    false
 };
 
 private _config = configFile >> "CfgMagazines" >> _item;
 
 if (isNull _config || {getNumber (_config >> "scope") < 2}) exitWith {
     TRACE_2("Item does not exist in Config",_container,_item);
-    _return
+    false
 };
 
 if (_count <= 0) exitWith {
     TRACE_3("Count is not a positive number",_container,_item,_count);
-    _return
+    false
 };
 
 // Ensure proper count
 _count = round _count;
+
+// [[type1, ammo1], [type2, ammo2], ...]
+private _magazinesAmmo = magazinesAmmoCargo _container;
 
 // Clear cargo space and readd the items as long it's not the type in question
 clearMagazineCargoGlobal _container;
@@ -70,13 +71,10 @@ private _removed = 0;
     if (_removed != _count && {_magazineClass == _item} && {_ammo < 0 || {_magazineAmmo == _ammo}}) then {
         // Process removal
         _removed = _removed + 1;
-        if (_removed == _count) then {
-            _return = true;
-        };
     } else {
-        // Readd only
+        // Readd
         _container addMagazineAmmoCargo [_magazineClass, 1, _magazineAmmo];
     };
-} forEach (magazinesAmmoCargo _container); // [[type1, ammo1], [type2, ammo2], ...]
+} forEach _magazinesAmmo;
 
-_return
+(_removed == _count)

--- a/addons/common/fnc_removeMagazineCargo.sqf
+++ b/addons/common/fnc_removeMagazineCargo.sqf
@@ -8,7 +8,7 @@ Parameters:
     _container - Object with cargo <OBJECT>
     _item      - Classname of magazine(s) to remove <STRING>
     _count     - Number of magazine(s) to remove <NUMBER> (Default: 1)
-    _ammo      - Ammo of magazine(s) to remove (-1 for a magazine with any ammo) <NUMBER> (Default: -1)
+    _ammo      - Ammo of magazine(s) to remove (-1 for magazine(s) with any ammo) <NUMBER> (Default: -1)
 
 Returns:
     true on success, false otherwise <BOOLEAN>

--- a/addons/common/fnc_removeWeaponCargo.sqf
+++ b/addons/common/fnc_removeWeaponCargo.sqf
@@ -82,10 +82,10 @@ clearWeaponCargoGlobal _container;
         _container addItemCargoGlobal [_optic, 1];
         _container addItemCargoGlobal [_bipod, 1];
 
-        _magazine params ["_magazineClass", "_magazineAmmoCount"];
+        _magazine params [["_magazineClass", ""], ["_magazineAmmoCount", ""]];
         _container addMagazineAmmoCargo [_magazineClass, 1, _magazineAmmoCount];
 
-        _magazineGL params ["_magazineGLClass", "_magazineGLAmmoCount"];
+        _magazineGL params [["_magazineGLClass", ""], ["_magazineGLAmmoCount", ""]];
         _container addMagazineAmmoCargo [_magazineGLClass, 1, _magazineGLAmmoCount];
     };
 } forEach _weaponsItemsCargo;

--- a/addons/common/fnc_removeWeaponCargo.sqf
+++ b/addons/common/fnc_removeWeaponCargo.sqf
@@ -74,7 +74,7 @@ clearWeaponCargoGlobal _container;
         // Process removal
         _count = _count - 1;
     } else {
-        _weapon = [_weapon] call CBA_fnc_getNoLinkedItemsClass;
+        _weapon = [_weapon] call CBA_fnc_getNonPresetClass;
         _container addWeaponCargoGlobal [_weapon, 1];
 
         _container addItemCargoGlobal [_muzzle, 1];

--- a/addons/common/fnc_removeWeaponCargo.sqf
+++ b/addons/common/fnc_removeWeaponCargo.sqf
@@ -15,13 +15,13 @@ Returns:
     true on success, false otherwise <BOOLEAN>
 
 Examples:
-   (begin example)
-   // Remove 1 Binocular locally from a box
-   _success = [myCoolWeaponBox, "Binocular"] call CBA_fnc_removeWeaponCargo;
+    (begin example)
+    // Remove 1 Binocular from a box
+    _success = [myCoolWeaponBox, "Binocular"] call CBA_fnc_removeWeaponCargo;
 
-   // Remove 2 M16A2 locally from a box
-   _success = [myCoolWeaponBox, "M16A2", 2] call CBA_fnc_removeWeaponCargo;
-   (end)
+    // Remove 2 M16A2 from a box
+    _success = [myCoolWeaponBox, "M16A2", 2] call CBA_fnc_removeWeaponCargo;
+    (end)
 
 Author:
     silencer.helling3r 2012-12-22, Jonpas

--- a/addons/common/fnc_removeWeaponCargo.sqf
+++ b/addons/common/fnc_removeWeaponCargo.sqf
@@ -31,28 +31,26 @@ SCRIPT(removeWeaponCargo);
 
 params [["_container", objNull, [objNull]], ["_item", "", [""]], ["_count", 1, [0]]];
 
-private _return = false;
-
 if (isNull _container) exitWith {
     TRACE_2("Container not Object or null",_container,_item);
-    _return
+    false
 };
 
 if (_item isEqualTo "") exitWith {
     TRACE_2("Item not String or empty",_container,_item);
-    _return
+    false
 };
 
 private _config = configFile >> "CfgWeapons" >> _item;
 
 if (isNull _config || {getNumber (_config >> "scope") < 1}) exitWith {
     TRACE_2("Item does not exist in Config",_container,_item);
-    _return
+    false
 };
 
 if (_count <= 0) exitWith {
     TRACE_3("Count is not a positive number",_container,_item,_count);
-    _return
+    false
 };
 
 // Ensure proper count
@@ -60,7 +58,6 @@ _count = round _count;
 
 // Returns array in weaponsItems format
 private _weaponsItemsCargo = weaponsItemsCargo _container;
-diag_log _weaponsItemsCargo;
 
 // Clear cargo space and readd the items as long it's not the type in question
 clearWeaponCargoGlobal _container;

--- a/addons/common/fnc_weaponComponents.sqf
+++ b/addons/common/fnc_weaponComponents.sqf
@@ -42,7 +42,6 @@ if (isNil "_components") then {
 
     // get attachments
     private _attachments = [];
-
     {
         _attachments pushBack toLower getText (_x >> "item");
     } forEach ("true" configClasses (_config >> "LinkedItems")); // inheritance is apparently disabled for these

--- a/addons/common/fnc_weaponComponents.sqf
+++ b/addons/common/fnc_weaponComponents.sqf
@@ -48,18 +48,19 @@ if (isNil "_components") then {
     } forEach ("true" configClasses (_config >> "LinkedItems")); // inheritance is apparently disabled for these
 
     // get first parent without attachments
+    private _baseWeapon = "";
     while {isClass _config && {getNumber (_config >> "scope") == 2}} do {
         if (count (_config >> "LinkedItems") == 0) exitWith {
-            _weapon = configName _config;
+            _baseWeapon = configName _config;
         };
 
         _config = inheritsFrom _config;
     };
 
-    _components = [toLower _weapon];
+    _components = [toLower _baseWeapon];
     _components append _attachments;
 
     GVAR(weaponComponentsCache) setVariable [_weapon, _components];
 };
 
-+ _components
++_components

--- a/addons/common/test_config.sqf
+++ b/addons/common/test_config.sqf
@@ -172,7 +172,7 @@ LOG("Testing " + _funcName);
 TEST_DEFINED("CBA_fnc_getNonPresetClass","");
 
 _result = ["arifle_MX_ACO_pointer_F"] call CBA_fnc_getNonPresetClass;
-TEST_TRUE(_result isEqualTo "arifle_MX_F",_funcName);
+TEST_TRUE(_result isEqualTo "arifle_mx_f",_funcName);
 
 _result = ["B_AssaultPack_mcamo_Ammo", "CfgVehicles"] call CBA_fnc_getNonPresetClass;
-TEST_TRUE(_result isEqualTo "B_AssaultPack_mcamo",_funcName);
+TEST_TRUE(_result isEqualTo "B_Carryall_mcamo",_funcName);

--- a/addons/common/test_config.sqf
+++ b/addons/common/test_config.sqf
@@ -163,3 +163,16 @@ TEST_TRUE(_result == 0,_funcName);
 
 _result = {!isNull _x} count ([[0],[1],[2],[3],[4]] apply {["B_Heli_Transport_03_F", _x] call CBA_fnc_getTurret});
 TEST_TRUE(_result == 5,_funcName);*/
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+_funcName = "CBA_fnc_getNoLinkedItemsClass";
+LOG("Testing " + _funcName);
+
+TEST_DEFINED("CBA_fnc_getNoLinkedItemsClass","");
+
+_result = ["arifle_MX_ACO_pointer_F"] call CBA_fnc_getNoLinkedItemsClass;
+TEST_TRUE(_result isEqualTo "arifle_MX_F",_funcName);
+
+_result = ["B_AssaultPack_mcamo_Ammo", "CfgVehicles"] call CBA_fnc_getNoLinkedItemsClass;
+TEST_TRUE(_result isEqualTo "B_AssaultPack_mcamo",_funcName);

--- a/addons/common/test_config.sqf
+++ b/addons/common/test_config.sqf
@@ -166,13 +166,13 @@ TEST_TRUE(_result == 5,_funcName);*/
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-_funcName = "CBA_fnc_getNoLinkedItemsClass";
+_funcName = "CBA_fnc_getNonPresetClass";
 LOG("Testing " + _funcName);
 
-TEST_DEFINED("CBA_fnc_getNoLinkedItemsClass","");
+TEST_DEFINED("CBA_fnc_getNonPresetClass","");
 
-_result = ["arifle_MX_ACO_pointer_F"] call CBA_fnc_getNoLinkedItemsClass;
+_result = ["arifle_MX_ACO_pointer_F"] call CBA_fnc_getNonPresetClass;
 TEST_TRUE(_result isEqualTo "arifle_MX_F",_funcName);
 
-_result = ["B_AssaultPack_mcamo_Ammo", "CfgVehicles"] call CBA_fnc_getNoLinkedItemsClass;
+_result = ["B_AssaultPack_mcamo_Ammo", "CfgVehicles"] call CBA_fnc_getNonPresetClass;
 TEST_TRUE(_result isEqualTo "B_AssaultPack_mcamo",_funcName);

--- a/addons/common/test_inventory.sqf
+++ b/addons/common/test_inventory.sqf
@@ -1,5 +1,5 @@
 #include "script_component.hpp"
-SCRIPT(test_config);
+SCRIPT(test_inventory);
 
 // 0 spawn compile preprocessFileLineNumbers "\x\cba\addons\common\test_inventory.sqf";
 
@@ -72,3 +72,66 @@ player removeMagazines "SmokeShell";
 
 _result = [player, "SmokeShell"] call CBA_fnc_removeMagazine;
 TEST_FALSE(_result,_funcName);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+private _container = createVehicle ["B_supplyCrate_F", player, [], 10, "NONE"];
+clearBackpackCargoGlobal _container;
+clearItemCargoGlobal _container;
+clearMagazineCargoGlobal _container;
+clearWeaponCargoGlobal _container;
+
+
+_funcName = "CBA_fnc_removeBackpackCargo";
+LOG("Testing " + _funcName);
+
+_result = [objNull, "SmokeShell"] call CBA_fnc_removeBackpackCargo;
+TEST_FALSE(_result,_funcName);
+
+_container addBackpackCargoGlobal ["B_AssaultPack_mcamo", 5];
+_result = [_container, "B_AssaultPack_mcamo", 3] call CBA_fnc_removeBackpackCargo;
+TEST_TRUE(_result,_funcName);
+TEST_TRUE(count (backpackCargo _container) == 2,_funcName);
+clearBackpackCargoGlobal _container;
+
+
+_funcName = "CBA_fnc_removeItemCargo";
+LOG("Testing " + _funcName);
+
+_result = [objNull, "SmokeShell"] call CBA_fnc_removeItemCargo;
+TEST_FALSE(_result,_funcName);
+
+_container addItemCargoGlobal ["FirstAidKit", 5];
+_result = [_container, "FirstAidKit", 3] call CBA_fnc_removeItemCargo;
+TEST_TRUE(_result,_funcName);
+TEST_TRUE(count (itemCargo _container) == 2,_funcName);
+clearItemCargoGlobal _container;
+
+
+_funcName = "CBA_fnc_removeMagazineCargo";
+LOG("Testing " + _funcName);
+
+_result = [objNull, "SmokeShell"] call CBA_fnc_removeMagazineCargo;
+TEST_FALSE(_result,_funcName);
+
+_container addMagazineCargoGlobal ["30Rnd_556x45_Stanag", 5];
+_result = [_container, "30Rnd_556x45_Stanag", 3] call CBA_fnc_removeMagazineCargo;
+TEST_TRUE(_result,_funcName);
+TEST_TRUE(count (magazineCargo _container) == 2,_funcName);
+clearMagazineCargoGlobal _container;
+
+
+_funcName = "CBA_fnc_removeWeaponCargo";
+LOG("Testing " + _funcName);
+
+_result = [objNull, "SmokeShell"] call CBA_fnc_removeWeaponCargo;
+TEST_FALSE(_result,_funcName);
+
+_container addWeaponCargoGlobal ["srifle_EBR_F", 5];
+_result = [_container, "srifle_EBR_F", 3] call CBA_fnc_removeWeaponCargo;
+TEST_TRUE(_result,_funcName);
+TEST_TRUE(count (weaponCargo _container) == 2,_funcName);
+clearWeaponCargoGlobal _container;
+
+
+deleteVehicle _container;


### PR DESCRIPTION
**When merged this pull request will:**
- Add `CBA_fnc_getNoLinkedItemsClass` - gets the first ancestor (or just passed class) that has no preset attachments (`LinkedItems`) or contents (`TransportX`)
- Add tests for `CBA_fnc_getNoLinkedItemsClass`
- Improve `CBA_fnc_removeBackpackCargo` - now retains all contents of other backpacks in container
- Improve `CBA_fnc_removeMagazineCargo` - now retains ammo count of other magazines in container
- Improve `CBA_fnc_removeWeaponCargo` - now retains all attachments and loaded magazines of other weapons in container
- Add basic tests for `removeXCargo` functions
- Fix indentation in all `removeXCargo` functions to 4 spaces
- Remove "locally" note (which is not valid anymore) from examples of all `removeXCargo` functions
- Fix `CBA_fnc_weaponComponents` caching (was caching the result instead of passed class)

The only issue remaining is with `CBA_fnc_removeBackpackCargo` and `CBA_fnc_removeWeaponCargo.sqf`, it is not possible to readd attachments and loaded magazines directly onto a weapon inside a container, or a weapon with already set attachments and loaded magazines. The current workaround used here adds those attachments and loaded magazines next to the weapon.