### PR TITLE
Always re-run preInit on mission load/new

### DIFF
--- a/addons/xeh/fnc_initDisplay3DEN.sqf
+++ b/addons/xeh/fnc_initDisplay3DEN.sqf
@@ -1,12 +1,13 @@
 #include "script_component.hpp"
 
-// fix for preInit = 1 functions not being executed when entering 3den from main menu
-[] call CBA_fnc_preInit;
+params ["_display"];
 
-// since 1.60, preInit = 1 functions aren't executed when returning from a preview either ...
-add3DENEventHandler ["OnMissionPreviewEnd", {[] call CBA_fnc_preInit}];
+private _fnc_watchDog = {
+    if (!ISPROCESSED(missionNamespace)) then {
+        diag_log text format ["XEH: missionNamespace processed [%1]", ISPROCESSED(missionNamespace)];
+        [] call CBA_fnc_preInit;
+    };
+};
 
-// switching terrains in 3den will reset missionNamespace
-add3DENEventHandler ["OnTerrainNew", {[] call CBA_fnc_preInit}];
-add3DENEventHandler ["OnMissionNew", {[] call CBA_fnc_preInit}];
-add3DENEventHandler ["OnMissionLoad", {[] call CBA_fnc_preInit}];
+_display displayAddEventHandler ["MouseMoving", _fnc_watchDog];
+_display displayAddEventHandler ["MouseHolding", _fnc_watchDog];

--- a/addons/xeh/fnc_initDisplay3DEN.sqf
+++ b/addons/xeh/fnc_initDisplay3DEN.sqf
@@ -8,14 +8,5 @@ add3DENEventHandler ["OnMissionPreviewEnd", {[] call CBA_fnc_preInit}];
 
 // switching terrains in 3den will reset missionNamespace
 add3DENEventHandler ["OnTerrainNew", {[] call CBA_fnc_preInit}];
-
-private _fnc_preInitMissionConfig = {
-    {
-        if (_x select 0 == "" && {_x select 1 == "preInit"}) then {
-            [] call (_x select 2);
-        };
-    } forEach (missionConfigFile call CBA_fnc_compileEventHandlers);
-};
-
-add3DENEventHandler ["OnMissionNew", _fnc_preInitMissionConfig];
-add3DENEventHandler ["OnMissionLoad", _fnc_preInitMissionConfig];
+add3DENEventHandler ["OnMissionNew", {[] call CBA_fnc_preInit}];
+add3DENEventHandler ["OnMissionLoad", {[] call CBA_fnc_preInit}];

--- a/addons/xeh/fnc_preInit.sqf
+++ b/addons/xeh/fnc_preInit.sqf
@@ -16,8 +16,6 @@ Author:
 ---------------------------------------------------------------------------- */
 #include "script_component.hpp"
 
-diag_log text format ["XEH: missionNamespace processed [%1]", ISPROCESSED(missionNamespace)];
-
 if (ISPROCESSED(missionNamespace)) exitWith {
     diag_log text "[XEH]: preInit already executed. Abort preInit.";
 };

--- a/addons/xeh/fnc_preInit.sqf
+++ b/addons/xeh/fnc_preInit.sqf
@@ -16,6 +16,8 @@ Author:
 ---------------------------------------------------------------------------- */
 #include "script_component.hpp"
 
+diag_log text format ["XEH: missionNamespace processed [%1]", ISPROCESSED(missionNamespace)];
+
 if (ISPROCESSED(missionNamespace)) exitWith {
     diag_log text "[XEH]: preInit already executed. Abort preInit.";
 };


### PR DESCRIPTION
Should fix #684

Seems like in 1.70, missionnamespace alwayse gets cleared out
(which seems good, just causes some problems)