### PR TITLE
make taskPatrol accept Pos2D again

### DIFF
--- a/addons/ai/fnc_taskPatrol.sqf
+++ b/addons/ai/fnc_taskPatrol.sqf
@@ -36,10 +36,10 @@ Author:
 #include "script_component.hpp"
 
 params [
-    ["_group",grpNull,[grpNull,objNull]],
-    ["_position",[],[[],objNull,grpNull,locationNull],3],
-    ["_radius",100,[0]],
-    ["_count",3,[0]]
+    ["_group", grpNull, [grpNull, objNull]],
+    ["_position", [], [[], objNull, grpNull, locationNull], [2, 3]],
+    ["_radius", 100, [0]],
+    ["_count", 3, [0]]
 ];
 
 _group = _group call CBA_fnc_getGroup;


### PR DESCRIPTION
**When merged this pull request will:**
- title
- should fix: https://forums.bistudio.com/forums/topic/168277-cba-community-base-addons-arma-3/?page=42#comment-3185643 in a mission called "Battlezone"

The function accepted Pos2D at some point, but it was restricted to 3D in this PR: https://github.com/CBATeam/CBA_A3/pull/572/files

Pos2D works fine, because the alternate syntax `getPos` in taskPatrol accepts Pos2D (and ignores z anyway in Pos3D).

Test:
```sqf
[this, getPosASL leader this select [0, 2], 50] call CBA_fnc_taskPatrol;
```

- works fine after this PR
- master:
```
 8:52:07 Error in expression <
... (edited out whitespace)
params [
["_group",grpNull,[grpNull,objN>
 8:52:07   Error position: <params [
["_group",grpNull,[grpNull,objN>
 8:52:07   Error 2 elements provided, 3 expected
 8:52:07 File \x\cba\addons\ai\fnc_taskPatrol.sqf [CBA_fnc_taskPatrol], line 1752
```

I have no idea why the line number is so wrong in the error.