### PR TITLE
Add Target Debug run with addon config

### DIFF
--- a/addons/diagnostic/XEH_preInit.sqf
+++ b/addons/diagnostic/XEH_preInit.sqf
@@ -18,7 +18,8 @@ GVAR(projectileTrackedUnits) = [];
 
 ADDON = true;
 
-if (getMissionConfigValue ["EnableTargetDebug", 0] isEqualTo 1) then {
+private _cfg = configFile >> "EnableTargetDebug";
+if (1 isEqualTo ([getMissionConfigValue ["EnableTargetDebug", 0], getNumber _cfg] select isNumber _cfg)) then {
     INFO("EnableTargetDebug is enabled");
 
     [QGVAR(watchVariable), {

--- a/addons/diagnostic/XEH_preInit.sqf
+++ b/addons/diagnostic/XEH_preInit.sqf
@@ -18,8 +18,7 @@ GVAR(projectileTrackedUnits) = [];
 
 ADDON = true;
 
-private _cfg = configFile >> "EnableTargetDebug";
-if (1 isEqualTo ([getMissionConfigValue ["EnableTargetDebug", 0], getNumber _cfg] select isNumber _cfg)) then {
+if (1 == getMissionConfigValue ["EnableTargetDebug", 0] || {1 == getNumber (configFile >> "EnableTargetDebug")}) then {
     INFO("EnableTargetDebug is enabled");
 
     [QGVAR(watchVariable), {

--- a/addons/diagnostic/fnc_initTargetDebugConsole.sqf
+++ b/addons/diagnostic/fnc_initTargetDebugConsole.sqf
@@ -17,8 +17,7 @@ Author:
 
 #define COUNT_WATCH_BOXES 8
 
-private _cfg = configFile >> "EnableTargetDebug";
-if !(1 isEqualTo ([getMissionConfigValue ["EnableTargetDebug", 0], getNumber _cfg] select isNumber _cfg)) exitWith {};
+if !(1 == getMissionConfigValue ["EnableTargetDebug", 0] || {1 == getNumber (configFile >> "EnableTargetDebug")}) exitWith {};
 
 params ["_display"];
 TRACE_1("adding server watch debug",_display);

--- a/addons/diagnostic/fnc_initTargetDebugConsole.sqf
+++ b/addons/diagnostic/fnc_initTargetDebugConsole.sqf
@@ -2,8 +2,8 @@
 Function: CBA_diagnostic_fnc_initTargetDebugConsole
 
 Description:
-    Adds addition watch statements that are run on a remote target and have their values returned to the client.
-    Requires `EnableTargetDebug = 1; `in description.ext
+    Adds additional watch statements that are run on a remote target and have their values returned to the client.
+    Requires `EnableTargetDebug = 1;` in addon root config or description.ext or 3den scenario attribute with the same name
 
 Author:
     (based on BIS's RscDebugConsole.sqf)
@@ -17,7 +17,8 @@ Author:
 
 #define COUNT_WATCH_BOXES 8
 
-if (!((getMissionConfigValue ["EnableTargetDebug", 0]) isEqualTo 1)) exitWith {};
+private _cfg = configFile >> "EnableTargetDebug";
+if !(1 isEqualTo ([getMissionConfigValue ["EnableTargetDebug", 0], getNumber _cfg] select isNumber _cfg)) exitWith {};
 
 params ["_display"];
 TRACE_1("adding server watch debug",_display);


### PR DESCRIPTION
Fixes #712.
~Addon config has a greater priority than mission one.~
Also function description fixed.

- [ ] If merged, fix [Target-Debugging wiki](/CBATeam/CBA_A3/wiki/Target-Debugging) page