### PR TITLE
abort init events during savegame load

### DIFF
--- a/addons/xeh/fnc_init.sqf
+++ b/addons/xeh/fnc_init.sqf
@@ -19,9 +19,15 @@ Examples:
 Author:
     commy2
 ---------------------------------------------------------------------------- */
+#define DEBUG_SYNCHRONOUS
 #include "script_component.hpp"
 
 params ["_this"];
+
+// fix for https://github.com/CBATeam/CBA_A3/issues/661
+if (scriptDone GVAR(LoadingCheck)) exitWith {
+    INFO_1("Abort init event during savegame load. Class: %1.",typeOf _this);
+};
 
 if !(ISINITIALIZED(_this)) then {
     SETINITIALIZED(_this);

--- a/addons/xeh/fnc_preInit.sqf
+++ b/addons/xeh/fnc_preInit.sqf
@@ -127,6 +127,17 @@ GVAR(initPostStack) = [];
     diag_log text format ["isScheduled = %1", call CBA_fnc_isScheduled];
 #endif
 
+// fix for https://github.com/CBATeam/CBA_A3/issues/661
+private _fnc_setUpLoadingCheck = {
+    GVAR(LoadingCheck) = 0 spawn {
+        disableSerialization;
+        sleep 1E9;
+    };
+};
+
+call _fnc_setUpLoadingCheck;
+addMissionEventHandler ["Loaded", _fnc_setUpLoadingCheck];
+
 SLX_XEH_MACHINE set [7, true]; // PreInit passed
 
 XEH_LOG("XEH: PreInit finished.");


### PR DESCRIPTION
**When merged this pull request will:**
- fix #661

These seem to only happen for map objects that are created during the loading of a savegame. We don't want XEH for these objects anyway, so aborting is good enough.

```sqf
GVAR(LoadingCheck) = 0 spawn {
    disableSerialization;
    sleep 1E9;
};
```
is the best way I know of to detect this state.