### PR TITLE
Fix undef error

### DIFF
--- a/addons/diagnostic/fnc_initExtendedDebugConsole.sqf
+++ b/addons/diagnostic/fnc_initExtendedDebugConsole.sqf
@@ -1,3 +1,4 @@
+#include "\a3\ui_f\hpp\defineResinclDesign.inc"
 #include "script_component.hpp"
 
 #define MAX_STATEMENTS 50

--- a/addons/diagnostic/script_component.hpp
+++ b/addons/diagnostic/script_component.hpp
@@ -14,7 +14,7 @@
 #include "\a3\ui_f\hpp\defineDIKCodes.inc"
 #include "\a3\ui_f\hpp\defineCommonGrids.inc"
 #include "\a3\ui_f\hpp\defineResincl.inc"
-#include "\a3\ui_f\hpp\defineResinclDesign.inc"
+// #include "\a3\ui_f\hpp\defineResinclDesign.inc" // moved to sqf to handle undef error
 
 #define IDC_DEBUGCONSOLE_PREV 90110
 #define IDC_DEBUGCONSOLE_NEXT 90111


### PR DESCRIPTION
Temporary fix for tools failing to make because of a double defined macro in BI's .inc files.