### PR TITLE
"Set Position" position type value --> "Module Position" in defend and patrol modules

### DIFF
--- a/addons/modules/CfgVehicles.hpp
+++ b/addons/modules/CfgVehicles.hpp
@@ -105,7 +105,7 @@ class CfgVehicles {
                 description = CSTRING(DefendPositionType_Desc);
                 typeName = "STRING";
                 class values {
-                    class moduleLoc {
+                    class setLoc {
                         name = CSTRING(ModuleLoc);
                         value = "";
                         default = 1;
@@ -219,7 +219,7 @@ class CfgVehicles {
                 description = CSTRING(PatrolCenterType_Desc);
                 typeName = "STRING";
                 class values {
-                    class moduleLoc {
+                    class setLoc {
                         name = CSTRING(ModuleLoc);
                         value = "";
                         default = 1;

--- a/addons/modules/CfgVehicles.hpp
+++ b/addons/modules/CfgVehicles.hpp
@@ -105,8 +105,8 @@ class CfgVehicles {
                 description = CSTRING(DefendPositionType_Desc);
                 typeName = "STRING";
                 class values {
-                    class setLoc {
-                        name = CSTRING(SetLoc);
+                    class moduleLoc {
+                        name = CSTRING(ModuleLoc);
                         value = "";
                         default = 1;
                     };
@@ -219,8 +219,8 @@ class CfgVehicles {
                 description = CSTRING(PatrolCenterType_Desc);
                 typeName = "STRING";
                 class values {
-                    class setLoc {
-                        name = CSTRING(SetLoc);
+                    class moduleLoc {
+                        name = CSTRING(ModuleLoc);
                         value = "";
                         default = 1;
                     };


### PR DESCRIPTION
**When merged this pull request will:**
- Replace "Set Position" position type value with "Module Position" in
the defend and patrol modules.

These settings do exactly the same thing, namely using the module's position to attack, to patrol around and to defend around. "Set Position" is confusing especially when the setting is named inconsistently across three similar modules.
