### PR TITLE
fix CBA_fnc_getPos

### DIFF
--- a/addons/common/fnc_getPos.sqf
+++ b/addons/common/fnc_getPos.sqf
@@ -50,7 +50,7 @@ switch (typeName _entity) do {
     case "ARRAY": {
         + _entity
     };
-    case "NUMBER": { // in case of position being passed not in array
+    case "SCALAR": { // in case of position being passed not in array
         + _this
     };
 };

--- a/addons/common/test.sqf
+++ b/addons/common/test.sqf
@@ -5,7 +5,7 @@
 #define DEBUG_MODE_FULL
 #include "script_component.hpp"
 
-#define TESTS ["config", "inventory", "weaponComponents", "ret", "macro_is_x"]
+#define TESTS ["config", "inventory", "weaponComponents", "position", "ret", "macro_is_x"]
 
 SCRIPT(test-common);
 

--- a/addons/common/test_position.sqf
+++ b/addons/common/test_position.sqf
@@ -1,0 +1,64 @@
+#include "script_component.hpp"
+SCRIPT(test_position);
+
+// execVM "\x\cba\addons\common\test_position.sqf";
+
+private ["_funcName", "_value", "_result"];
+
+_funcName = "CBA_fnc_getPos";
+LOG("Testing " + _funcName);
+
+TEST_DEFINED(_funcName,"");
+
+_value = objNull;
+_result = _value call CBA_fnc_getPos;
+
+#define EXPECTED [0,0,0]
+TEST_TRUE(_result isEqualTo EXPECTED,_funcName);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+_value = grpNull;
+_result = _value call CBA_fnc_getPos;
+
+TEST_TRUE(_result isEqualTo EXPECTED,_funcName);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+_value = ""; // marker
+_result = _value call CBA_fnc_getPos;
+
+TEST_TRUE(_result isEqualTo EXPECTED,_funcName);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+_value = locationNull;
+_result = _value call CBA_fnc_getPos;
+
+TEST_TRUE(_result isEqualTo EXPECTED,_funcName);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#define EXPECTED [1,2,0] // Pos 3D
+
+_value = EXPECTED;
+_result = _value call CBA_fnc_getPos;
+
+// confirm that input array is copied
+_value set [0,-1];
+
+TEST_TRUE(_result isEqualTo EXPECTED,_funcName);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#define EXPECTED [1,2] // Pos 2D
+
+_value = EXPECTED;
+_result = _value call CBA_fnc_getPos;
+
+// confirm that input array is copied
+_value set [0,-1];
+
+TEST_TRUE(_result isEqualTo EXPECTED,_funcName);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
**When merged this pull request will:**
- fix `CBA_fnc_getPos` reporting `true` instead of a position in certain cases
- solves `CBA_fnc_taskPatrol`, `CBA_fnc_addWaypoint` etc. not working correctly
- solves getting stuck in loading screen when using ALiVE
- adds unit test for `CBA_fnc_getPos`

```sqf
execVM "\x\cba\addons\common\test_position.sqf";
```
```
14:00:51 [CBA] (common) Test OK: (CBA_fnc_getPos is defined) x\cba\addons\common\test_position.sqf:11
14:00:51 [CBA] (common) Test OK: (_result isEqualTo [0,0,0]) x\cba\addons\common\test_position.sqf:17
14:00:51 [CBA] (common) Test OK: (_result isEqualTo [0,0,0]) x\cba\addons\common\test_position.sqf:24
14:00:51 [CBA] (common) Test OK: (_result isEqualTo [0,0,0]) x\cba\addons\common\test_position.sqf:31
14:00:51 [CBA] (common) Test OK: (_result isEqualTo [0,0,0]) x\cba\addons\common\test_position.sqf:38
14:00:51 [CBA] (common) Test OK: (_result isEqualTo [1,2,0] ) x\cba\addons\common\test_position.sqf:50
14:00:51 [CBA] (common) Test OK: (_result isEqualTo [1,2] ) x\cba\addons\common\test_position.sqf:62
```