### PR TITLE
Minor statemachine performance improvments

### DIFF
--- a/addons/statemachine/fnc_addState.sqf
+++ b/addons/statemachine/fnc_addState.sqf
@@ -62,6 +62,7 @@ _stateMachine setVariable [EVENTTRANSITIONS(_name), []];
 // First state added is always the intial state
 if (isNil {_stateMachine getVariable QGVAR(initialState)}) then {
     _stateMachine setVariable [QGVAR(initialState), _name];
+    GVAR(stateMachines) pushBack _stateMachine; // add it to the list now that it has an initial state
 };
 
 _name

--- a/addons/statemachine/fnc_clockwork.sqf
+++ b/addons/statemachine/fnc_clockwork.sqf
@@ -22,80 +22,76 @@ SCRIPT(clockwork);
     private _skipNull = _stateMachine getVariable QGVAR(skipNull);
     private _updateCode = _stateMachine getVariable QGVAR(updateCode);
     private _id = _stateMachine getVariable QGVAR(ID);
+    private _tick = _stateMachine getVariable QGVAR(tick);
 
-    // Skip state machine when it has no states yet
-    if !(isNil {_stateMachine getVariable QGVAR(initialState)}) then {
-        private _tick = _stateMachine getVariable QGVAR(tick);
-
-        // Skip to next non-null element or end of list
-        if (_skipNull) then {
-            while {(_tick < count _list) && {isNull (_list select _tick)}} do {
-                _tick = _tick + 1;
-            };
+    // Skip to next non-null element or end of list
+    if (_skipNull) then {
+        while {(_tick < count _list) && {isNull (_list select _tick)}} do {
+            _tick = _tick + 1;
         };
+    };
 
-        // When the list was iterated through, jump back to start and update it
-        if (_tick >= count _list) then {
-            _tick = 0;
-            if !(_updateCode isEqualTo {}) then {
-                _list = [] call _updateCode;
+    // When the list was iterated through, jump back to start and update it
+    if (_tick >= count _list) then {
+        _tick = 0;
+        if !(_updateCode isEqualTo {}) then {
+            _list = [] call _updateCode;
 
-                // Make sure list contains no null elements in case the code doesn't filter them
-                // Else they wouldn't be skipped at this point which could cause errors
-                if (_skipNull) then {
-                    _list = _list select {!isNull _x};
-                };
-
-                _stateMachine setVariable [QGVAR(list), _list];
-            };
-        };
-
-        // If the list has no items, we can stop checking this state machine
-        // No need to set the tick when it will get reset next frame anyways
-        if !(_list isEqualTo []) then {
-            _stateMachine setVariable [QGVAR(tick), _tick + 1];
-
-            private _current = _list select _tick;
-            private _thisState = _current getVariable (QGVAR(state) + str _id);
-
-            if (isNil "_thisState") then {
-                // Item is new and gets set to the intial state, onStateEntered
-                // function of initial state gets executed as well.
-                _thisState = _stateMachine getVariable QGVAR(initialState);
-                _current setVariable [QGVAR(state) + str _id, _thisState];
-                _current call (_stateMachine getVariable ONSTATEENTERED(_thisState));
+            // Make sure list contains no null elements in case the code doesn't filter them
+            // Else they wouldn't be skipped at this point which could cause errors
+            if (_skipNull) then {
+                _list = _list select {!isNull _x};
             };
 
-            // onState functions can use:
-            //   _stateMachine - the state machine
-            //   _this         - the current list item
-            //   _thisState    - the current state
-            _current call (_stateMachine getVariable ONSTATE(_thisState));
-
-            private _thisOrigin = _thisState;
-            {
-                _x params ["_thisTransition", "_condition", "_thisTarget", "_onTransition"];
-                // Transition conditions, onTransition, onStateLeaving and
-                // onStateEntered functions can use:
-                //   _stateMachine   - the state machine
-                //   _this           - the current list item
-                //   _thisTransition - the current transition we're in
-                //   _thisOrigin     - the state we're coming from
-                //   _thisState      - same as _thisOrigin
-                //   _thisTarget     - the state we're transitioning to
-                // Note: onTransition and onStateLeaving functions can change
-                //       the transition target by overwriting the passed
-                //       _thisTarget variable.
-                // Note: onStateEntered functions of initial states won't have
-                //       some of these variables defined.
-                if (_current call _condition) exitWith {
-                    _current call (_stateMachine getVariable ONSTATELEAVING(_thisOrigin));
-                    _current call _onTransition;
-                    _current setVariable [QGVAR(state) + str _id, _thisTarget];
-                    _current call (_stateMachine getVariable ONSTATEENTERED(_thisTarget));
-                };
-            } forEach (_stateMachine getVariable TRANSITIONS(_thisState));
+            _stateMachine setVariable [QGVAR(list), _list];
         };
+    };
+
+    // If the list has no items, we can stop checking this state machine
+    // No need to set the tick when it will get reset next frame anyways
+    if !(_list isEqualTo []) then {
+        _stateMachine setVariable [QGVAR(tick), _tick + 1];
+
+        private _current = _list select _tick;
+        private _thisState = _current getVariable (QGVAR(state) + str _id);
+
+        if (isNil "_thisState") then {
+            // Item is new and gets set to the intial state, onStateEntered
+            // function of initial state gets executed as well.
+            _thisState = _stateMachine getVariable QGVAR(initialState);
+            _current setVariable [QGVAR(state) + str _id, _thisState];
+            _current call (_stateMachine getVariable ONSTATEENTERED(_thisState));
+        };
+
+        // onState functions can use:
+        //   _stateMachine - the state machine
+        //   _this         - the current list item
+        //   _thisState    - the current state
+        _current call (_stateMachine getVariable ONSTATE(_thisState));
+
+        private _thisOrigin = _thisState;
+        {
+            _x params ["_thisTransition", "_condition", "_thisTarget", "_onTransition"];
+            // Transition conditions, onTransition, onStateLeaving and
+            // onStateEntered functions can use:
+            //   _stateMachine   - the state machine
+            //   _this           - the current list item
+            //   _thisTransition - the current transition we're in
+            //   _thisOrigin     - the state we're coming from
+            //   _thisState      - same as _thisOrigin
+            //   _thisTarget     - the state we're transitioning to
+            // Note: onTransition and onStateLeaving functions can change
+            //       the transition target by overwriting the passed
+            //       _thisTarget variable.
+            // Note: onStateEntered functions of initial states won't have
+            //       some of these variables defined.
+            if (_current call _condition) exitWith {
+                _current call (_stateMachine getVariable ONSTATELEAVING(_thisOrigin));
+                _current call _onTransition;
+                _current setVariable [QGVAR(state) + str _id, _thisTarget];
+                _current call (_stateMachine getVariable ONSTATEENTERED(_thisTarget));
+            };
+        } forEach (_stateMachine getVariable TRANSITIONS(_thisState));
     };
 
     false

--- a/addons/statemachine/fnc_create.sqf
+++ b/addons/statemachine/fnc_create.sqf
@@ -55,10 +55,9 @@ _stateMachine setVariable [QGVAR(skipNull), _skipNull];     // Skip items that a
 _stateMachine setVariable [QGVAR(updateCode), _updateCode]; // List update code
 _stateMachine setVariable [QGVAR(ID), GVAR(nextUniqueID)];  // Unique state machine ID
 INC(GVAR(nextUniqueID));
-GVAR(stateMachines) pushBack _stateMachine;
 
-if (isNil QGVAR(pfh)) then {
-    GVAR(pfh) = [FUNC(clockwork), 0, []] call CBA_fnc_addPerFrameHandler;
+if (isNil QGVAR(efID)) then {
+    GVAR(efID) = addMissionEventHandler ["EachFrame", {call FUNC(clockwork)}];
 };
 
 _stateMachine


### PR DESCRIPTION
Tag @BaerMitUmlaut

Diff is a mess because of the removal of an if statement, this just does 2 minor things
- Use `addMissionEventHandler ["EachFrame"` which has slightly less overhead over a PFEH
- Add the statemachine to `GVAR(stateMachines)` when adding an initial state, which lets us drop an if statement in clockwork.