### PR TITLE
Fix "unit" changed PlayerEH not working reliably

### DIFF
--- a/addons/events/fnc_addPlayerEventHandler.sqf
+++ b/addons/events/fnc_addPlayerEventHandler.sqf
@@ -40,49 +40,49 @@ params [["_type", "", [""]], ["_function", {}, [{}]], ["_applyRetroactively", fa
 _type = toLower _type;
 
 private _id = switch (_type) do {
-case ("unit"): {
+case "unit": {
     if (_applyRetroactively && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
         [GVAR(oldUnit), objNull] call _function;
     };
     [QGVAR(unitEvent), _function] call CBA_fnc_addEventHandler // return id
 };
-case ("weapon"): {
+case "weapon": {
     if (_applyRetroactively && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
         [GVAR(oldUnit), currentWeapon GVAR(oldUnit)] call _function;
     };
     [QGVAR(weaponEvent), _function] call CBA_fnc_addEventHandler // return id
 };
-case ("loadout"): {
+case "loadout": {
     if (_applyRetroactively && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
         [GVAR(oldUnit), getUnitLoadout GVAR(oldUnit)] call _function;
     };
     [QGVAR(loadoutEvent), _function] call CBA_fnc_addEventHandler // return id
 };
-case ("vehicle"): {
+case "vehicle": {
     if (_applyRetroactively && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
         [GVAR(oldUnit), vehicle GVAR(oldUnit)] call _function;
     };
     [QGVAR(vehicleEvent), _function] call CBA_fnc_addEventHandler // return id
 };
-case ("turret"): {
+case "turret": {
     if (_applyRetroactively && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
         [GVAR(oldUnit), GVAR(oldUnit) call CBA_fnc_turretPath] call _function;
     };
     [QGVAR(turretEvent), _function] call CBA_fnc_addEventHandler // return id
 };
-case ("visionmode"): {
+case "visionmode": {
     if (_applyRetroactively && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
         [GVAR(oldUnit), currentVisionMode GVAR(oldUnit)] call _function;
     };
     [QGVAR(visionModeEvent), _function] call CBA_fnc_addEventHandler // return id
 };
-case ("cameraview"): {
+case "cameraview": {
     if (_applyRetroactively && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
         [GVAR(oldUnit), cameraView] call _function;
     };
     [QGVAR(cameraViewEvent), _function] call CBA_fnc_addEventHandler // return id
 };
-case ("visiblemap"): {
+case "visiblemap": {
     if (_applyRetroactively && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
         [GVAR(oldUnit), visibleMap] call _function;
     };
@@ -109,6 +109,10 @@ if (_id != -1) then {
         GVAR(playerEHInfo) pushBack addMissionEventHandler ["EachFrame", {call FUNC(playerEH_EachFrame)}];
         [QFUNC(playerEH_EachFrame), {
             private _player = call CBA_fnc_currentUnit;
+            if !(_player isEqualTo GVAR(oldUnit)) then {
+                [QGVAR(unitEvent), [_player, GVAR(oldUnit)]] call CBA_fnc_localEvent;
+                GVAR(oldUnit) = _player;
+            };
 
             private _data = currentWeapon _player;
             if !(_data isEqualTo GVAR(oldWeapon)) then {
@@ -137,11 +141,8 @@ if (_id != -1) then {
                 };
             };
 
-            // Fix for problems with PlayerViewChanged eh not always firing on vehicle switch on dedicated
-            // Look into removing this block if event is fixed
             _data = vehicle _player;
             if !(_data isEqualTo GVAR(oldVehicle)) then {
-                TRACE_1("Using fallback polling event for vehicle change",_data);
                 GVAR(oldVehicle) = _data;
                 [QGVAR(vehicleEvent), [_player, _data]] call CBA_fnc_localEvent;
             };
@@ -165,26 +166,9 @@ if (_id != -1) then {
             };
         }] call CBA_fnc_compileFinal;
 
-        GVAR(playerEHInfo) pushBack addMissionEventHandler ["PlayerViewChanged", {call FUNC(playerEH_ViewChanged)}];
-        [QFUNC(playerEH_ViewChanged), {
-            private _player = call CBA_fnc_currentUnit;
-
-            if !(_player isEqualTo GVAR(oldUnit)) then {
-                [QGVAR(unitEvent), [_player, GVAR(oldUnit)]] call CBA_fnc_localEvent;
-                GVAR(oldUnit) = _player;
-            };
-
-            private _data = vehicle _player;
-            if !(_data isEqualTo GVAR(oldVehicle)) then {
-                GVAR(oldVehicle) = _data;
-                [QGVAR(vehicleEvent), [_player, _data]] call CBA_fnc_localEvent;
-            };
-        }] call CBA_fnc_compileFinal;
-
         GVAR(playerEHInfo) pushBack addMissionEventHandler ["Map", {call FUNC(playerEH_Map)}];
         [QFUNC(playerEH_Map), {
-            params ["_data"]; //visibleMap is updated one frame later
-
+            params ["_data"]; // visibleMap is updated one frame later
             if !(_data isEqualTo GVAR(oldVisibleMap)) then {
                 GVAR(oldVisibleMap) = _data;
                 [QGVAR(visibleMapEvent), [call CBA_fnc_currentUnit, _data]] call CBA_fnc_localEvent;
@@ -195,23 +179,10 @@ if (_id != -1) then {
         // using spawn-dc to not having to wait for postInit to complete
         0 spawn {
             {
-                private _player = call CBA_fnc_currentUnit;
-
-                if !(_player isEqualTo GVAR(oldUnit)) then {
-                    [QGVAR(unitEvent), [_player, GVAR(oldUnit)]] call CBA_fnc_localEvent;
-                    GVAR(oldUnit) = _player;
-                };
-
-                private _data = vehicle _player;
-                if !(_data isEqualTo GVAR(oldVehicle)) then {
-                    GVAR(oldVehicle) = _data;
-                    [QGVAR(vehicleEvent), [_player, _data]] call CBA_fnc_localEvent;
-                };
-
-                _data = visibleMap;
+                private _data = visibleMap;
                 if !(_data isEqualTo GVAR(oldVisibleMap)) then {
                     GVAR(oldVisibleMap) = _data;
-                    [QGVAR(visibleMapEvent), [_player, _data]] call CBA_fnc_localEvent;
+                    [QGVAR(visibleMapEvent), [call CBA_fnc_currentUnit, _data]] call CBA_fnc_localEvent;
                 };
             } call CBA_fnc_directCall;
         };

--- a/addons/events/fnc_removePlayerEventHandler.sqf
+++ b/addons/events/fnc_removePlayerEventHandler.sqf
@@ -27,28 +27,28 @@ params [["_type", "", [""]], ["_id", -1, [0]]];
 _type = toLower _type;
 
 switch (_type) do {
-case ("unit"): {
+case "unit": {
     [QGVAR(unitEvent), _id] call CBA_fnc_removeEventHandler;
 };
-case ("weapon"): {
+case "weapon": {
     [QGVAR(weaponEvent), _id] call CBA_fnc_removeEventHandler;
 };
-case ("loadout"): {
+case "loadout": {
     [QGVAR(loadoutEvent), _id] call CBA_fnc_removeEventHandler;
 };
-case ("vehicle"): {
+case "vehicle": {
     [QGVAR(vehicleEvent), _id] call CBA_fnc_removeEventHandler;
 };
-case ("turret"): {
+case "turret": {
     [QGVAR(turretEvent), _id] call CBA_fnc_removeEventHandler;
 };
-case ("visionmode"): {
+case "visionmode": {
     [QGVAR(visionModeEvent), _id] call CBA_fnc_removeEventHandler;
 };
-case ("cameraview"): {
+case "cameraview": {
     [QGVAR(cameraViewEvent), _id] call CBA_fnc_removeEventHandler;
 };
-case ("visiblemap"): {
+case "visiblemap": {
     [QGVAR(visibleMapEvent), _id] call CBA_fnc_removeEventHandler;
 };
 default {nil};
@@ -57,10 +57,12 @@ default {nil};
 if (!isNil QGVAR(playerEHInfo)) then {
     GVAR(playerEHInfo) deleteAt (GVAR(playerEHInfo) find [_type, _id]);
 
-    if (count GVAR(playerEHInfo) == 3) then {
-        removeMissionEventHandler ["EachFrame",         GVAR(playerEHInfo) select 0];
-        removeMissionEventHandler ["PlayerViewChanged", GVAR(playerEHInfo) select 1];
-        removeMissionEventHandler ["Map",               GVAR(playerEHInfo) select 2];
+    // First two entries are mission eventhandler ids. Rest are framework
+    // specific ids in array form. If all playerChanged eventhandlers were
+    // removed, then also clean up the mission eventhandlers.
+    if (count GVAR(playerEHInfo) == 2) then {
+        removeMissionEventHandler ["EachFrame", GVAR(playerEHInfo) select 0];
+        removeMissionEventHandler ["Map",       GVAR(playerEHInfo) select 1];
         GVAR(playerEHInfo) = nil;
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- "unit"  and "vehicle" player eventhandlers seem to not work the same as the BI playerViewChanged after all, so switch back to the old polling method to avoid bugs.
