### PR TITLE
Build only master, release and PRs on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ branches:
   only:
     - master
     - release
+dist: trusty
 language: python
 python:
   - '3.5'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+branches:
+  only:
+    - master
+    - release
 language: python
 python:
   - '3.5'


### PR DESCRIPTION
**When merged this pull request will:**
- Only build `travis-ci/pr` on PRs open for merge into `master` (previously also built `travis-ci/push` because of not branch restrictions, so you had 2 builds for exact same commit)
- Only build `master` and `release` branches for (`travis-ci/push`) - everything goes through PRs to master so other branches make no sense to build (simply open a PR), master gets build because merge commits and things may be changed, same for release in case of hotfixes/cherry-picks.
- Use Trusty distro on Travis - has Python 3.5 pre-installed, Precise has only 3.4 (Trusty is also a bit faster on Travis, but in beta for a while now) ~45s -> ~35s