### PR TITLE
fix credits line obstructing game version info box

### DIFF
--- a/addons/help/fnc_setCreditsLine.sqf
+++ b/addons/help/fnc_setCreditsLine.sqf
@@ -60,3 +60,6 @@ if (isText (_entry >> "version")) then {
 
 // add single line
 _control ctrlSetStructuredText parseText format ["%1%2 by %3", _name, _version, _author];
+
+// make credits line not obstruct other controls
+_control ctrlEnable false;


### PR DESCRIPTION
**When merged this pull request will:**
- title

See this:
![http://i.imgur.com/cRlJh7A.jpg](http://i.imgur.com/cRlJh7A.jpg)

By disabling the credits line, it no longer takes away onMouseEnter/Exit "focus" from the info box.