### PR TITLE
fix a script error

### DIFF
--- a/addons/events/fnc_keyHandlerDown.sqf
+++ b/addons/events/fnc_keyHandlerDown.sqf
@@ -74,7 +74,7 @@ private _blockInput = false;
             _params pushBack + _keybindParams;
             _params pushBack _x;
 
-            _blockInput = [_params call _code] param [0, false] || {_blockInput};
+            _blockInput = ([_params call _code] param [0, false] isEqualTo true) || {_blockInput};
         };
     };
 } forEach (GVAR(keyDownStates) param [_inputKey, []]);


### PR DESCRIPTION
**When merged this pull request will:**
- fixes:
```
 5:09:44   Error ||: Type Display (dialog), expected Bool
 5:09:44 File x\cba\addons\events\fnc_keyHandlerDown.sqf, line 69
 5:09:44 Error in expression <= [_params call _code] param [0, false] || {_blockInput};
```
Retrun value could be anything and not bool would error.

```sqf
[_params call _code] param [0, false] isEqualTo true
```
is essentially:
```sqf
private _temp = _params call _code;
!isNil "_temp" && {_temp isEqualTo true}
```
but a bit faster.