### PR TITLE
fix: added buttons are missing in MP

### DIFF
--- a/addons/ui/CfgEventHandlers.hpp
+++ b/addons/ui/CfgEventHandlers.hpp
@@ -15,4 +15,7 @@ class Extended_DisplayLoad_EventHandlers {
     class RscDisplayInterrupt {
         ADDON = QUOTE(_this call (uiNamespace getVariable 'FUNC(initDisplayInterrupt)'));
     };
+    class RscDisplayMPInterrupt {
+        ADDON = QUOTE(_this call (uiNamespace getVariable 'FUNC(initDisplayInterrupt)'));
+    };
 };

--- a/addons/ui/fnc_initDisplayInterrupt.sqf
+++ b/addons/ui/fnc_initDisplayInterrupt.sqf
@@ -10,7 +10,7 @@ _display setVariable [QGVAR(MenuButtons), _buttons];
 
 // inital button placement
 private _offset = -1.1 * (count GVAR(MenuButtons) + 4);
-if (getNumber (missionConfigFile >> "replaceAbortButton") > 0) then {
+if (!isMultiplayer && {getNumber (missionConfigFile >> "replaceAbortButton") > 0}) then {
     _offset = _offset - 1.1;
 };
 
@@ -73,64 +73,67 @@ _button ctrlAddEventHandler ["ButtonClick", {
     _buttons = + (_display getVariable QGVAR(MenuButtons));
 
     _offset = 0;
-    if (getNumber (missionConfigFile >> "replaceAbortButton") > 0) then {
+    if (!isMultiplayer && {getNumber (missionConfigFile >> "replaceAbortButton") > 0}) then {
         _offset = 1.1;
     };
 
-    //if options are expanded (Video Options button is shown), collapse it and vice versa
-    //if(ctrlFade (_display displayCtrl 301) < 0.5) then
-    _upperPartTime = 0.05 * count _buttons; //0.05 for each button
+    _upperPartTime = 0.05 * count _buttons;
     _buttonsTime = 0.05;
 
     //hide buttons and collapse accordion
     if (uiNamespace getvariable "BIS_DisplayInterrupt_isOptionsExpanded") then {
         //move down - background, title, player's name, play, editor, profile, options
-        
+
         //Title background
-        _control = _display displayctrl 1050;
-        _control ctrlSetPosition [(1 * GUI_GRID_W + GUI_GRID_X), ((14.2 - _offset) * GUI_GRID_H + GUI_GRID_Y)];                                                                                                                 
+        _control = _display displayCtrl 1050;
+        _control ctrlSetPosition [1 * GUI_GRID_W + GUI_GRID_X, (14.2 - _offset) * GUI_GRID_H + GUI_GRID_Y];
         _control ctrlCommit _upperPartTime;
-        
+
         //Title - same position as title background
-        _control = _display displayctrl 523;
-        _control ctrlSetPosition [(1 * GUI_GRID_W + GUI_GRID_X), ((14.2 - _offset) * GUI_GRID_H + GUI_GRID_Y)];                                                                                                                 
+        _control = _display displayCtrl 523;
+        _control ctrlSetPosition [1 * GUI_GRID_W + GUI_GRID_X, (14.2 - _offset) * GUI_GRID_H + GUI_GRID_Y];
         _control ctrlCommit _upperPartTime;
-        
+
         //Player's name - same position as title background
-        _control = _display displayctrl 109;
-        _control ctrlSetPosition [(6 * GUI_GRID_W + GUI_GRID_X), ((14.2 - _offset) * GUI_GRID_H + GUI_GRID_Y)];                                                                                                                 
+        _control = _display displayCtrl 109;
+        _control ctrlSetPosition [6 * GUI_GRID_W + GUI_GRID_X, (14.2 - _offset) * GUI_GRID_H + GUI_GRID_Y];
         _control ctrlCommit _upperPartTime;
-        
+
         //Continue button
-        _control = _display displayctrl 2;
-        _control ctrlSetPosition [(1 * GUI_GRID_W + GUI_GRID_X), ((15.3 - _offset) * GUI_GRID_H + GUI_GRID_Y)];                                                                                                                 
+        _control = _display displayCtrl 2;
+        _control ctrlSetPosition [1 * GUI_GRID_W + GUI_GRID_X, (15.3 - _offset) * GUI_GRID_H + GUI_GRID_Y];
         _control ctrlCommit _upperPartTime;
-        
+
         //Save button
-        _control = _display displayctrl 103;
-        _control ctrlSetPosition [(1 * GUI_GRID_W + GUI_GRID_X), ((16.4 - _offset) * GUI_GRID_H + GUI_GRID_Y)];                                                                                                                 
+        _control = _display displayCtrl 103;
+        _control ctrlSetPosition [1 * GUI_GRID_W + GUI_GRID_X, (16.4 - _offset) * GUI_GRID_H + GUI_GRID_Y];
         _control ctrlCommit _upperPartTime;
-        
+
         //Skip button - same position as Save
-        _control = _display displayctrl 1002;
-        _control ctrlSetPosition [(1 * GUI_GRID_W + GUI_GRID_X), ((16.4 - _offset) * GUI_GRID_H + GUI_GRID_Y)];                                                                                                                 
+        _control = _display displayCtrl 1002;
+        _control ctrlSetPosition [1 * GUI_GRID_W + GUI_GRID_X, (16.4 - _offset) * GUI_GRID_H + GUI_GRID_Y];
         _control ctrlCommit _upperPartTime;
-        
+
         //Revert
-        _control = _display displayctrl 119;
-        _control ctrlSetPosition [(1 * GUI_GRID_W + GUI_GRID_X), ((17.5 - _offset) * GUI_GRID_H + GUI_GRID_Y)];                                                                                                                 
+        _control = _display displayCtrl 119;
+        _control ctrlSetPosition [1 * GUI_GRID_W + GUI_GRID_X, (17.5 - _offset) * GUI_GRID_H + GUI_GRID_Y];
         _control ctrlCommit _upperPartTime;
-        
+
         //Again - same position as Revert
-        _control = _display displayctrl 1003;
-        _control ctrlSetPosition [(1 * GUI_GRID_W + GUI_GRID_X), ((17.5 - _offset) * GUI_GRID_H + GUI_GRID_Y)];                                                                                                                 
+        _control = _display displayCtrl 1003;
+        _control ctrlSetPosition [1 * GUI_GRID_W + GUI_GRID_X, (17.5 - _offset) * GUI_GRID_H + GUI_GRID_Y];
         _control ctrlCommit _upperPartTime;
-        
+
+        //Respawn
+        _control = _display displayCtrl 1010;
+        _control ctrlSetPosition [1 * GUI_GRID_W + GUI_GRID_X, (17.5 - _offset) * GUI_GRID_H + GUI_GRID_Y];
+        _control ctrlCommit _upperPartTime;
+
         //Options button
-        _control = _display displayctrl 101;
-        _control ctrlSetPosition [(1 * GUI_GRID_W + GUI_GRID_X), ((18.6 - _offset) * GUI_GRID_H + GUI_GRID_Y)];                                                                                                                 
+        _control = _display displayCtrl 101;
+        _control ctrlSetPosition [1 * GUI_GRID_W + GUI_GRID_X, (18.6 - _offset) * GUI_GRID_H + GUI_GRID_Y];
         _control ctrlCommit _upperPartTime;
-        
+
         private _fnc_hideButton = {
             private _button = (_this select 0) deleteAt 0;
 
@@ -145,60 +148,65 @@ _button ctrlAddEventHandler ["ButtonClick", {
 
         [_buttons, -1] call _fnc_hideButton;
         [_fnc_hideButton, _buttonsTime, _buttons] call CBA_fnc_addPerFrameHandler;
-        
+
         uiNamespace setVariable ["BIS_DisplayInterrupt_isOptionsExpanded", false];
     } else {
         //expand accordion and show buttons
-            
+
         // additional buttons from CBA minus 4 already existing ones
         _offset = _offset + (count _buttons - 4) * 1.1;
 
         //Title background
-        _control = _display displayctrl 1050;
-        _control ctrlSetPosition [(1 * GUI_GRID_W + GUI_GRID_X), ((9.8 - _offset) * GUI_GRID_H + GUI_GRID_Y)];                                                                                                                  
+        _control = _display displayCtrl 1050;
+        _control ctrlSetPosition [1 * GUI_GRID_W + GUI_GRID_X, (9.8 - _offset) * GUI_GRID_H + GUI_GRID_Y];
         _control ctrlCommit _upperPartTime;
-        
+
         //Title - same position as title background
-        _control = _display displayctrl 523;
-        _control ctrlSetPosition [(1 * GUI_GRID_W + GUI_GRID_X), ((9.8 - _offset) * GUI_GRID_H + GUI_GRID_Y)];                                                                                                                  
+        _control = _display displayCtrl 523;
+        _control ctrlSetPosition [1 * GUI_GRID_W + GUI_GRID_X, (9.8 - _offset) * GUI_GRID_H + GUI_GRID_Y];
         _control ctrlCommit _upperPartTime;
-        
+
         //Player's name - same position as title background
-        _control = _display displayctrl 109;
-        _control ctrlSetPosition [(6 * GUI_GRID_W + GUI_GRID_X), ((9.8 - _offset) * GUI_GRID_H + GUI_GRID_Y)];                                                                                                                  
+        _control = _display displayCtrl 109;
+        _control ctrlSetPosition [6 * GUI_GRID_W + GUI_GRID_X, (9.8 - _offset) * GUI_GRID_H + GUI_GRID_Y];
         _control ctrlCommit _upperPartTime;
-        
+
         //Continue button
-        _control = _display displayctrl 2;
-        _control ctrlSetPosition [(1 * GUI_GRID_W + GUI_GRID_X), ((10.9 - _offset) * GUI_GRID_H + GUI_GRID_Y)];                                                                                                                 
+        _control = _display displayCtrl 2;
+        _control ctrlSetPosition [1 * GUI_GRID_W + GUI_GRID_X, (10.9 - _offset) * GUI_GRID_H + GUI_GRID_Y];
         _control ctrlCommit _upperPartTime;
-        
+
         //Save button
-        _control = _display displayctrl 103;
-        _control ctrlSetPosition [(1 * GUI_GRID_W + GUI_GRID_X), ((12.0 - _offset) * GUI_GRID_H + GUI_GRID_Y)];                                                                                                                 
+        _control = _display displayCtrl 103;
+        _control ctrlSetPosition [1 * GUI_GRID_W + GUI_GRID_X, (12.0 - _offset) * GUI_GRID_H + GUI_GRID_Y];
         _control ctrlCommit _upperPartTime;
-        
+
         //Skip button - same position as Save
-        _control = _display displayctrl 1002;
-        _control ctrlSetPosition [(1 * GUI_GRID_W + GUI_GRID_X), ((12.0 - _offset) * GUI_GRID_H + GUI_GRID_Y)];                                                                                                                 
+        _control = _display displayCtrl 1002;
+        _control ctrlSetPosition [1 * GUI_GRID_W + GUI_GRID_X, (12.0 - _offset) * GUI_GRID_H + GUI_GRID_Y];
         _control ctrlCommit _upperPartTime;
-        
+
         //Revert
-        _control = _display displayctrl 119;
-        _control ctrlSetPosition [(1 * GUI_GRID_W + GUI_GRID_X), ((13.1 - _offset) * GUI_GRID_H + GUI_GRID_Y)];                                                                                                                 
+        _control = _display displayCtrl 119;
+        _control ctrlSetPosition [1 * GUI_GRID_W + GUI_GRID_X, (13.1 - _offset) * GUI_GRID_H + GUI_GRID_Y];
         _control ctrlCommit _upperPartTime;
-        
+
         //Again - same position as Revert
-        _control = _display displayctrl 1003;
-        _control ctrlSetPosition [(1 * GUI_GRID_W + GUI_GRID_X), ((13.1 - _offset) * GUI_GRID_H + GUI_GRID_Y)];                                                                                                                 
+        _control = _display displayCtrl 1003;
+        _control ctrlSetPosition [1 * GUI_GRID_W + GUI_GRID_X, (13.1 - _offset) * GUI_GRID_H + GUI_GRID_Y];
         _control ctrlCommit _upperPartTime;
-        
+
+        //Respawn
+        _control = _display displayCtrl 1010;
+        _control ctrlSetPosition [1 * GUI_GRID_W + GUI_GRID_X, (13.1 - _offset) * GUI_GRID_H + GUI_GRID_Y];
+        _control ctrlCommit _upperPartTime;
+
         //Options button
-        _control = _display displayctrl 101;
-        _control ctrlSetPosition [(1 * GUI_GRID_W + GUI_GRID_X), ((14.2 - _offset) * GUI_GRID_H + GUI_GRID_Y)];                                                                                                             
+        _control = _display displayCtrl 101;
+        _control ctrlSetPosition [1 * GUI_GRID_W + GUI_GRID_X, (14.2 - _offset) * GUI_GRID_H + GUI_GRID_Y];
         _control ctrlCommit _upperPartTime;
-        
-        if (getNumber (missionConfigFile >> "replaceAbortButton") > 0) then {
+
+        if (!isMultiplayer && {getNumber (missionConfigFile >> "replaceAbortButton") > 0}) then {
             {
                 _x ctrlSetPosition [
                     2 * GUI_GRID_W + GUI_GRID_X,
@@ -208,7 +216,7 @@ _button ctrlAddEventHandler ["ButtonClick", {
                 _offset = _offset - 1.1;
             } forEach _buttons;
         };
-        
+
         //From bottom to top
         reverse _buttons;
 
@@ -226,7 +234,7 @@ _button ctrlAddEventHandler ["ButtonClick", {
 
         [_buttons, -1] call _fnc_showButton;
         [_fnc_showButton, _buttonsTime, _buttons] call CBA_fnc_addPerFrameHandler;
-        
+
         uiNamespace setVariable ["BIS_DisplayInterrupt_isOptionsExpanded", true];
     };
 


### PR DESCRIPTION
**When merged this pull request will:**
- title


This was missing, because the pause menu uses a different init script in MP (RscDisplayMPInterrupt).
Differences are:
- "replaceAbortButton" doesn't exist (hence `!isMultiplayer`)
- additional possible "Respawn" button to be moved

Thanks @rebelvg  for the report.
