### PR TITLE
run missions preInit XEH on mission switch in 3DEN

### DIFF
--- a/addons/xeh/CfgEventHandlers.hpp
+++ b/addons/xeh/CfgEventHandlers.hpp
@@ -85,7 +85,7 @@ class Extended_Deleted_EventHandlers {};
 // display xeh
 class Extended_DisplayLoad_EventHandlers {
     class Display3DEN {
-        ADDON = QUOTE(call (uiNamespace getVariable 'FUNC(3DENDisplayLoad)'));
+        ADDON = QUOTE(call (uiNamespace getVariable 'FUNC(initDisplay3DEN)'));
     };
 };
 class Extended_DisplayUnload_EventHandlers {};

--- a/addons/xeh/fnc_3DENDisplayLoad.sqf
+++ b/addons/xeh/fnc_3DENDisplayLoad.sqf
@@ -1,7 +1,0 @@
-#include "script_component.hpp"
-
-// fix for preInit = 1 functions not being executed when entering 3den from main menu
-[] call CBA_fnc_preInit;
-
-// since 1.60, preInit = 1 functions aren't executed when returning from a preview either ...
-add3DENEventHandler ["OnMissionPreviewEnd", {[] call CBA_fnc_preInit}];

--- a/addons/xeh/fnc_initDisplay3DEN.sqf
+++ b/addons/xeh/fnc_initDisplay3DEN.sqf
@@ -1,0 +1,21 @@
+#include "script_component.hpp"
+
+// fix for preInit = 1 functions not being executed when entering 3den from main menu
+[] call CBA_fnc_preInit;
+
+// since 1.60, preInit = 1 functions aren't executed when returning from a preview either ...
+add3DENEventHandler ["OnMissionPreviewEnd", {[] call CBA_fnc_preInit}];
+
+// switching terrains in 3den will reset missionNamespace
+add3DENEventHandler ["OnTerrainNew", {[] call CBA_fnc_preInit}];
+
+private _fnc_preInitMissionConfig = {
+    {
+        if (_x select 0 == "" && {_x select 1 == "preInit"}) then {
+            [] call (_x select 2);
+        };
+    } forEach (missionConfigFile call CBA_fnc_compileEventHandlers);
+};
+
+add3DENEventHandler ["OnMissionNew", _fnc_preInitMissionConfig];
+add3DENEventHandler ["OnMissionLoad", _fnc_preInitMissionConfig];

--- a/addons/xeh/fnc_preInit.sqf
+++ b/addons/xeh/fnc_preInit.sqf
@@ -21,13 +21,6 @@ if (ISPROCESSED(missionNamespace)) exitWith {
 };
 SETPROCESSED(missionNamespace);
 
-add3DENEventHandler ["OnTerrainNew", { // switching terrains in 3den will reset missionNamespace
-    if (!ISPROCESSED(missionNamespace)) then { 
-        diag_log text "[XEH]: Re-running preInit after 3den terrain switch";
-        [] call CBA_fnc_preInit;
-    };
-}];
-
 SLX_XEH_DisableLogging = uiNamespace getVariable ["SLX_XEH_DisableLogging", false]; // get from preStart
 
 XEH_LOG("XEH: PreInit started. v" + getText (configFile >> "CfgPatches" >> "cba_common" >> "version"));

--- a/addons/xeh/fnc_preStart.sqf
+++ b/addons/xeh/fnc_preStart.sqf
@@ -26,7 +26,7 @@ with uiNamespace do {
     SLX_XEH_COMPILE = compileFinal "compile preprocessFileLineNumbers _this"; //backwards comps
     SLX_XEH_COMPILE_NEW = CBA_fnc_compileFunction; //backwards comp
 
-    PREP(3DENDisplayLoad);
+    PREP(initDisplay3DEN);
 
     // call PreStart events
     {


### PR DESCRIPTION
**When merged this pull request will:**
- runs the missions XEH preInit eventhandlers every time a new mission is selected in the Eden-Editor ("OnMissionNew" and "OnMissionLoad")
- moves "OnTerrainNew" fix to the 3DEN display load event, so the 3DEN eventhandler isn't repeatedly added by itself every time the terrain is switched in the Eden-Editor.
- also renames `3DENDisplayLoad` to `initDisplay3DEN` ("init" of "Display3DEN")

This isn't a perfect fix, because functions or settings defined in the missions preInit will still carry over to the new mission / loaded mission if the terrain was *not* switched. This fixes itself when the preview is used though. Currently using the preview would delete the carried over functions and settings and also initialize the new ones, so at least half the problem is gone.