### PR TITLE
fix strange modifier key behavior

### DIFF
--- a/addons/events/XEH_preInit.sqf
+++ b/addons/events/XEH_preInit.sqf
@@ -79,3 +79,7 @@ GVAR(keyHoldTimers) = call CBA_fnc_createNamespace;
 
     false
 }] call CBA_fnc_compileFinal;
+
+GVAR(shift) = false;
+GVAR(control) = false;
+GVAR(alt) = false;

--- a/addons/events/fnc_keyHandlerDown.sqf
+++ b/addons/events/fnc_keyHandlerDown.sqf
@@ -15,7 +15,20 @@ params ["", "_inputKey"];
 
 if (_inputKey isEqualTo 0) exitWith {};
 
-private _inputModifiers = _this select [2,3];
+// handle modifiers
+switch (true) do {
+    case (_inputKey in [DIK_LSHIFT, DIK_RSHIFT]): {
+        GVAR(shift) = true;
+    };
+    case (_inputKey in [DIK_LCONTROL, DIK_RCONTROL]): {
+        GVAR(control) = true;
+    };
+    case (_inputKey in [DIK_LMENU, DIK_RMENU]): {
+        GVAR(alt) = true;
+    };
+};
+
+private _inputModifiers = [GVAR(shift), GVAR(control), GVAR(alt)];
 
 private _blockInput = false;
 

--- a/addons/events/fnc_keyHandlerDown.sqf
+++ b/addons/events/fnc_keyHandlerDown.sqf
@@ -28,6 +28,18 @@ switch (true) do {
     };
 };
 
+if !(_this select 2) then {
+    GVAR(shift) = false;
+};
+
+if !(_this select 3) then {
+    GVAR(control) = false;
+};
+
+if !(_this select 4) then {
+    GVAR(alt) = false;
+};
+
 private _inputModifiers = [GVAR(shift), GVAR(control), GVAR(alt)];
 
 private _blockInput = false;

--- a/addons/events/fnc_keyHandlerUp.sqf
+++ b/addons/events/fnc_keyHandlerUp.sqf
@@ -15,6 +15,19 @@ params ["", "_inputKey"];
 
 if (_inputKey isEqualTo 0) exitWith {};
 
+// handle modifiers
+switch (true) do {
+    case (_inputKey in [DIK_LSHIFT, DIK_RSHIFT]): {
+        GVAR(shift) = false;
+    };
+    case (_inputKey in [DIK_LCONTROL, DIK_RCONTROL]): {
+        GVAR(control) = false;
+    };
+    case (_inputKey in [DIK_LMENU, DIK_RMENU]): {
+        GVAR(alt) = false;
+    };
+};
+
 private _removeHandlers = [];
 
 {

--- a/addons/events/fnc_mouseHandlerDown.sqf
+++ b/addons/events/fnc_mouseHandlerDown.sqf
@@ -13,6 +13,4 @@ SCRIPT(mouseHandlerDown);
 
 params ["_display", "_inputButton"];
 
-private _inputModifiers = _this select [4,3];
-
-([_display, MOUSE_OFFSET + _inputButton] + _inputModifiers) call FUNC(keyHandlerDown);
+[_display, MOUSE_OFFSET + _inputButton, GVAR(shift), GVAR(control), GVAR(alt)] call FUNC(keyHandlerDown);

--- a/addons/events/fnc_mouseHandlerUp.sqf
+++ b/addons/events/fnc_mouseHandlerUp.sqf
@@ -13,6 +13,4 @@ SCRIPT(mouseHandlerUp);
 
 params ["_display", "_inputButton"];
 
-private _inputModifiers = _this select [4,3];
-
-([_display, MOUSE_OFFSET + _inputButton] + _inputModifiers) call FUNC(keyHandlerUp);
+[_display, MOUSE_OFFSET + _inputButton, GVAR(shift), GVAR(control), GVAR(alt)] call FUNC(keyHandlerUp);

--- a/addons/events/fnc_mouseWheelHandler.sqf
+++ b/addons/events/fnc_mouseWheelHandler.sqf
@@ -15,5 +15,5 @@ params ["_display", "_inputDirection"];
 
 private _inputDirection = [0, 1] select (_inputDirection < 0);
 
-[_display, MOUSE_WHEEL_OFFSET + _inputDirection, false, false, false] call FUNC(keyHandlerDown);
-[_display, MOUSE_WHEEL_OFFSET + _inputDirection, false, false, false] call FUNC(keyHandlerUp);
+[_display, MOUSE_WHEEL_OFFSET + _inputDirection, GVAR(shift), GVAR(control), GVAR(alt)] call FUNC(keyHandlerDown);
+[_display, MOUSE_WHEEL_OFFSET + _inputDirection, GVAR(shift), GVAR(control), GVAR(alt)] call FUNC(keyHandlerUp);


### PR DESCRIPTION
**When merged this pull request will:**
- fixes #213

The shift/control/alt parameters passed by the keyDown/Up events are really crappy. When you released a key, say _shift_, the "shift" parameter will still report true for all keyDown/Up events that happen up to about half a second later, even though the keyUp event for "shift" already occurred.
With this PR we look for the modifier keys themselves and store their states in variables. This makes the behavior way more intuitive and predictable.
By doing this, this PR also adds modifier support to the mouse wheel.
