### PR TITLE
improved init box 2

### DIFF
--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -5,14 +5,6 @@
             <English>Community Base Addons - Common Component</English>
             <Japanese>Community Base Addons - 全般要素</Japanese>
         </Key>
-        <Key ID="STR_CBA_Common_ValidateInitBox">
-            <English>Validate Init Expression</English>
-            <German>Prüfe Init-Ausdruck</German>
-        </Key>
-        <Key ID="STR_CBA_Common_ValidateInitBox_tooltip">
-            <English>Enable code validation of the Init box\n\nUnchecking this enables the usage of local variables and return values in the Init box.</Original>
-            <German>Aktiviere Code-Validierung der Init-Box\n\nDeaktivieren ermöglicht die Benutzung von lokalen Variablen und Rückgabewerten in der Init-Box</German>
-        </Key>
     </Package>
 </Project>
 


### PR DESCRIPTION
**When merged this pull request will:**
- Follow up on #612 
- Removes the "validate" checkbox. It's no longer needed. This method has code validation and allows local variables and return values. No drawbacks, all benefits.

- fixes that the hidden init box could still be selected by using "tab".
- init expression is no longer saved twice in mission.sqm