### PR TITLE
bump required version to 1.72

### DIFF
--- a/addons/main/script_mod.hpp
+++ b/addons/main/script_mod.hpp
@@ -12,7 +12,7 @@
 
 
 // MINIMAL required version for the Mod. Components can specify others..
-#define REQUIRED_VERSION 1.68
+#define REQUIRED_VERSION 1.72
 
 /*
 // Defined DEBUG_MODE_NORMAL in a few CBA_fncs to prevent looped logging :)


### PR DESCRIPTION
**When merged this pull request will:**
- `Land_Laptop_02_unfolded_F` is used in #708 and does not exist in my unpatched 1.70 version.
- 1.70 is required for the JR changes