### PR TITLE
Fix #719 Invalid result for CBA_fnc_getNearest

### DIFF
--- a/addons/common/fnc_getNearest.sqf
+++ b/addons/common/fnc_getNearest.sqf
@@ -41,8 +41,7 @@ private _return = [[], objNull] select (isNil {param [2]});
 
     if (_distance < _radius) then {
         if !(call _code) exitWith {}; // don't move up. condition has to return false, vs. has to return true. Can be nil!
-
-        if !(_return isEqualType objNull) then {
+        if (count _this > 2) then {
             _return pushBack _x;
         } else {
             _radius = _distance;

--- a/addons/common/test_position.sqf
+++ b/addons/common/test_position.sqf
@@ -62,3 +62,19 @@ _value set [0,-1];
 TEST_TRUE(_result isEqualTo EXPECTED,_funcName);
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#define EXPECTED [1,1,0] //Pos nearest to [0,0,0]
+
+_value = [[0,0,0], [[10,10,0],[1,1,0], [5,5,0]]];
+_result = _value call CBA_fnc_getNearest;
+
+TEST_TRUE(_result isEqualTo EXPECTED,_funcName);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#define EXPECTED [[1,1,0], [5,5,0]] //Pos within distance 10
+
+_value = [[0,0,0], [[30,30,0],[1,1,0], [5,5,0]], 10];
+_result = _value call CBA_fnc_getNearest;
+
+TEST_TRUE(_result isEqualTo EXPECTED,_funcName);


### PR DESCRIPTION
Fix #719 Invalid result for CBA_fnc_getNearest
res = [[0,0,0], [[10,10,0],[1,1,0], [5,5,0]]] call CBA_fnc_getNearest;
result before fix => [10,10,0,[1,1,0],[5,5,0]]
result after fix => [1,1,0]
