### PR TITLE
change hotkey for config viewer

### DIFF
--- a/addons/diagnostic/CfgDisplay3DEN.hpp
+++ b/addons/diagnostic/CfgDisplay3DEN.hpp
@@ -12,7 +12,7 @@ class Display3DEN {
                     shortcuts[] = {INPUT_ALT_OFFSET + DIK_F};
                 };
                 class ConfigViewer {
-                    shortcuts[] = {INPUT_CTRL_OFFSET + DIK_G};
+                    shortcuts[] = {INPUT_ALT_OFFSET + DIK_G};
                 };
             };
         };


### PR DESCRIPTION
**When merged this pull request will:**
- Ctrl + G no longer works for opening the config viewer
- BI probably uses that keybind for something else
- Alt + G seems to work and to be free, so change it to that
