### PR TITLE
addKeybind - Handle empty strings to indicated no code

### DIFF
--- a/addons/keybinding/fnc_addKeybind.sqf
+++ b/addons/keybinding/fnc_addKeybind.sqf
@@ -88,9 +88,15 @@ if (_defaultKeybind isEqualTypeParams [0, false, false, false]) then {
     _defaultKeybind = [_defaultKey, [_defaultShift, _defaultControl, _defaultAlt]];
 };
 
-// Handle empty strings to indicated no code
-if (_downCode isEqualType "") then {_downCode = {};};
-if (_upCode isEqualType "") then {_upCode = {};};
+// Handle non-code type being passed for up/down code args
+if (!(_downCode isEqualType {})) then {
+    if (!(_downCode isEqualTo "")) then {WARNING_1("_downCode: Non code type [%1] will be ignored",_downCode);};
+    _downCode = {};
+};
+if (!(_upCode isEqualType {})) then {
+    if (!(_upCode isEqualTo "")) then {WARNING_1("_upCode: Non code type [%1] will be ignored",_upCode);};
+    _upCode = {};
+};
 
 // Make sure modifer is set to true, if base key is a modifier
 _defaultKeybind params [["_defaultKey", 0, [0]], ["_defaultModifiers", [], [[]]]];

--- a/addons/keybinding/fnc_addKeybind.sqf
+++ b/addons/keybinding/fnc_addKeybind.sqf
@@ -71,8 +71,8 @@ params [
     ["_addon", "", [""]],
     ["_addonAction", "", [""]],
     ["_title", "", ["", []]],
-    ["_downCode", {}, [{}]],
-    ["_upCode", {}, [{}]],
+    ["_downCode", {}, [{}, ""]],
+    ["_upCode", {}, [{}, ""]],
     ["_defaultKeybind", KEYBIND_NULL, [KEYBIND_NULL]],
     ["_holdKey", false, [false]],
     ["_holdDelay", 0, [0]],
@@ -87,6 +87,10 @@ if (_defaultKeybind isEqualTypeParams [0, false, false, false]) then {
     _defaultKeybind params ["_defaultKey", "_defaultShift", "_defaultControl", "_defaultAlt"];
     _defaultKeybind = [_defaultKey, [_defaultShift, _defaultControl, _defaultAlt]];
 };
+
+// Handle empty strings to indicated no code
+if (_downCode isEqualType "") then {_downCode = {};};
+if (_upCode isEqualType "") then {_upCode = {};};
 
 // Make sure modifer is set to true, if base key is a modifier
 _defaultKeybind params [["_defaultKey", 0, [0]], ["_defaultModifiers", [], [[]]]];


### PR DESCRIPTION
`  _downCode       - Code for down event, empty string for no code. <CODE>`

ACRE uses this:
`["ACRE2", "CycleRadio", (localize LSTRING(CycleRadio)), { [1] call FUNC(cycleRadios) }, "", [58, [true, false, true]]] call cba_fnc_addKeybind;`