### PR TITLE
Fix error with turkish keyboard

### DIFF
--- a/addons/keybinding/XEH_preStart.sqf
+++ b/addons/keybinding/XEH_preStart.sqf
@@ -167,7 +167,14 @@ private _supportedKeys = [
 
 _supportedKeys = _supportedKeys apply {
     // strip away additional quote marks
-    private _keyName = parseSimpleArray format ["[%1]", keyName _x] select 0;
+    // Turkish keyboard which has a double quotes key (41), will throw an error in parseSimpleArray
+
+    private _formatedKeyname = format ["[%1]", keyName _x];
+    private _keyName = if (_formatedKeyname != "[""""""]") then {
+        (parseSimpleArray _formatedKeyname) select 0;
+    } else {
+        "''"
+    };
 
     [str _x, _keyName]
 };


### PR DESCRIPTION
From ace's slack
Turkish-Q keyboard

Edit: quick summery
- Keyboard has a double quote key
- parseSimpleArray does not like parsing it (`["""]`)

```
23:47:30 [0,9.361,0,"XEH: PreStart started."]
23:47:30 Error in expression <pportedKeys apply {

private _keyName = parseSimpleArray format ["[%1]", keyName>
23:47:30   Error position: <parseSimpleArray format ["[%1]", keyName>
23:47:30   Error Generic error in expression
23:47:30 File x\cba\addons\keybinding\XEH_preStart.sqf, line 168
23:47:33 [0,12.409,0,"XEH: PreStart finished."]
```
determined that 
```
    private _string = format ["[%1]", keyName _x];
    private _result = parseSimpleArray _string select 0;
    diag_log text format ["[%1] = [%2]", _string, _result];
```
`3:12:58 [["""]] = [any]`

This handles the error and just uses two single quotes as the key name, which looks fine.
Can test and reproduce the error by changing input language in windows.