### PR TITLE
delay initPost eventhandler of objects created mid mission

### DIFF
--- a/addons/xeh/fnc_init.sqf
+++ b/addons/xeh/fnc_init.sqf
@@ -34,7 +34,7 @@ if !(ISINITIALIZED(_this)) then {
     // run InitPost or put on stack
     if (SLX_XEH_MACHINE select 8) then {
         {
-            [_this] call _x;
+            [_x, [_this]] call CBA_fnc_execNextFrame;
         } forEach (_this getVariable QGVAR(initPost));
     } else {
         GVAR(initPostStack) pushBack _this;


### PR DESCRIPTION
This "solves" this issue:

```sqf
["B_MRAP_01_F", "init", {(_this select 0) setVariable ["test1", true, true]}] call CBA_fnc_addClassEventHandler;
_v = "B_MRAP_01_F" createVehicle position player;
_v setVariable ["test2", true, true];
missionNamespace setVariable ["v", _v, true];
```

>On local machine: test1 and test2 are defined
>On remote machine: test1 undefined, test2 defined
>-> setVariable public doesn't work inside the init eventhandler
>We have initPost, which solves this for editor placed objects (init artificially delayed until postInit eventhandler), but it fails for objects created mid mission, which is a pretty nasty inconsistency.
>I plan to fix this in the next CBA update by delaying initPost one frame artifically if postInit already happened.