### PR TITLE
add mouse button translations

### DIFF
--- a/addons/events/XEH_preInit.sqf
+++ b/addons/events/XEH_preInit.sqf
@@ -79,3 +79,7 @@ GVAR(keyHoldTimers) = call CBA_fnc_createNamespace;
 
     false
 }] call CBA_fnc_compileFinal;
+
+GVAR(shift) = false;
+GVAR(control) = false;
+GVAR(alt) = false;

--- a/addons/events/fnc_addKeyHandler.sqf
+++ b/addons/events/fnc_addKeyHandler.sqf
@@ -69,6 +69,12 @@ if (_type isEqualTo "keydown") then {
 };
 
 private _hash = [GVAR(keyHandlersDown), GVAR(keyHandlersUp)] select (_type == "keyup");
+
+// fix using addKeyHander twice on different keys makes old handler unremovable
+if (!isNil {_hash getVariable _hashKey}) then {
+    [_hashKey, _type] call CBA_fnc_removeKeyHandler;
+};
+
 _hash setVariable [_hashKey, [_key, _settings, _code, _allowHold, _holdDelay]];
 
 private _keyHandlers = [GVAR(keyDownStates), GVAR(keyUpStates)] select (_type == "keyup");

--- a/addons/events/fnc_keyHandlerDown.sqf
+++ b/addons/events/fnc_keyHandlerDown.sqf
@@ -15,7 +15,32 @@ params ["", "_inputKey"];
 
 if (_inputKey isEqualTo 0) exitWith {};
 
-private _inputModifiers = _this select [2,3];
+// handle modifiers
+switch (true) do {
+    case (_inputKey in [DIK_LSHIFT, DIK_RSHIFT]): {
+        GVAR(shift) = true;
+    };
+    case (_inputKey in [DIK_LCONTROL, DIK_RCONTROL]): {
+        GVAR(control) = true;
+    };
+    case (_inputKey in [DIK_LMENU, DIK_RMENU]): {
+        GVAR(alt) = true;
+    };
+};
+
+if !(_this select 2) then {
+    GVAR(shift) = false;
+};
+
+if !(_this select 3) then {
+    GVAR(control) = false;
+};
+
+if !(_this select 4) then {
+    GVAR(alt) = false;
+};
+
+private _inputModifiers = [GVAR(shift), GVAR(control), GVAR(alt)];
 
 private _blockInput = false;
 

--- a/addons/events/fnc_keyHandlerUp.sqf
+++ b/addons/events/fnc_keyHandlerUp.sqf
@@ -15,6 +15,19 @@ params ["", "_inputKey"];
 
 if (_inputKey isEqualTo 0) exitWith {};
 
+// handle modifiers
+switch (true) do {
+    case (_inputKey in [DIK_LSHIFT, DIK_RSHIFT]): {
+        GVAR(shift) = false;
+    };
+    case (_inputKey in [DIK_LCONTROL, DIK_RCONTROL]): {
+        GVAR(control) = false;
+    };
+    case (_inputKey in [DIK_LMENU, DIK_RMENU]): {
+        GVAR(alt) = false;
+    };
+};
+
 private _removeHandlers = [];
 
 {

--- a/addons/events/fnc_mouseHandlerDown.sqf
+++ b/addons/events/fnc_mouseHandlerDown.sqf
@@ -13,6 +13,4 @@ SCRIPT(mouseHandlerDown);
 
 params ["_display", "_inputButton"];
 
-private _inputModifiers = _this select [4,3];
-
-([_display, MOUSE_OFFSET + _inputButton] + _inputModifiers) call FUNC(keyHandlerDown);
+[_display, MOUSE_OFFSET + _inputButton, GVAR(shift), GVAR(control), GVAR(alt)] call FUNC(keyHandlerDown);

--- a/addons/events/fnc_mouseHandlerUp.sqf
+++ b/addons/events/fnc_mouseHandlerUp.sqf
@@ -13,6 +13,4 @@ SCRIPT(mouseHandlerUp);
 
 params ["_display", "_inputButton"];
 
-private _inputModifiers = _this select [4,3];
-
-([_display, MOUSE_OFFSET + _inputButton] + _inputModifiers) call FUNC(keyHandlerUp);
+[_display, MOUSE_OFFSET + _inputButton, GVAR(shift), GVAR(control), GVAR(alt)] call FUNC(keyHandlerUp);

--- a/addons/events/fnc_mouseWheelHandler.sqf
+++ b/addons/events/fnc_mouseWheelHandler.sqf
@@ -15,5 +15,5 @@ params ["_display", "_inputDirection"];
 
 private _inputDirection = [0, 1] select (_inputDirection < 0);
 
-[_display, MOUSE_WHEEL_OFFSET + _inputDirection, false, false, false] call FUNC(keyHandlerDown);
-[_display, MOUSE_WHEEL_OFFSET + _inputDirection, false, false, false] call FUNC(keyHandlerUp);
+[_display, MOUSE_WHEEL_OFFSET + _inputDirection, GVAR(shift), GVAR(control), GVAR(alt)] call FUNC(keyHandlerDown);
+[_display, MOUSE_WHEEL_OFFSET + _inputDirection, GVAR(shift), GVAR(control), GVAR(alt)] call FUNC(keyHandlerUp);

--- a/addons/keybinding/XEH_preStart.sqf
+++ b/addons/keybinding/XEH_preStart.sqf
@@ -172,6 +172,22 @@ _supportedKeys = _supportedKeys apply {
 
 GVAR(keyNamesHash) = [_supportedKeys] call CBA_fnc_hashCreate;
 
+// manually add mouse key localizations to our inofficial DIK codes
+{
+    [GVAR(keyNamesHash), str (_x select 0), parseSimpleArray format ["[%1]", keyName (_x select 1)] select 0] call CBA_fnc_hashSet;
+} forEach [
+    [0xF0, 0x10000],
+    [0xF1, 0x10081],
+    [0xF2, 0x10002],
+    [0xF3, 0x10003],
+    [0xF4, 0x10004],
+    [0xF5, 0x10005],
+    [0xF6, 0x10006],
+    [0xF7, 0x10007],
+    [0xF8, 0x100004],
+    [0xF9, 0x100005]
+];
+
 GVAR(forbiddenKeys) = [
     DIK_XBOX_LEFT_TRIGGER,
     DIK_XBOX_RIGHT_TRIGGER,


### PR DESCRIPTION
**When merged this pull request will:**
- assigns `keyName` translations to our "custom DIK codes" used in #651


`0x10081` is not a typo, because `0x10001` is "hold secondary mouse" for whatever reason, which doesn't exist for the other mouse buttons.
