### PR TITLE
Use correct file when loading settings from userconfig

### DIFF
--- a/addons/settings/fnc_initDisplayMain.sqf
+++ b/addons/settings/fnc_initDisplayMain.sqf
@@ -21,15 +21,15 @@ if (_file != "") then {
 
     if (!isNull _display) then {
         private _control = _display ctrlCreate ["RscHTML", -1];
-        _control htmlLoad USERCONFIG_SETTINGS_FILE;
+        _control htmlLoad _file;
         _fileExists = ctrlHTMLLoaded _control;
         ctrlDelete _control;
     } else {
-        _fileExists = loadFile USERCONFIG_SETTINGS_FILE != "";
+        _fileExists = loadFile _file != "";
     };
 
     if (_fileExists) then {
-        _userconfig = preprocessFile USERCONFIG_SETTINGS_FILE;
+        _userconfig = preprocessFile _file;
     };
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Title
- Server-side userconfig was always used due to direct macro usage instead of the actual file found above.