### PR TITLE
CBA_statemachine_fnc_createFromConfig - fix default value

### DIFF
--- a/addons/statemachine/fnc_createFromConfig.sqf
+++ b/addons/statemachine/fnc_createFromConfig.sqf
@@ -22,7 +22,7 @@ Author:
 ---------------------------------------------------------------------------- */
 #include "script_component.hpp"
 SCRIPT(createFromConfig);
-params [["_config", [], [configNull]]];
+params [["_config", configNull, [configNull]]];
 
 if (isNull _config) exitWith {};
 


### PR DESCRIPTION
fixing a simple typo I've recognized