### PR TITLE
addClassEH - Handle respawning units

### DIFF
--- a/addons/xeh/fnc_addClassEventHandler.sqf
+++ b/addons/xeh/fnc_addClassEventHandler.sqf
@@ -57,7 +57,7 @@ if (_applyInitRetroactively && {!(_eventName in ["init", "initpost"])}) then {
 // add events to already existing objects
 private _eventVarName = format [QGVAR(%1), _eventName];
 
-private _entities = (entities [[], [], true, true]);
+private _entities = (entities [[], [], true, false]); // include dead entities to handle respawning units
 _entities = _entities arrayIntersect _entities; // entities can return duplicates at postInit - #567
 
 {


### PR DESCRIPTION
Ref https://github.com/acemod/ACE3/issues/5005

Add class event handler fails if the unit is dead and in the process of respawning, 

To reproduce:
```
addMissionEventHandler ["EntityKilled", {
    ["CAManBase", "fired", {systemChat str _this}] call CBA_fnc_addClassEventHandler;
}];
```
Put in init.sqf and hit respawn in MP.
