### PR TITLE
fix assignment operator return value bug for directCall

### DIFF
--- a/addons/common/fnc_directCall.sqf
+++ b/addons/common/fnc_directCall.sqf
@@ -22,12 +22,12 @@ Author:
 ---------------------------------------------------------------------------- */
 #include "script_component.hpp"
 
-params [["_CBA_code", {}, [{}]], ["_CBA_arguments", []]];
+params [["_CBA_code", {}, [{}]], ["_this", []]];
 
 private "_CBA_return";
 
 isNil {
-    _CBA_return = _CBA_arguments call _CBA_code;
+    _CBA_return = [_x] apply _CBA_code select 0;
 };
 
 if (!isNil "_CBA_return") then {_CBA_return};


### PR DESCRIPTION
**When merged this pull request will:**
- title

before PR:
```sqf
_a = {_b = 1} call CBA_fnc_directCall; // generic error
isNil "_a"
```

after PR:
```sqf
_a = {_b = 1} call CBA_fnc_directCall;
isNil "_a"
-> true
```