### PR TITLE
add CBA_fnc_(de)serializeNamespace

### DIFF
--- a/addons/hashes/CfgFunctions.hpp
+++ b/addons/hashes/CfgFunctions.hpp
@@ -80,6 +80,8 @@ class CfgFunctions
                 description = "Parses a YAML file into a nested array/Hash structure.";
                 file = "\x\cba\addons\hashes\fnc_parseYAML.sqf";
             };
+            PATHTO_FNC(serializeNamespace);
+            PATHTO_FNC(deserializeNamespace);
         };
     };
 };

--- a/addons/hashes/fnc_deserializeNamespace.sqf
+++ b/addons/hashes/fnc_deserializeNamespace.sqf
@@ -1,0 +1,40 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_deserializeNamespace
+
+Description:
+    Creates namespace containing all variables stored in a CBA hash.
+
+Parameters:
+    _hash     - a hash <ARRAY>
+    _isGlobal - create a global namespace (optional, default: false) <BOOLEAN>
+
+Returns:
+    _namespace - a namespace <LOCATION, OBJECT>
+
+Examples:
+    (begin example)
+        private _hash = profileNamespace getVariable "My_serializedNamespace";
+        My_namespace = [_hash] call CBA_fnc_deserializeNamespace;
+    (end)
+
+Author:
+    commy2
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+SCRIPT(deserializeNamespace);
+
+params [["_hash", [], [[]]], ["_isGlobal", false, [false]]];
+
+private _namespace = _isGlobal call CBA_fnc_createNamespace;
+
+if (_isGlobal) then {
+    [_hash, {
+        _namespace setVariable [_key, _value, true];
+    }] call CBA_fnc_hashEachPair;
+} else {
+    [_hash, {
+        _namespace setVariable [_key, _value];
+    }] call CBA_fnc_hashEachPair;
+};
+
+_namespace

--- a/addons/hashes/fnc_serializeNamespace.sqf
+++ b/addons/hashes/fnc_serializeNamespace.sqf
@@ -1,0 +1,33 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_serializeNamespace
+
+Description:
+    Creates CBA hash containing all variables stored in a namespace.
+
+Parameters:
+    _namespace - a namespace <LOCATION, OBJECT>
+
+Returns:
+    _hash - a hash <ARRAY>
+
+Examples:
+    (begin example)
+        private _hash = _namespace call CBA_fnc_serializeNamespace;
+        profileNamespace setVariable ["My_serializedNamespace", _hash];
+    (end)
+
+Author:
+    commy2
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+SCRIPT(serializeNamespace);
+
+params [["_namespace", locationNull, [locationNull, objNull]]];
+
+private _hash = [] call CBA_fnc_hashCreate;
+
+{
+    [_hash, _x, _namespace getVariable _x] call CBA_fnc_hashSet;
+} forEach allVariables _namespace;
+
+_hash


### PR DESCRIPTION
**When merged this pull request will:**
- title

I already use this idea for the settings stuff, but this is put inside functions. The one downside of the pseudo namespaces is, that LOCATION's and OBJECT's don't survive the missions end. CBA hashes are just arrays, so they do. By "serializing" you can essentially store a copy of the pseudo namespace in the `profileNamespace` or even in the mission (using `s`/`get3DENMissionAttributes`) by converting them to a CBA hash first.