### PR TITLE
redo CBA_fnc_addKeybind to support multiple keybinds

### DIFF
--- a/addons/keybinding/XEH_preInit.sqf
+++ b/addons/keybinding/XEH_preInit.sqf
@@ -33,42 +33,16 @@ GVAR(firstKey) = [];
 GVAR(secondKey) = [];
 GVAR(thirdKey) = [];
 GVAR(waitingForInput) = false;
-GVAR(modPrettyNames) = [[],[]];
 GVAR(defaultKeybinds) = [[],[]];
-GVAR(activeMods) = [];
-GVAR(activeBinds) = [];
 
-/////////////////////////////////////////////////////////////////////////////////
+if (isNil QGVAR(activeMods)) then {
+    GVAR(activeMods) = [] call CBA_fnc_createNamespace;
+    GVAR(activeBinds) = [] call CBA_fnc_createNamespace;
+};
 
-// All keybinds are stored as an array in this format:
-// keybind = [DIKcode, shift?, ctrl?, alt?]
-//
-// example: [15, true, false, false]
-
-// The keybind registry is stored in profileNamespace as "cba_keybinding_registry."
-// Permament array that tracks all key configs registered by fnc_registerKeybindHandler.
-// Format: Associative array. Access with bis_fnc_getFromPairs.
-// [
-//   ["modName1", [
-//                  ["actionName1", [currentKeybind, defaultKeybind]],
-//                  ["actionName2", [currentKeybind, defaultKeybind]],
-//                  ["actionName3", [currentKeybind, defaultKeybind]]
-//                ],
-//   ],
-//   ["modName2", [
-//                  ["actionName1", [currentKeybind, defaultKeybind]]
-//                ],
-//   ]
-// ]
-//
-// This clears the keybind registry.
-// profileNamespace setVariable ["cba_keybinding_registry", []];
-
-// Temporary array that tracks loaded key handlers for specified keybinds.
-// Format: Array of arrays
-//      [["modName", "actionName", [keybind], {code}, ehID], ...]
-GVAR(handlers) = [[],[]];
-GVAR(handlersBackup) = [];
+if (isNil QGVAR(modPrettyNames)) then {
+    GVAR(modPrettyNames) = [] call CBA_fnc_createNamespace;
+};
 
 // Counter for indexing added key handlers.
 GVAR(ehCounter) = 512;

--- a/addons/keybinding/fnc_addKeybind.sqf
+++ b/addons/keybinding/fnc_addKeybind.sqf
@@ -2,170 +2,157 @@
 Function: CBA_fnc_addKeybind
 
 Description:
- Adds or updates the keybind handler for a specified mod action, and associates
- a function with that keybind being pressed.
+    Adds or updates the keybind handler for a specified mod action, and associates
+    a function with that keybind being pressed.
+
+    This file should be included for readable DIK codes:
+        #include "\a3\editor_f\Data\Scripts\dikCodes.h"
+
+    Additional DIK codes usable with this function:
+        0xF0: Left mouse button
+        0xF1: Right mouse button
+        0xF2: Middle mouse button
+        0xF3: Mouse #4
+        0xF4: Mouse #5
+        0xF5: Mouse #6
+        0xF6: Mouse #7
+        0xF7: Mouse #8
+        0xF8: Mouse wheel up
+        0xF9: Mouse wheel down
 
 Parameters:
- _modName            - Name of the registering mod [String]
- _actionId          - Id of the key action. [String]
- _displayName       - Pretty name, or an array of strings for the pretty name and a tool tip [String]
- _downCode          - Code for down event, empty string for no code. [Code]
- _upCode            - Code for up event, empty string for no code. [Code]
+    _addon          - Name of the registering mod <STRING>
+    _action         - Id of the key action. <STRING>
+    _title          - Pretty name, or an array of pretty name and tooltip <STRING>
+    _downCode       - Code for down event, empty string for no code. <CODE>
+    _upCode         - Code for up event, empty string for no code. <CODE>
 
- Optional:
- _defaultKeybind    - The keybinding data in the format [DIK, [shift, ctrl, alt]] [Array]
- _holdKey           - Will the key fire every frame while down [Bool]
- _holdDelay         - How long after keydown will the key event fire, in seconds. [Float]
- _overwrite         - Overwrite any previously stored default keybind [Bool]
+Optional:
+    _defaultKeybind - The keybinding data in the format [DIK, [shift, ctrl, alt]] <ARRAY>
+    _holdKey        - Will the key fire every frame while down <BOOLEAN>
+    _holdDelay      - How long after keydown will the key event fire, in seconds. <NUMBER>
+    _overwrite      - Overwrite any previously stored default keybind <BOOLEAN>
 
 Returns:
- Returns the current keybind for the action [Array]
+    Returns the current keybind for the action <ARRAY>
 
 Examples:
     (begin example)
- // Register a simple keypress to an action
- // This file should be included for readable DIK codes.
- #include "\a3\editor_f\Data\Scripts\dikCodes.h"
+        // Register a simple keypress to an action
+        #include "\a3\editor_f\Data\Scripts\dikCodes.h"
 
- ["MyMod", "MyKey", ["My Pretty Key Name", "My Pretty Tool Tip"], { _this call mymod_fnc_keyDown }, { _this call mymod_fnc_keyUp }, [DIK_TAB, [false, false, false]]] call cba_fnc_addKeybind;
-    (end example)
-    (begin example)
- ["MyMod", "MyOtherKey", "My Other Pretty Key Name", { _this call mymod_fnc_keyDownOther }, { _this call mymod_fnc_keyUpOther }, [DIK_K, [false, false, false]]] call cba_fnc_addKeybind;
+        ["MyMod", "MyKey", ["My Pretty Key Name", "My Pretty Tool Tip"], {
+            _this call mymod_fnc_keyDown
+        }, {
+            _this call mymod_fnc_keyUp
+        }, [DIK_TAB, [false, false, false]]] call CBA_fnc_addKeybind;
+
+        ["MyMod", "MyOtherKey", "My Other Pretty Key Name", {
+            _this call mymod_fnc_keyDownOther
+        }, {
+            _this call mymod_fnc_keyUpOther
+        }, [DIK_K, [false, false, false]]] call CBA_fnc_addKeybind;
     (end example)
 
 Author:
- Taosenai & Nou
+    Taosenai & Nou, commy2
 ---------------------------------------------------------------------------- */
-//TODD: Implement the holdkey features - Nou
-//#define DEBUG_MODE_FULL
-#include "\x\cba\addons\keybinding\script_component.hpp"
+#include "script_component.hpp"
 
-// Clients only.
+// clients only.
 if (!hasInterface) exitWith {};
 
-_nullKeybind = [-1, [false,false,false]];
-
-params [
-    ["_modName", "", [""]],
-    ["_actionId", "", [""]],
-    ["_displayName", "", ["", []]],
-    "_downCode",
-    "_upCode",
-    ["_defaultKeybind", _nullKeybind],
-    ["_holdKey", true],
-    ["_holdDelay", 0],
-    ["_overwrite", false]
-];
-
-_displayName params [["_name", "", [""]], ["_tooltip", "", [""]]];
-
-if (_tooltip isEqualTo "") then {
-    _displayName = _name;
-} else {
-    _displayName = [_name, _tooltip];
+// prevent race conditions. function could be called from scheduled env.
+if (canSuspend) exitWith {
+    [CBA_fnc_addKeybind, _this] call CBA_fnc_directCall;
 };
 
-if (count _defaultKeybind == 4) then {
-    WARNING_2("%1: %2 - Wrong format for the default keybind parameter. Use [DIK, [shift, ctrl, alt]]",_modName,_actionId);
-    _modifiers=[_defaultKeybind select 1, _defaultKeybind select 2, _defaultKeybind select 3];
-    _defaultKeybind = [_defaultKeybind select 0, _modifiers];
+params [
+    ["_addon", "", [""]],
+    ["_action", "", [""]],
+    ["_title", "", ["", []]],
+    ["_downCode", {}, [{}]],
+    ["_upCode", {}, [{}]],
+    ["_defaultKeybind", KEYBIND_NULL, [KEYBIND_NULL]],
+    ["_holdKey", true, [false]],
+    ["_holdDelay", 0, [0]],
+    ["_overwrite", false, [false]]
+];
+
+_title params [["_displayName", _action, [""]], ["_tooltip", "", [""]]];
+_action = toLower _action;
+
+// support old format
+if (_defaultKeybind isEqualTypeParams [0, false, false, false]) then {
+    _defaultKeybind params ["_defaultKey", "_defaultShift", "_defaultControl", "_defaultAlt"];
+    _defaultKeybind = [_defaultKey, [_defaultShift, _defaultControl, _defaultAlt]];
 };
 
 // Make sure modifer is set to true, if base key is a modifier
-// This can happen with script added keybinds AND from the rebinding code (fnc_onLBDblClick)
-_defaultKeybind params ["_keyNumber", "_keyParams"];
-if (_keyNumber in [DIK_LSHIFT, DIK_RSHIFT]) then {TRACE_1("setting shift", _keyParams); _keyParams set [0, true];};
-if (_keyNumber in [DIK_LCONTROL, DIK_RCONTROL]) then {TRACE_1("setting ctrl", _keyParams); _keyParams set [1, true];};
-if (_keyNumber in [DIK_LMENU, DIK_RMENU]) then {TRACE_1("setting alt", _keyParams); _keyParams set [2, true];};
+_defaultKeybind params [["_defaultKey", 0, [0]], ["_defaultModifiers", [], [[]]]];
+_defaultModifiers params [["_defaultShift", false, [false]], ["_defaultControl", false, [false]], ["_defaultAlt", false, [false]]];
 
-_keybind = nil;
-
-// Get a local copy of the keybind registry.
-_registry = profileNamespace getVariable [QGVAR(registryNew), nil];
-if(isNil "_registry") then {
-    _registry = [[],[]];
-    profileNamespace setVariable [QGVAR(registryNew), _registry];
-};
-if(!(_modName in GVAR(activeMods))) then {
-    GVAR(activeMods) pushBack _modName;
+if (_defaultKey in [DIK_LSHIFT, DIK_RSHIFT]) then {
+    _defaultShift = true;
 };
 
-TRACE_1("",_registry);
-
-GVAR(activeBinds) pushBack (_modName + "_" + _actionId);
-_modId = (_registry select 0) find _modName;
-TRACE_2("",_modId,_modName);
-
-if(_modId == -1) then {
-    (_registry select 0) pushBack _modName;
-    _modId = (_registry select 1) pushBack [[],[]];
+if (_defaultKey in [DIK_LCONTROL, DIK_RCONTROL]) then {
+    _defaultControl = true;
 };
 
-_modRegistry = (_registry select 1) select _modId;
-
-_actionEntryId = (_modRegistry select 0) find _actionId;
-TRACE_3("",_actionEntryId,_actionId, _modRegistry);
-
-if(_actionEntryId == -1) then {
-    (_modRegistry select 0) pushBack _actionId;
-    _actionEntryId = (_modRegistry select 1) pushBack [_displayName, _defaultKeybind];
+if (_defaultKey in [DIK_LMENU, DIK_RMENU]) then {
+    _defaultAlt = true;
 };
-_actionEntry = (_modRegistry select 1) select _actionEntryId;
-_actionEntry set[0, _displayName];
 
-_hashDown = format["%1_%2_down", _modName, _actionId];
-_hashUp = format["%1_%2_up", _modName, _actionId];
+private _keybind = [_defaultKey, [_defaultShift, _defaultControl, _defaultAlt]];
 
-TRACE_3("",_defaultKeybind,_actionEntryId,_hashDown);
-TRACE_2("",_actionEntry,_hashUp);
+// get a local copy of the keybind registry
+private _registry = profileNamespace getVariable QGVAR(registry_v3);
 
-_entryIndex = (GVAR(defaultKeybinds) select 0) find _hashDown;
-if(_entryIndex == -1) then {
-    _entryIndex = (GVAR(defaultKeybinds) select 0) pushBack _hashDown;
-    (GVAR(defaultKeybinds) select 1) set[_entryIndex, []];
+if (isNil "_registry") then {
+    _registry = HASH_NULL;
+    profileNamespace setVariable [QGVAR(registry_v3), _registry];
 };
-_defaultEntry = (GVAR(defaultKeybinds) select 1) select _entryIndex;
 
-TRACE_1("",_defaultEntry);
+private _registryKeybinds = [_registry, _action] call CBA_fnc_hashGet;
 
-if(_overwrite) then {
-    if(IS_CODE(_downCode)) then {
-        [_hashDown, "keydown"] call cba_fnc_removeKeyHandler;
+// action doesn't exist in registry yet, create it and store default keybinding
+if (isNil "_registryKeybinds" || {_overwrite}) then {
+    _registryKeybinds = [_keybind];
+    [_registry, _action, _registryKeybinds] call CBA_fnc_hashSet;
+};
+
+// make list of active mods and keybinds for gui
+if (isNil QGVAR(activeMods)) then {
+    GVAR(activeMods) = [] call CBA_fnc_createNamespace;
+    GVAR(activeBinds) = [] call CBA_fnc_createNamespace;
+};
+
+private _addonInfo = GVAR(activeMods) getVariable _addon;
+
+if (isNil "_addonInfo") then {
+    _addonInfo = [_addon, []];
+    GVAR(activeMods) setVariable [_addon, _addonInfo];
+};
+
+(_addonInfo select 1) pushBackUnique toLower _action;
+
+GVAR(activeBinds) setVariable [_addon + "$" + _action, [_displayName, _tooltip, _registryKeybinds, _defaultKeybind]];
+
+// add this action to all keybinds
+{
+    _keybind = _x;
+
+    if !(_downCode isEqualTo {}) then {
+        [_keybind select 0, _keybind select 1, _downCode, "keyDown", format ["%1$%2$down", _addon, _action], _holdKey, _holdDelay] call CBA_fnc_addKeyHandler;
     };
 
-    if(IS_CODE(_upCode)) then {
-        [_hashUp, "keyup"] call cba_fnc_removeKeyHandler;
+    if !(_upCode isEqualTo {}) then {
+        [_keybind select 0, _keybind select 1, _upCode, "keyUp", format ["%1$%2$up", _addon, _action]] call CBA_fnc_addKeyHandler;
     };
-    _actionEntry set[1, _defaultKeybind];
-};
-if(!_overwrite) then {
-    _actionEntry set[2, _defaultKeybind];
-    _defaultKeybind = _actionEntry select 1;
-};
-
-_defaultEntry set[0, _downCode];
-_defaultEntry set[1, _upCode];
-_defaultEntry set[2, _holdKey];
-_defaultEntry set[3, _holdDelay];
-
-
-
-if(_defaultKeybind select 0 != -1) then {
-    if(IS_CODE(_downCode)) then {
-        [_defaultKeybind select 0, _defaultKeybind select 1, _downCode, "keyDown", _hashDown, _holdKey, _holdDelay] call cba_fnc_addKeyHandler;
-    };
-
-    if(IS_CODE(_upCode)) then {
-        [_defaultKeybind select 0, _defaultKeybind select 1, _upCode, "keyUp", _hashUp] call cba_fnc_addKeyHandler;
-    };
-};
-
-_keybind = +(_actionEntry select 1); // return a copy
-TRACE_1("",_keybind);
-
-GVAR(handlers) = _registry;
+} forEach _registryKeybinds;
 
 // Emit an event that a key has been registered.
-["cba_keybinding_registerKeybind", _this] call cba_fnc_localEvent;
+[QGVAR(registerKeybind), _this] call CBA_fnc_localEvent;
 
-_keybind;
+_keybind // only return the last keybind for bwc

--- a/addons/keybinding/fnc_registerKeybindModPrettyName.sqf
+++ b/addons/keybinding/fnc_registerKeybindModPrettyName.sqf
@@ -2,32 +2,30 @@
 Function: CBA_fnc_registerKeybindModPrettyName
 
 Description:
- Associates a pretty name to a keybinding mod entry.
+    Associates a pretty name to a keybinding mod entry.
 
 Parameters:
- _modName            - Name of the registering mod [String]
- _prettyName        - Pretty name of the mod (localized, etc) [String]
+    _addonName  - Name of the registering mod [String]
+    _prettyName - Pretty name of the mod (localized, etc) [String]
 
 Returns:
 
 Examples:
     (begin example)
- ["mymod", "My Cool Mod!"] call CBA_fnc_registerKeybindModPrettyName;
+        ["mymod", "My Cool Mod!"] call CBA_fnc_registerKeybindModPrettyName;
     (end example)
 
 Author:
- Nou
+    Nou
 ---------------------------------------------------------------------------- */
 #include "script_component.hpp"
-params ["_mod","_prettyName"];
 
-private ["_modIndex"];
+params ["_addonName", "_prettyName"];
 
-_modIndex = (GVAR(modPrettyNames) select 0) find _mod;
-if(_modIndex == -1) then {
-    _modIndex = (GVAR(modPrettyNames) select 0) pushBack _mod;
+if (isNil QGVAR(modPrettyNames)) then {
+    GVAR(modPrettyNames) = [] call CBA_fnc_createNamespace;
 };
 
-(GVAR(modPrettyNames) select 1) set[_modIndex, _prettyName];
+GVAR(modPrettyNames) setVariable [_addonName, _prettyName];
 
 true

--- a/addons/keybinding/gui/fnc_updateGUI.sqf
+++ b/addons/keybinding/gui/fnc_updateGUI.sqf
@@ -17,34 +17,25 @@ if !(isNull _display) then {
 
     // First run only actions.
     if (_firstRun) then {
-        // Clear the combobox.
         lbClear _combo;
 
-        if (count GVAR(activeMods) > 0) then {
-            // Populate the combolistbox.
-            {
-                private ["_nameIndex", "_modPrettyName", "_entry"];
-                if(_x in GVAR(activeMods)) then {
-                    _nameIndex = (GVAR(modPrettyNames) select 0) find _x;
-                    _modPrettyName = _x;
-                    if(_nameIndex != -1) then {
-                        _modPrettyName = (GVAR(modPrettyNames) select 1) select _nameIndex;
-                    };
-                    _entry = _combo lbAdd _modPrettyName;
-                    _combo lbSetData [_entry, _x];
-                };
-            } foreach (GVAR(handlers) select 0);
-        };
+        {
+            private _addonInfo = GVAR(activeMods) getVariable _x;
+            private _addonName = GVAR(modPrettyNames) getVariable [_x, _addonInfo select 0];
 
+            _combo lbSetData [_combo lbAdd _addonName, _x];
+        } forEach allVariables GVAR(activeMods);
+
+        lbSort _combo;
         _combo lbSetCurSel 0;
     };
 
     // Fill the listnbox with actions.
-    if (count GVAR(activeMods) > 0) then {
+    if (count allVariables GVAR(activeMods) > 0) then {
         // Get the selected mod.
         _modName = _combo lbData (lbCurSel _combo);
         // Get the actions associated with the current mod.
-        _modActions = (GVAR(handlers) select 1) select ((GVAR(handlers) select 0) find _modName);
+        _modActions = GVAR(activeMods) getVariable _modName select 1;
 
         // Clear the listbox.
         lnbClear _lnb;
@@ -52,16 +43,14 @@ if !(isNull _display) then {
         // Add the actions to the listbox and associate their data.
         // of keybinds due to keyup/keydown.
         {
-            private ["_actionId", "_action", "_actionName", "_isDuplicated", "_dupeActionName", "_lbCount", "_indexArray"];
+            private ["_actionId", "_action", "_keybind", "_isDuplicated", "_dupeActionName", "_lbCount", "_indexArray"];
             _actionId = _x;
-            if((format ["%1_%2", _modName, _actionId]) in GVAR(activeBinds)) then {
-                _action = (_modActions select 1) select _forEachIndex;
-                _action params ["_actionName", "_keybind"];
+            if((toLower format ["%1$%2", _modName, _actionId]) in allVariables GVAR(activeBinds)) then {
+                _action = GVAR(activeBinds) getVariable format ["%1$%2", _modName, _actionId];
+                _action params ["_displayName", "_tooltip", "_registryKeybinds"];
+                _keybind = _registryKeybinds select 0;
 
-                _actionName params ["_prettyName", ["_toolTip", ""]];
-                _actionName = _prettyName;
-
-                TRACE_4("",_modName,_action,_actionName,_keybind);
+                TRACE_4("",_modName,_action,_displayName,_keybind);
                 if(IS_ARRAY(_keybind) && {IS_ARRAY(_keybind select 1)}) then {
                     _keybind params ["_key", "_modifier"];
                     _modifier params ["_shift", "_ctrl", "_alt"];
@@ -97,17 +86,14 @@ if !(isNull _display) then {
                     if (_key > 0) then {
                         _dupeActionName = "";
                         {
-                            private ["_sActionId", "_dupeAction"];
-                            _sActionId = _x;
-                            _dupeAction = (_modActions select 1) select _forEachIndex;
-                            _dupeAction params ["_sActionName", "_sKeybind"];
-                            if((format ["%1_%2", _modName, _sActionId]) in GVAR(activeBinds)) then {
-                                if (_sActionId != _actionId && _sKeybind isEqualTo _keybind) exitWith {
-                                    _isDuplicated = true;
-                                    _dupeActionName = _sActionName param [0];
-                                };
+                            private _dupeActionId = _x;
+                            private _dupeKeybinds = GVAR(activeBinds) getVariable format ["%1$%2", _modName, _dupeActionId] select 2;
+
+                            if (_keybind in _dupeKeybinds && {_actionId != _dupeActionId}) exitWith {
+                                _isDuplicated = true;
+                                _dupeActionName = GVAR(activeBinds) getVariable format ["%1$%2", _modName, _dupeActionId] select 0;
                             };
-                        } foreach (_modActions select 0);
+                        } forEach _modActions;
 
                         if (_isDuplicated) then {
                             // Add the name of the action that dupes the keybinding to the
@@ -120,7 +106,7 @@ if !(isNull _display) then {
                     };
 
                     // Add the row.
-                    _lbCount = _lnb lnbAddRow [_actionName, _keyName];
+                    _lbCount = _lnb lnbAddRow [_displayName, _keyName];
                     _lnb lbSetTooltip [2*_lbCount, _toolTip];
                     _lnb lbSetTooltip [2*_lbCount + 1, _toolTip];
 
@@ -140,6 +126,6 @@ if !(isNull _display) then {
                     };
                 };
             };
-        } foreach (_modActions select 0);
+        } foreach _modActions;
     };
 };

--- a/addons/keybinding/script_component.hpp
+++ b/addons/keybinding/script_component.hpp
@@ -43,3 +43,7 @@
 #define DIK_XBOX_LEFT_THUMB_Y_DOWN 327701
 #define DIK_XBOX_RIGHT_THUMB_X_LEFT 327702
 #define DIK_XBOX_RIGHT_THUMB_Y_DOWN 327703
+
+#define NAMESPACE_NULL objNull
+#define HASH_NULL ([] call CBA_fnc_hashCreate)
+#define KEYBIND_NULL [0, [false, false, false]]


### PR DESCRIPTION
**When merged this pull request will:**
- use a new profile registry which can have infinite binds for each key action instead of just one.
- fixes some race conditions when `CBA_fnc_addKeybind` is used in preInit before keybinding's preInit.
- use "$" to glue strings instead of "_" to avoid `MyMod_super` with `keybind` to collide with `MyMod` `super_keybind`.

todo:
- fix:
```
15:44:41 Error in expression <ns = (cba_keybinding_handlers select 1) select ((cba_keybinding_handlers select >
15:44:41   Error position: <select ((cba_keybinding_handlers select >
15:44:41   Error Zero divisor
15:44:41 File x\cba\addons\keybinding\gui\fnc_updateGUI.sqf, line 47
```