### PR TITLE
Implement taskDefend ratio arguments

### DIFF
--- a/addons/ai/fnc_waypointGarrison.sqf
+++ b/addons/ai/fnc_waypointGarrison.sqf
@@ -31,7 +31,7 @@ private _buildings = (_position nearObjects ["Building", 50]) apply {_x building
         _x assignAsGunner (_staticWeapons deleteAt 0);
         [_x] orderGetIn true;
     } else {
-        if (count _buildings > 0 && {random 1 < 0.93}) then {
+        if (count _buildings > 0 && {random 1 < 0.90}) then {
             private _building = selectRandom _buildings;
             private _position = POP_RAND(_building);
 

--- a/addons/modules/CfgVehicles.hpp
+++ b/addons/modules/CfgVehicles.hpp
@@ -158,11 +158,11 @@ class CfgVehicles {
                     class two {
                         name = "2";
                         value = 2;
-                        default = 1;
                     };
                     class three {
                         name = "3";
                         value = 3;
+                        default = 1;
                     };
                     class four {
                         name = "4";
@@ -182,8 +182,15 @@ class CfgVehicles {
             class canPatrol {
                 displayName = CSTRING(CanPatrol);
                 description = CSTRING(CanPatrol_Desc);
-                typeName = "BOOL";
-                defaultValue = 1;
+                typeName = "NUMBER";
+                defaultValue = 0.1;
+            };
+
+            class shouldHold {
+                displayName = CSTRING(ShouldHold);
+                description = CSTRING(ShouldHold_Desc);
+                typeName = "NUMBER";
+                defaultValue = 0;
             };
         };
 

--- a/addons/modules/fnc_moduleDefend.sqf
+++ b/addons/modules/fnc_moduleDefend.sqf
@@ -64,12 +64,13 @@ _defendPos = [_defendLocType, _defendPos] call CBA_fnc_getPosFromString;
 if (isNil "_defendPos") then {_defendSetPos = true;};
 
 // Define if allowed to patrol
-_canPatrol = _logic getVariable ["canPatrol",true];
+_canPatrol = _logic getVariable ["canPatrol",0.1];
+_shouldHold = _logic getVariable ["shouldHold",0];
 
 // Command local group leaders to defend area
 _defendRadius = _logic getVariable ["defendRadius",25];
 _threshold = _logic getVariable ["threshold",2];
 {
     if (_defendSetPos) then {_defendPos = getPos _x;};
-    [_x, _defendPos, _defendRadius, _threshold, _canPatrol] call CBA_fnc_taskDefend;
+    [_x, _defendPos, _defendRadius, _threshold, _canPatrol, _shouldHold] call CBA_fnc_taskDefend;
 } forEach _localGroups;

--- a/addons/modules/stringtable.xml
+++ b/addons/modules/stringtable.xml
@@ -114,12 +114,16 @@
             <Japanese>小さい数字ではより多くの建物が利用できます</Japanese>
         </Key>
         <Key ID="STR_CBA_Modules_CanPatrol">
-            <English>Allow Patrolling</English>
-            <Japanese>哨戒を許可</Japanese>
+            <English>Patrol Chance</English>
         </Key>
         <Key ID="STR_CBA_Modules_CanPatrol_Desc">
-            <English>AI will be able to patrol the area they are defending</English>
-            <Japanese>防衛のために AI が哨戒するのを許可します</Japanese>
+            <English>Chance for each unit to patrol instead of garrison</English>
+        </Key>
+        <Key ID="STR_CBA_Modules_ShouldHold">
+            <English>Hold Chance</English>
+        </Key>
+        <Key ID="STR_CBA_Modules_ShouldHold_Desc">
+            <English>Chance for each unit to hold their garrison in combat</English>
         </Key>
         <Key ID="STR_CBA_Modules_DefendModuleDescription">
             <English>Sync to leader of group to defend a parsed location</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Update function header
- Change threshold to work on a `>=` comparison as it is more intuative as
  an argument
- Make patrol parameter accept a percentage chance to provide better
  control over units that will patrol
- Add a hold parameter to allow the function to force units to hold their
  positions inside buildings and not react to combat

This is the re-implementation of #573
