### PR TITLE
Add a Slower PFH that only checks every 5 secs to Player Events

### DIFF
--- a/addons/events/fnc_addPlayerEventHandler.sqf
+++ b/addons/events/fnc_addPlayerEventHandler.sqf
@@ -7,14 +7,14 @@ Description:
     Possible events:
         "unit"       - player controlled unit changed
         "weapon"     - currently selected weapon change
-        "loadout"    - players loadout changed (Only Checks every 5 sec)
+        "loadout"    - players loadout changed (Only Checks every 1 sec)
         "vehicle"    - players current vehicle changed
         "turret"     - position in vehicle changed
         "visionMode" - player changed to normal/night/thermal view
         "cameraView" - camera mode changed ("Internal", "External", "Gunner" etc.)
         "visibleMap" - opened or closed map
-        "group"      - player group changes (Only Checks every 5 sec)
-        "leader"     - leader of player changes (Only Checks every 5 sec)
+        "group"      - player group changes (Only Checks every 1 sec)
+        "leader"     - leader of player changes (Only Checks every 1 sec)
 
 Parameters:
     _type      - Event handler type. <STRING>

--- a/addons/events/fnc_removePlayerEventHandler.sqf
+++ b/addons/events/fnc_removePlayerEventHandler.sqf
@@ -69,7 +69,6 @@ if (!isNil QGVAR(playerEHInfo)) then {
     if (count GVAR(playerEHInfo) == 3) then {
         removeMissionEventHandler ["EachFrame", GVAR(playerEHInfo) select 0];
         removeMissionEventHandler ["Map",       GVAR(playerEHInfo) select 1];
-        (GVAR(playerEHInfo) select 2) call CBA_fnc_removePerFrameHandler;
         GVAR(playerEHInfo) = nil;
     };
 };

--- a/addons/events/fnc_removePlayerEventHandler.sqf
+++ b/addons/events/fnc_removePlayerEventHandler.sqf
@@ -66,9 +66,10 @@ if (!isNil QGVAR(playerEHInfo)) then {
     // First two entries are mission eventhandler ids. Rest are framework
     // specific ids in array form. If all playerChanged eventhandlers were
     // removed, then also clean up the mission eventhandlers.
-    if (count GVAR(playerEHInfo) == 2) then {
+    if (count GVAR(playerEHInfo) == 3) then {
         removeMissionEventHandler ["EachFrame", GVAR(playerEHInfo) select 0];
         removeMissionEventHandler ["Map",       GVAR(playerEHInfo) select 1];
+        (GVAR(playerEHInfo) select 2) call CBA_fnc_removePerFrameHandler;
         GVAR(playerEHInfo) = nil;
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Add a slower PFH to player EHs
- move Loadout, group and leader changed to the slower PFH