### PR TITLE
add CBA_fnc_isTerrainObject, abort init for terrain objects

### DIFF
--- a/addons/common/CfgFunctions.hpp
+++ b/addons/common/CfgFunctions.hpp
@@ -91,6 +91,7 @@ class CfgFunctions {
             PATHTO_FNC(mapRelPos);
             PATHTO_FNC(mapDirTo);
             PATHTO_FNC(getTerrainProfile);
+            PATHTO_FNC(isTerrainObject);
         };
 
         class Positions {

--- a/addons/common/fnc_isTerrainObject.sqf
+++ b/addons/common/fnc_isTerrainObject.sqf
@@ -1,0 +1,26 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_isTerrainObject
+
+Description:
+    Check if object is a terrain object.
+
+Parameters:
+    _object - any object <OBJECT>
+
+Returns:
+    true for terrain objects, false otherwise <BOOLEAN>
+
+Examples:
+    (begin example)
+        cursorObject call CBA_fnc_isTerrainObject
+    (end)
+
+Author:
+    commy2
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+SCRIPT(isTerrainObject);
+
+params [["_object", objNull, [objNull]]];
+
+_object in nearestTerrainObjects [_object, [], 1, false, true] // return

--- a/addons/xeh/fnc_init.sqf
+++ b/addons/xeh/fnc_init.sqf
@@ -19,9 +19,14 @@ Examples:
 Author:
     commy2
 ---------------------------------------------------------------------------- */
+#define DEBUG_SYNCHRONOUS
 #include "script_component.hpp"
 
 params ["_this"];
+
+if (_this call CBA_fnc_isTerrainObject) exitWith {
+    INFO_2("Abort init event for terrain object %1. Class: %2.",_this,typeOf _this);
+};
 
 if !(ISINITIALIZED(_this)) then {
     SETINITIALIZED(_this);


### PR DESCRIPTION
**When merged this pull request will:**
- adds `CBA_fnc_isTerrainObject`
- fixes #661 by aborting init for terrain objects

Different from #662 in that it does not need a weird endless script running with disabled serialization to test for the loading phase.