### PR TITLE
Add support for removing non-preset weapon if preset weapon present to removeWeaponCargo

### DIFF
--- a/addons/common/fnc_removeWeaponCargo.sqf
+++ b/addons/common/fnc_removeWeaponCargo.sqf
@@ -4,6 +4,9 @@ Function: CBA_fnc_removeWeaponCargo
 Description:
     Removes specific weapon(s) from cargo space.
 
+    Passing a non-preset weapon when there is a preset (classname with preset attachments/magazine)
+    weapon in cargo of that class will remove weapon only, leaving attachments and magazine.
+
     Warning: All weapon attachments/magazines in container will become detached.
 
 Parameters:
@@ -64,6 +67,7 @@ clearWeaponCargoGlobal _container;
 
 {
     _x params ["_weapon", "_muzzle", "_pointer", "_optic", "_magazine", "_magazineGL", "_bipod"];
+
     // weaponsItems magazineGL does not exist if not loaded (not even as empty array)
     if (count _x < 7) then {
         _bipod = _magazineGL;
@@ -74,8 +78,14 @@ clearWeaponCargoGlobal _container;
         // Process removal
         _count = _count - 1;
     } else {
-        _weapon = [_weapon] call CBA_fnc_getNonPresetClass;
-        _container addWeaponCargoGlobal [_weapon, 1];
+        private _weaponNonPreset = [_weapon] call CBA_fnc_getNonPresetClass;
+
+        if (_count != 0 && {_weaponNonPreset == _item}) then {
+            // Process removal of non-preset weapon, simply detach attachments on the weapon
+            _count = _count - 1;
+        } else {
+            _container addWeaponCargoGlobal [_weaponNonPreset, 1];
+        };
 
         _container addItemCargoGlobal [_muzzle, 1];
         _container addItemCargoGlobal [_pointer, 1];

--- a/addons/common/test_inventory.sqf
+++ b/addons/common/test_inventory.sqf
@@ -133,5 +133,10 @@ TEST_TRUE(_result,_funcName);
 TEST_TRUE(count (weaponCargo _container) == 2,_funcName);
 clearWeaponCargoGlobal _container;
 
+_container addWeaponCargoGlobal ["arifle_MX_ACO_pointer_F", 1];
+_result = [_container, "arifle_MX_F"] call CBA_fnc_removeWeaponCargo;
+TEST_TRUE(count (weaponCargo _container) == 0 && count (magazineCargo _container) == 1 && count (itemCargo _container) == 2,_funcName);
+clearWeaponCargoGlobal _container;
+
 
 deleteVehicle _container;

--- a/addons/common/test_inventory.sqf
+++ b/addons/common/test_inventory.sqf
@@ -135,7 +135,7 @@ clearWeaponCargoGlobal _container;
 
 _container addWeaponCargoGlobal ["arifle_MX_ACO_pointer_F", 1];
 _result = [_container, "arifle_MX_F"] call CBA_fnc_removeWeaponCargo;
-TEST_TRUE(count (weaponCargo _container) == 0 && count (magazineCargo _container) == 1 && count (itemCargo _container) == 2,_funcName);
+TEST_TRUE(count (weaponCargo _container) == 0 && count (itemCargo _container) == 2,_funcName);
 clearWeaponCargoGlobal _container;
 
 


### PR DESCRIPTION
**When merged this pull request will:**
- When passing a non-preset classname to `removeWeaponCargo` function and there is a preset weapon (classname that has predefined attachments/magazine), it will now remove the weapon only and leave the attachments/magazine itself. To remove the whole preset weapon, the preset class has to be used.
- Change behaviour a bit, but this is expected behaviour I think.
- Support multiple weapon removal as well (except when called in succession instead of using the number argument, due to inability to readd attachments to weapon when in cargo).
- Add test for new functionality.