### PR TITLE
Fix: String STR_cba_help_unkownKey not found

### DIFF
--- a/addons/help/XEH_postClientInit.sqf
+++ b/addons/help/XEH_postClientInit.sqf
@@ -63,7 +63,7 @@ if (!isNil QGVAR(keys)) then {
                 private _keyName = EGVAR(keybinding,keyNames) getVariable str _key;
 
                 if (isNil "_keyName") then {
-                    _keyName = ["", format [localize ELSTRING(keybinding,unkownKey), _key]] select (_key > -1);
+                    _keyName = ["", format [localize ELSTRING(keybinding,unkownKey), _key]] select (_key > 0);
                 };
 
                 // Build the full key combination name.

--- a/addons/help/XEH_postClientInit.sqf
+++ b/addons/help/XEH_postClientInit.sqf
@@ -63,7 +63,7 @@ if (!isNil QGVAR(keys)) then {
                 private _keyName = EGVAR(keybinding,keyNames) getVariable str _key;
 
                 if (isNil "_keyName") then {
-                    _keyName = format [localize ELSTRING(keybinding,unkownKey), _key];
+                    _keyName = ["", format [localize ELSTRING(keybinding,unkownKey), _key]] select (_key > -1);
                 };
 
                 // Build the full key combination name.

--- a/addons/help/XEH_postClientInit.sqf
+++ b/addons/help/XEH_postClientInit.sqf
@@ -63,7 +63,7 @@ if (!isNil QGVAR(keys)) then {
                 private _keyName = EGVAR(keybinding,keyNames) getVariable str _key;
 
                 if (isNil "_keyName") then {
-                    _keyName = format [localize LSTRING(unkownKey), _key];
+                    _keyName = format [localize ELSTRING(keybinding,unkownKey), _key];
                 };
 
                 // Build the full key combination name.


### PR DESCRIPTION
**When merged this pull request will:**
- This string is defined in keybinding and not help, so ELSTRING has to be used instead of LSTRING.
- Also leave blank if key action is unbound (key = -1).