### PR TITLE
Quick fix for getArea

### DIFF
--- a/addons/common/fnc_getArea.sqf
+++ b/addons/common/fnc_getArea.sqf
@@ -1,6 +1,8 @@
 /* ----------------------------------------------------------------------------
 Function: CBA_fnc_getArea
 
+DEPRECATED - Please use <BIS_fnc_getArea at https://community.bistudio.com/wiki/BIS_fnc_getArea> added in Arma 3 1.58
+
 Description:
     Returns the array form of any area construct: [center, a, b, angle, isRectangle]
 

--- a/addons/common/fnc_getArea.sqf
+++ b/addons/common/fnc_getArea.sqf
@@ -42,6 +42,7 @@ if (_zRef isEqualType "") then {
         if !((triggerArea _zRef) isEqualTo []) then {
             _area pushBack (getPos _zRef);
             _area append (triggerArea _zRef);
+            _area resize 5;
         };
     } else {
         if (_zRef isEqualType locationNull) then {


### PR DESCRIPTION
somewhere along the line "triggerArea" started returning z values, making the return array size 6. This causes problems for other functions using the area format so this change simply removes the 6th element of the array. 
