### PR TITLE
Add keep contents/attachments support and fix non-existing non-preset weapon parents in removeXCargo functions

### DIFF
--- a/addons/common/fnc_removeBackpackCargo.sqf
+++ b/addons/common/fnc_removeBackpackCargo.sqf
@@ -24,7 +24,7 @@ Examples:
     // Remove 2 Carryall Desert Camo backpacks from a box
     _success = [myCoolBackpackBox, "B_Carryall_ocamo", 2] call CBA_fnc_removeBackpackCargo;
 
-    // Remove 1 Backpack from a box and keep conents
+    // Remove 1 Backpack from a box and keep contents
     _success = [myCoolWeaponBox, "B_AssaultPack_khk", 1, true] call CBA_fnc_removeBackpackCargo;
     (end)
 

--- a/addons/common/fnc_removeBackpackCargo.sqf
+++ b/addons/common/fnc_removeBackpackCargo.sqf
@@ -5,6 +5,7 @@ Description:
     Removes specific backpack(s) from cargo space.
 
     Warning: All weapon attachments/magazines in all backpacks in container will become detached.
+    Warning: Preset weapons without non-preset parents will get their attachments readded (engine limitation).
 
 Parameters:
     _container - Object with cargo <OBJECT>
@@ -104,19 +105,40 @@ clearBackpackCargoGlobal _container;
                 _magazineGL = "";
             };
 
-            private _weapon = [_weapon] call CBA_fnc_getNonPresetClass;
-            _backpack addWeaponCargoGlobal [_weapon, 1];
+            // Some weapons don't have non-preset parents
+            private _weaponNonPreset = [_weapon] call CBA_fnc_getNonPresetClass;
+            if (_weaponNonPreset == "") then {
+                _weaponNonPreset = _weapon;
+            };
 
-            _backpack addItemCargoGlobal [_muzzle, 1];
-            _backpack addItemCargoGlobal [_pointer, 1];
-            _backpack addItemCargoGlobal [_optic, 1];
-            _backpack addItemCargoGlobal [_bipod, 1];
+            _backpack addWeaponCargoGlobal [_weaponNonPreset, 1];
 
-            _magazine params [["_magazineClass", ""], ["_magazineAmmoCount", ""]];
-            _backpack addMagazineAmmoCargo [_magazineClass, 1, _magazineAmmoCount];
+            // If weapon does not have a non-preset parent, only add attachments that were custom added
+            // Removed attachments cannot be handled (engine limitation) and will be readded due to having to readd preset weapon
 
-            _magazineGL params [["_magazineGLClass", ""], ["_magazineGLAmmoCount", ""]];
-            _backpack addMagazineAmmoCargo [_magazineGLClass, 1, _magazineGLAmmoCount];
+            private _presetAttachments = [];
+            if (_weaponNonPreset == _weapon) then {
+                _presetAttachments = _weapon call CBA_fnc_weaponComponents;
+            } else {
+                _magazine params [["_magazineClass", ""], ["_magazineAmmoCount", ""]];
+                _backpack addMagazineAmmoCargo [_magazineClass, 1, _magazineAmmoCount];
+
+                _magazineGL params [["_magazineGLClass", ""], ["_magazineGLAmmoCount", ""]];
+                _backpack addMagazineAmmoCargo [_magazineGLClass, 1, _magazineGLAmmoCount];
+            };
+
+            if !(toLower _muzzle in _presetAttachments) then {
+                _backpack addItemCargoGlobal [_muzzle, 1];
+            };
+            if !(toLower _pointer in _presetAttachments) then {
+                _backpack addItemCargoGlobal [_pointer, 1];
+            };
+            if !(toLower _optic in _presetAttachments) then {
+                _backpack addItemCargoGlobal [_optic, 1];
+            };
+            if !(toLower _bipod in _presetAttachments) then {
+                _backpack addItemCargoGlobal [_bipod, 1];
+            };
         } forEach _weaponsItemsCargo;
     };
 } forEach _backpackData;

--- a/addons/common/fnc_removeBackpackCargo.sqf
+++ b/addons/common/fnc_removeBackpackCargo.sqf
@@ -8,9 +8,10 @@ Description:
     Warning: Preset weapons without non-preset parents will get their attachments readded (engine limitation).
 
 Parameters:
-    _container - Object with cargo <OBJECT>
-    _item      - Classname of backpack(s) to remove <STRING>
-    _count     - Number of backpack(s) to remove <NUMBER> (Default: 1)
+    _container    - Object with cargo <OBJECT>
+    _item         - Classname of backpack(s) to remove <STRING>
+    _count        - Number of backpack(s) to remove <NUMBER> (Default: 1)
+    _keepContents - Keep contents of the removed backpack <BOOLEAN> (Default: false)
 
 Returns:
     true on success, false otherwise <BOOLEAN>
@@ -22,6 +23,9 @@ Examples:
 
     // Remove 2 Carryall Desert Camo backpacks from a box
     _success = [myCoolBackpackBox, "B_Carryall_ocamo", 2] call CBA_fnc_removeBackpackCargo;
+
+    // Remove 1 Backpack from a box and keep conents
+    _success = [myCoolWeaponBox, "B_AssaultPack_khk", 1, true] call CBA_fnc_removeBackpackCargo;
     (end)
 
 Author:
@@ -30,7 +34,7 @@ Author:
 #include "script_component.hpp"
 SCRIPT(removeBackpackCargo);
 
-params [["_container", objNull, [objNull]], ["_item", "", [""]], ["_count", 1, [0]]];
+params [["_container", objNull, [objNull]], ["_item", "", [""]], ["_count", 1, [0]], ["_keepContents", false, [true]]];
 
 if (isNull _container) exitWith {
     TRACE_2("Container not Object or null",_container,_item);
@@ -66,12 +70,81 @@ private _backpackData = [];
 // Clear cargo space and readd the items as long it's not the type in question
 clearBackpackCargoGlobal _container;
 
+
+// Add contents to backpack or box helper function
+private _fnc_addContents = {
+    params ["_container", "_itemCargo", "_magazinesAmmoCargo", "_weaponsItemsCargo"];
+
+    // Items
+    {
+        private _itemCount = (_itemCargo select 1) select _forEachIndex;
+        _container addItemCargoGlobal [_x, _itemCount];
+    } forEach (_itemCargo select 0);
+
+    // Magazines (and their ammo count)
+    {
+        _container addMagazineAmmoCargo [_x select 0, 1, _x select 1];
+    } forEach _magazinesAmmoCargo;
+
+    // Weapons (and their attachments)
+    // Put attachments next to weapon, no command to put it directly onto a weapon when weapon is in a container
+    {
+        _x params ["_weapon", "_muzzle", "_pointer", "_optic", "_magazine", "_magazineGL", "_bipod"];
+
+        // weaponsItems magazineGL does not exist if not loaded (not even as empty array)
+        if (count _x < 7) then {
+            _bipod = _magazineGL;
+            _magazineGL = "";
+        };
+
+        // Some weapons don't have non-preset parents
+        private _weaponNonPreset = [_weapon] call CBA_fnc_getNonPresetClass;
+        if (_weaponNonPreset == "") then {
+            _weaponNonPreset = _weapon;
+        };
+
+        _container addWeaponCargoGlobal [_weaponNonPreset, 1];
+
+        // If weapon does not have a non-preset parent, only add attachments that were custom added
+        // Removed attachments cannot be handled (engine limitation) and will be readded due to having to readd preset weapon
+
+        private _presetAttachments = [];
+        if (_weaponNonPreset == _weapon) then {
+            _presetAttachments = _weapon call CBA_fnc_weaponComponents;
+        } else {
+            _magazine params [["_magazineClass", ""], ["_magazineAmmoCount", ""]];
+            _container addMagazineAmmoCargo [_magazineClass, 1, _magazineAmmoCount];
+
+            _magazineGL params [["_magazineGLClass", ""], ["_magazineGLAmmoCount", ""]];
+            _container addMagazineAmmoCargo [_magazineGLClass, 1, _magazineGLAmmoCount];
+        };
+
+        if !(toLower _muzzle in _presetAttachments) then {
+            _container addItemCargoGlobal [_muzzle, 1];
+        };
+        if !(toLower _pointer in _presetAttachments) then {
+            _container addItemCargoGlobal [_pointer, 1];
+        };
+        if !(toLower _optic in _presetAttachments) then {
+            _container addItemCargoGlobal [_optic, 1];
+        };
+        if !(toLower _bipod in _presetAttachments) then {
+            _container addItemCargoGlobal [_bipod, 1];
+        };
+    } forEach _weaponsItemsCargo;
+};
+
+// Process all backpacks
 {
     _x params ["_backpackClass", "_itemCargo", "_magazinesAmmoCargo", "_weaponsItemsCargo"];
 
     if (_count != 0 && {_backpackClass == _item}) then {
         // Process removal
         _count = _count - 1;
+
+        if (_keepContents) then {
+            [_container, _itemCargo, _magazinesAmmoCargo, _weaponsItemsCargo] call _fnc_addContents;
+        };
     } else {
         // Save all backpacks for finding the one we readd after this
         private _addedBackpacks = everyBackpack _container;
@@ -83,63 +156,7 @@ clearBackpackCargoGlobal _container;
         // Find just added backpack and add contents (no command returns reference when adding)
         private _backpack = (everyBackpack _container - _addedBackpacks) select 0;
 
-        // Items
-        {
-            private _itemCount = (_itemCargo select 1) select _forEachIndex;
-            _backpack addItemCargoGlobal [_x, _itemCount];
-        } forEach (_itemCargo select 0);
-
-        // Magazines (and their ammo count)
-        {
-            _backpack addMagazineAmmoCargo [_x select 0, 1, _x select 1];
-        } forEach _magazinesAmmoCargo;
-
-        // Weapons (and their attachments)
-        // Put attachments next to weapon, no command to put it directly onto a weapon when weapon is in a container
-        {
-            _x params ["_weapon", "_muzzle", "_pointer", "_optic", "_magazine", "_magazineGL", "_bipod"];
-
-            // weaponsItems magazineGL does not exist if not loaded (not even as empty array)
-            if (count _x < 7) then {
-                _bipod = _magazineGL;
-                _magazineGL = "";
-            };
-
-            // Some weapons don't have non-preset parents
-            private _weaponNonPreset = [_weapon] call CBA_fnc_getNonPresetClass;
-            if (_weaponNonPreset == "") then {
-                _weaponNonPreset = _weapon;
-            };
-
-            _backpack addWeaponCargoGlobal [_weaponNonPreset, 1];
-
-            // If weapon does not have a non-preset parent, only add attachments that were custom added
-            // Removed attachments cannot be handled (engine limitation) and will be readded due to having to readd preset weapon
-
-            private _presetAttachments = [];
-            if (_weaponNonPreset == _weapon) then {
-                _presetAttachments = _weapon call CBA_fnc_weaponComponents;
-            } else {
-                _magazine params [["_magazineClass", ""], ["_magazineAmmoCount", ""]];
-                _backpack addMagazineAmmoCargo [_magazineClass, 1, _magazineAmmoCount];
-
-                _magazineGL params [["_magazineGLClass", ""], ["_magazineGLAmmoCount", ""]];
-                _backpack addMagazineAmmoCargo [_magazineGLClass, 1, _magazineGLAmmoCount];
-            };
-
-            if !(toLower _muzzle in _presetAttachments) then {
-                _backpack addItemCargoGlobal [_muzzle, 1];
-            };
-            if !(toLower _pointer in _presetAttachments) then {
-                _backpack addItemCargoGlobal [_pointer, 1];
-            };
-            if !(toLower _optic in _presetAttachments) then {
-                _backpack addItemCargoGlobal [_optic, 1];
-            };
-            if !(toLower _bipod in _presetAttachments) then {
-                _backpack addItemCargoGlobal [_bipod, 1];
-            };
-        } forEach _weaponsItemsCargo;
+        [_backpack, _itemCargo, _magazinesAmmoCargo, _weaponsItemsCargo] call _fnc_addContents;
     };
 } forEach _backpackData;
 

--- a/addons/common/fnc_removeItemCargo.sqf
+++ b/addons/common/fnc_removeItemCargo.sqf
@@ -5,6 +5,7 @@ Description:
     Removes specific item(s) from cargo space.
 
     Warning: All weapon attachments/magazines in containers in container will become detached.
+    Warning: Preset weapons without non-preset parents will get their attachments readded (engine limitation).
 
 Parameters:
     _container - Object with cargo <OBJECT>
@@ -129,19 +130,40 @@ clearItemCargoGlobal _container;
                     _magazineGL = "";
                 };
 
-                private _weapon = [_weapon] call CBA_fnc_getNonPresetClass;
-                _addedContainer addWeaponCargoGlobal [_weapon, 1];
+                // Some weapons don't have non-preset parents
+                private _weaponNonPreset = [_weapon] call CBA_fnc_getNonPresetClass;
+                if (_weaponNonPreset == "") then {
+                    _weaponNonPreset = _weapon;
+                };
 
-                _addedContainer addItemCargoGlobal [_muzzle, 1];
-                _addedContainer addItemCargoGlobal [_pointer, 1];
-                _addedContainer addItemCargoGlobal [_optic, 1];
-                _addedContainer addItemCargoGlobal [_bipod, 1];
+                _addedContainer addWeaponCargoGlobal [_weaponNonPreset, 1];
 
-                _magazine params [["_magazineClass", ""], ["_magazineAmmoCount", ""]];
-                _addedContainer addMagazineAmmoCargo [_magazineClass, 1, _magazineAmmoCount];
+                // If weapon does not have a non-preset parent, only add attachments that were custom added
+                // Removed attachments cannot be handled (engine limitation) and will be readded due to having to readd preset weapon
 
-                _magazineGL params [["_magazineGLClass", ""], ["_magazineGLAmmoCount", ""]];
-                _addedContainer addMagazineAmmoCargo [_magazineGLClass, 1, _magazineGLAmmoCount];
+                private _presetAttachments = [];
+                if (_weaponNonPreset == _weapon) then {
+                    _presetAttachments = _weapon call CBA_fnc_weaponComponents;
+                } else {
+                    _magazine params [["_magazineClass", ""], ["_magazineAmmoCount", ""]];
+                    _addedContainer addMagazineAmmoCargo [_magazineClass, 1, _magazineAmmoCount];
+
+                    _magazineGL params [["_magazineGLClass", ""], ["_magazineGLAmmoCount", ""]];
+                    _addedContainer addMagazineAmmoCargo [_magazineGLClass, 1, _magazineGLAmmoCount];
+                };
+
+                if !(toLower _muzzle in _presetAttachments) then {
+                    _addedContainer addItemCargoGlobal [_muzzle, 1];
+                };
+                if !(toLower _pointer in _presetAttachments) then {
+                    _addedContainer addItemCargoGlobal [_pointer, 1];
+                };
+                if !(toLower _optic in _presetAttachments) then {
+                    _addedContainer addItemCargoGlobal [_optic, 1];
+                };
+                if !(toLower _bipod in _presetAttachments) then {
+                    _addedContainer addItemCargoGlobal [_bipod, 1];
+                };
             } forEach _weaponsItemsCargo;
         };
     };

--- a/addons/common/fnc_removeItemCargo.sqf
+++ b/addons/common/fnc_removeItemCargo.sqf
@@ -24,7 +24,7 @@ Examples:
     // Remove 2 Compasses from a box
     _success = [myCoolItemBox, "ItemCompass", 2] call CBA_fnc_removeItemCargo;
 
-    // Remove 1 Vest from a box and keep conents
+    // Remove 1 Vest from a box and keep contents
     _success = [myCoolWeaponBox, "V_PlateCarrier1_rgr", 1, true] call CBA_fnc_removeItemCargo;
     (end)
 

--- a/addons/common/fnc_removeItemCargo.sqf
+++ b/addons/common/fnc_removeItemCargo.sqf
@@ -8,9 +8,10 @@ Description:
     Warning: Preset weapons without non-preset parents will get their attachments readded (engine limitation).
 
 Parameters:
-    _container - Object with cargo <OBJECT>
-    _item      - Classname of item(s) to remove <STRING>
-    _count     - Number of item(s) to remove <NUMBER> (Default: 1)
+    _container    - Object with cargo <OBJECT>
+    _item         - Classname of item(s) to remove <STRING>
+    _count        - Number of item(s) to remove <NUMBER> (Default: 1)
+    _keepContents - Keep contents of the removed item (if uniform/vest) <BOOLEAN> (Default: false)
 
 Returns:
     true on success, false otherwise <BOOLEAN>
@@ -22,6 +23,9 @@ Examples:
 
     // Remove 2 Compasses from a box
     _success = [myCoolItemBox, "ItemCompass", 2] call CBA_fnc_removeItemCargo;
+
+    // Remove 1 Vest from a box and keep conents
+    _success = [myCoolWeaponBox, "V_PlateCarrier1_rgr", 1, true] call CBA_fnc_removeItemCargo;
     (end)
 
 Author:
@@ -30,7 +34,7 @@ Author:
 #include "script_component.hpp"
 SCRIPT(removeItemCargo);
 
-params [["_container", objNull, [objNull]], ["_item", "", [""]], ["_count", 1, [0]]];
+params [["_container", objNull, [objNull]], ["_item", "", [""]], ["_count", 1, [0]], ["_keepContents", false, [true]]];
 
 if (isNull _container) exitWith {
     TRACE_2("Container not Object or null",_container,_item);
@@ -74,6 +78,71 @@ private _containerNames = [];
 // Clear cargo space and readd the items as long it's not the type in question
 clearItemCargoGlobal _container;
 
+
+// Add contents to backpack or box helper function
+private _fnc_addContents = {
+    params ["_container", "_itemCargo", "_magazinesAmmoCargo", "_weaponsItemsCargo"];
+
+    // Items
+    {
+        private _itemCount = (_itemCargo select 1) select _forEachIndex;
+        _container addItemCargoGlobal [_x, _itemCount];
+    } forEach (_itemCargo select 0);
+
+    // Magazines (and their ammo count)
+    {
+        _container addMagazineAmmoCargo [_x select 0, 1, _x select 1];
+    } forEach _magazinesAmmoCargo;
+
+    // Weapons (and their attachments)
+    // Put attachments next to weapon, no command to put it directly onto a weapon when weapon is in a container
+    {
+        _x params ["_weapon", "_muzzle", "_pointer", "_optic", "_magazine", "_magazineGL", "_bipod"];
+
+        // weaponsItems magazineGL does not exist if not loaded (not even as empty array)
+        if (count _x < 7) then {
+            _bipod = _magazineGL;
+            _magazineGL = "";
+        };
+
+        // Some weapons don't have non-preset parents
+        private _weaponNonPreset = [_weapon] call CBA_fnc_getNonPresetClass;
+        if (_weaponNonPreset == "") then {
+            _weaponNonPreset = _weapon;
+        };
+
+        _container addWeaponCargoGlobal [_weaponNonPreset, 1];
+
+        // If weapon does not have a non-preset parent, only add attachments that were custom added
+        // Removed attachments cannot be handled (engine limitation) and will be readded due to having to readd preset weapon
+
+        private _presetAttachments = [];
+        if (_weaponNonPreset == _weapon) then {
+            _presetAttachments = _weapon call CBA_fnc_weaponComponents;
+        } else {
+            _magazine params [["_magazineClass", ""], ["_magazineAmmoCount", ""]];
+            _container addMagazineAmmoCargo [_magazineClass, 1, _magazineAmmoCount];
+
+            _magazineGL params [["_magazineGLClass", ""], ["_magazineGLAmmoCount", ""]];
+            _container addMagazineAmmoCargo [_magazineGLClass, 1, _magazineGLAmmoCount];
+        };
+
+        if !(toLower _muzzle in _presetAttachments) then {
+            _container addItemCargoGlobal [_muzzle, 1];
+        };
+        if !(toLower _pointer in _presetAttachments) then {
+            _container addItemCargoGlobal [_pointer, 1];
+        };
+        if !(toLower _optic in _presetAttachments) then {
+            _container addItemCargoGlobal [_optic, 1];
+        };
+        if !(toLower _bipod in _presetAttachments) then {
+            _container addItemCargoGlobal [_bipod, 1];
+        };
+    } forEach _weaponsItemsCargo;
+};
+
+// Process removal
 {
     private _itemCount = _allItemsCount select _forEachIndex;
     private _containerIndex = _containerNames find _x;
@@ -87,6 +156,11 @@ clearItemCargoGlobal _container;
                 _container addItemCargoGlobal [_x, _itemCount];
             };
         } else {
+            if (_keepContents) then {
+                (_containerData select _containerIndex) params ["_itemCargo", "_magazinesAmmoCargo", "_weaponsItemsCargo"];
+                [_container, _itemCargo, _magazinesAmmoCargo, _weaponsItemsCargo] call _fnc_addContents;
+            };
+
             _containerData deleteAt _containerIndex;
             _containerNames deleteAt _containerIndex;
         };
@@ -108,63 +182,7 @@ clearItemCargoGlobal _container;
             // Find just added container and add contents (no command returns reference when adding)
             private _addedContainer = ((((everyContainer _container) apply {_x select 1}) - everyBackpack _container) - _addedContainers) select 0;
 
-            // Items
-            {
-                private _itemCount = (_itemCargo select 1) select _forEachIndex;
-                _addedContainer addItemCargoGlobal [_x, _itemCount];
-            } forEach (_itemCargo select 0);
-
-            // Magazines (and their ammo count)
-            {
-                _addedContainer addMagazineAmmoCargo [_x select 0, 1, _x select 1];
-            } forEach _magazinesAmmoCargo;
-
-            // Weapons (and their attachments)
-            // Put attachments next to weapon, no command to put it directly onto a weapon when weapon is in a container
-            {
-                _x params ["_weapon", "_muzzle", "_pointer", "_optic", "_magazine", "_magazineGL", "_bipod"];
-
-                // weaponsItems magazineGL does not exist if not loaded (not even as empty array)
-                if (count _x < 7) then {
-                    _bipod = _magazineGL;
-                    _magazineGL = "";
-                };
-
-                // Some weapons don't have non-preset parents
-                private _weaponNonPreset = [_weapon] call CBA_fnc_getNonPresetClass;
-                if (_weaponNonPreset == "") then {
-                    _weaponNonPreset = _weapon;
-                };
-
-                _addedContainer addWeaponCargoGlobal [_weaponNonPreset, 1];
-
-                // If weapon does not have a non-preset parent, only add attachments that were custom added
-                // Removed attachments cannot be handled (engine limitation) and will be readded due to having to readd preset weapon
-
-                private _presetAttachments = [];
-                if (_weaponNonPreset == _weapon) then {
-                    _presetAttachments = _weapon call CBA_fnc_weaponComponents;
-                } else {
-                    _magazine params [["_magazineClass", ""], ["_magazineAmmoCount", ""]];
-                    _addedContainer addMagazineAmmoCargo [_magazineClass, 1, _magazineAmmoCount];
-
-                    _magazineGL params [["_magazineGLClass", ""], ["_magazineGLAmmoCount", ""]];
-                    _addedContainer addMagazineAmmoCargo [_magazineGLClass, 1, _magazineGLAmmoCount];
-                };
-
-                if !(toLower _muzzle in _presetAttachments) then {
-                    _addedContainer addItemCargoGlobal [_muzzle, 1];
-                };
-                if !(toLower _pointer in _presetAttachments) then {
-                    _addedContainer addItemCargoGlobal [_pointer, 1];
-                };
-                if !(toLower _optic in _presetAttachments) then {
-                    _addedContainer addItemCargoGlobal [_optic, 1];
-                };
-                if !(toLower _bipod in _presetAttachments) then {
-                    _addedContainer addItemCargoGlobal [_bipod, 1];
-                };
-            } forEach _weaponsItemsCargo;
+            [_addedContainer, _itemCargo, _magazinesAmmoCargo, _weaponsItemsCargo] call _fnc_addContents;
         };
     };
 } forEach _allItemsType;

--- a/addons/common/fnc_removeWeaponCargo.sqf
+++ b/addons/common/fnc_removeWeaponCargo.sqf
@@ -4,9 +4,6 @@ Function: CBA_fnc_removeWeaponCargo
 Description:
     Removes specific weapon(s) from cargo space.
 
-    Passing a non-preset weapon when there is a preset (classname with preset attachments/magazine)
-    weapon in cargo of that class will remove weapon only, leaving attachments and magazine.
-
     Warning: All weapon attachments/magazines in container will become detached.
     Warning: Preset weapons without non-preset parents will get their attachments readded (engine limitation).
 

--- a/addons/common/fnc_removeWeaponCargo.sqf
+++ b/addons/common/fnc_removeWeaponCargo.sqf
@@ -24,7 +24,7 @@ Examples:
     // Remove 2 M16A2 from a box
     _success = [myCoolWeaponBox, "M16A2", 2] call CBA_fnc_removeWeaponCargo;
 
-    // Remove 1 MX (with ACO and IR pointer) and keep attachments
+    // Remove 1 MX (with ACO and IR pointer) from a box and keep attachments
     _success = [myCoolWeaponBox, "arifle_MX_ACO_pointer_F", 1, true] call CBA_fnc_removeWeaponCargo;
     (end)
 

--- a/addons/common/fnc_removeWeaponCargo.sqf
+++ b/addons/common/fnc_removeWeaponCargo.sqf
@@ -8,11 +8,13 @@ Description:
     weapon in cargo of that class will remove weapon only, leaving attachments and magazine.
 
     Warning: All weapon attachments/magazines in container will become detached.
+    Warning: Preset weapons without non-preset parents will get their attachments readded (engine limitation).
 
 Parameters:
-    _container - Object with cargo <OBJECT>
-    _item      - Classname of weapon(s) to remove <STRING>
-    _count     - Number of weapon(s) to remove <NUMBER> (Default: 1)
+    _container       - Object with cargo <OBJECT>
+    _item            - Classname of weapon(s) to remove <STRING>
+    _count           - Number of weapon(s) to remove <NUMBER> (Default: 1)
+    _keepAttachments - Keep attachments/magazines of the removed weapon <BOOLEAN> (Default: false)
 
 Returns:
     true on success, false otherwise <BOOLEAN>
@@ -24,6 +26,9 @@ Examples:
 
     // Remove 2 M16A2 from a box
     _success = [myCoolWeaponBox, "M16A2", 2] call CBA_fnc_removeWeaponCargo;
+
+    // Remove 1 MX (with ACO and IR pointer) and keep attachments
+    _success = [myCoolWeaponBox, "arifle_MX_ACO_pointer_F", 1, true] call CBA_fnc_removeWeaponCargo;
     (end)
 
 Author:
@@ -32,7 +37,7 @@ Author:
 #include "script_component.hpp"
 SCRIPT(removeWeaponCargo);
 
-params [["_container", objNull, [objNull]], ["_item", "", [""]], ["_count", 1, [0]]];
+params [["_container", objNull, [objNull]], ["_item", "", [""]], ["_count", 1, [0]], ["_keepAttachments", false, [true]]];
 
 if (isNull _container) exitWith {
     TRACE_2("Container not Object or null",_container,_item);
@@ -74,29 +79,59 @@ clearWeaponCargoGlobal _container;
         _magazineGL = "";
     };
 
-    if (_count != 0 && {_weapon == _item}) then {
+    // Some weapons don't have non-preset parents
+    private _weaponNonPreset = [_weapon] call CBA_fnc_getNonPresetClass;
+    if (_weaponNonPreset == "") then {
+        _weaponNonPreset = _weapon;
+    };
+
+    if (_count != 0 && {_weapon == _item || _weaponNonPreset == _item}) then {
         // Process removal
         _count = _count - 1;
-    } else {
-        private _weaponNonPreset = [_weapon] call CBA_fnc_getNonPresetClass;
 
-        if (_count != 0 && {_weaponNonPreset == _item}) then {
-            // Process removal of non-preset weapon, simply detach attachments on the weapon
-            _count = _count - 1;
+        if (_keepAttachments) then {
+            _container addItemCargoGlobal [_muzzle, 1];
+            _container addItemCargoGlobal [_pointer, 1];
+            _container addItemCargoGlobal [_optic, 1];
+            _container addItemCargoGlobal [_bipod, 1];
+
+            _magazine params [["_magazineClass", ""], ["_magazineAmmoCount", ""]];
+            _container addMagazineAmmoCargo [_magazineClass, 1, _magazineAmmoCount];
+
+            _magazineGL params [["_magazineGLClass", ""], ["_magazineGLAmmoCount", ""]];
+            _container addMagazineAmmoCargo [_magazineGLClass, 1, _magazineGLAmmoCount];
+        };
+    } else {
+        _container addWeaponCargoGlobal [_weaponNonPreset, 1];
+
+        // If weapon does not have a non-preset parent, only add attachments that were custom added
+        // Removed attachments cannot be handled (engine limitation) and will be readded due to having to readd preset weapon
+
+        private _presetAttachments = [];
+        if (_weaponNonPreset == _weapon) then {
+            _presetAttachments = _weapon call CBA_fnc_weaponComponents;
+            systemChat _weapon;
+            systemChat str _presetAttachments;
         } else {
-            _container addWeaponCargoGlobal [_weaponNonPreset, 1];
+            _magazine params [["_magazineClass", ""], ["_magazineAmmoCount", ""]];
+            _container addMagazineAmmoCargo [_magazineClass, 1, _magazineAmmoCount];
+
+            _magazineGL params [["_magazineGLClass", ""], ["_magazineGLAmmoCount", ""]];
+            _container addMagazineAmmoCargo [_magazineGLClass, 1, _magazineGLAmmoCount];
         };
 
-        _container addItemCargoGlobal [_muzzle, 1];
-        _container addItemCargoGlobal [_pointer, 1];
-        _container addItemCargoGlobal [_optic, 1];
-        _container addItemCargoGlobal [_bipod, 1];
-
-        _magazine params [["_magazineClass", ""], ["_magazineAmmoCount", ""]];
-        _container addMagazineAmmoCargo [_magazineClass, 1, _magazineAmmoCount];
-
-        _magazineGL params [["_magazineGLClass", ""], ["_magazineGLAmmoCount", ""]];
-        _container addMagazineAmmoCargo [_magazineGLClass, 1, _magazineGLAmmoCount];
+        if !(toLower _muzzle in _presetAttachments) then {
+            _container addItemCargoGlobal [_muzzle, 1];
+        };
+        if !(toLower _pointer in _presetAttachments) then {
+            _container addItemCargoGlobal [_pointer, 1];
+        };
+        if !(toLower _optic in _presetAttachments) then {
+            _container addItemCargoGlobal [_optic, 1];
+        };
+        if !(toLower _bipod in _presetAttachments) then {
+            _container addItemCargoGlobal [_bipod, 1];
+        };
     };
 } forEach _weaponsItemsCargo;
 

--- a/addons/common/fnc_removeWeaponCargo.sqf
+++ b/addons/common/fnc_removeWeaponCargo.sqf
@@ -107,8 +107,6 @@ clearWeaponCargoGlobal _container;
         private _presetAttachments = [];
         if (_weaponNonPreset == _weapon) then {
             _presetAttachments = _weapon call CBA_fnc_weaponComponents;
-            systemChat _weapon;
-            systemChat str _presetAttachments;
         } else {
             _magazine params [["_magazineClass", ""], ["_magazineAmmoCount", ""]];
             _container addMagazineAmmoCargo [_magazineClass, 1, _magazineAmmoCount];

--- a/addons/common/test_inventory.sqf
+++ b/addons/common/test_inventory.sqf
@@ -139,13 +139,34 @@ TEST_FALSE(_result,_funcName);
 _container addWeaponCargoGlobal ["srifle_EBR_F", 5];
 _result = [_container, "srifle_EBR_F", 3] call CBA_fnc_removeWeaponCargo;
 TEST_TRUE(_result,_funcName);
-TEST_TRUE(count (weaponCargo _container) == 2,_funcName);
+TEST_TRUE(count (weaponCargo _container) == 2 && count (itemCargo _container) == 0,_funcName);
 clearWeaponCargoGlobal _container;
+clearItemCargoGlobal _container;
 
 _container addWeaponCargoGlobal ["arifle_MX_ACO_pointer_F", 1];
 _result = [_container, "arifle_MX_F"] call CBA_fnc_removeWeaponCargo;
+TEST_TRUE(count (weaponCargo _container) == 0 && count (itemCargo _container) == 0,_funcName);
+clearWeaponCargoGlobal _container;
+clearItemCargoGlobal _container;
+
+_container addWeaponCargoGlobal ["arifle_MX_ACO_pointer_F", 1];
+_result = [_container, "arifle_MX_F", 1, true] call CBA_fnc_removeWeaponCargo;
 TEST_TRUE(count (weaponCargo _container) == 0 && count (itemCargo _container) == 2,_funcName);
 clearWeaponCargoGlobal _container;
+clearItemCargoGlobal _container;
+
+_container addWeaponCargoGlobal ["arifle_MX_SW_F", 1]; // arifle_MX_SW_F has no non-preset parent class
+_result = [_container, "arifle_MX_SW_F", 1, true] call CBA_fnc_removeWeaponCargo;
+TEST_TRUE(count (weaponCargo _container) == 0 && count (itemCargo _container) == 1,_funcName);
+clearWeaponCargoGlobal _container;
+clearItemCargoGlobal _container;
+
+_container addWeaponCargoGlobal ["arifle_MX_ACO_pointer_F", 1];
+_container addWeaponCargoGlobal ["arifle_MX_SW_F", 1]; // arifle_MX_SW_F has no non-preset parent class
+_result = [_container, "arifle_MX_ACO_pointer_F", 1] call CBA_fnc_removeWeaponCargo;
+TEST_TRUE(count (weaponCargo _container) == 1 && count (itemCargo _container) == 0,_funcName);
+clearWeaponCargoGlobal _container;
+clearItemCargoGlobal _container;
 
 
 deleteVehicle _container;

--- a/addons/common/test_inventory.sqf
+++ b/addons/common/test_inventory.sqf
@@ -94,6 +94,40 @@ TEST_TRUE(_result,_funcName);
 TEST_TRUE(count (backpackCargo _container) == 2,_funcName);
 clearBackpackCargoGlobal _container;
 
+_container addBackpackCargoGlobal ["B_AssaultPack_mcamo_Ammo", 1];
+_result = [_container, "B_AssaultPack_mcamo_Ammo", 1, true] call CBA_fnc_removeBackpackCargo;
+TEST_TRUE(_result,_funcName);
+TEST_TRUE(count (backpackCargo _container) == 0 && count (itemCargo _container) == 4 && count (magazineCargo _container) == 20,_funcName);
+clearBackpackCargoGlobal _container;
+clearItemCargoGlobal _container;
+clearMagazineCargoGlobal _container;
+
+_container addBackpackCargoGlobal ["B_AssaultPack_mcamo", 1];
+((everyBackpack _container) select 0) addWeaponCargoGlobal ["arifle_MX_ACO_pointer_F", 1];
+_result = [_container, "B_AssaultPack_mcamo", 1] call CBA_fnc_removeBackpackCargo;
+TEST_TRUE(_result,_funcName);
+TEST_TRUE(count (backpackCargo _container) == 0 && count (weaponCargo _container) == 0 && count (itemCargo _container) == 0,_funcName);
+clearBackpackCargoGlobal _container;
+clearWeaponCargoGlobal _container;
+clearItemCargoGlobal _container;
+
+_container addBackpackCargoGlobal ["B_AssaultPack_mcamo", 1];
+((everyBackpack _container) select 0) addWeaponCargoGlobal ["arifle_MX_ACO_pointer_F", 1];
+_result = [_container, "B_AssaultPack_mcamo", 1, true] call CBA_fnc_removeBackpackCargo;
+TEST_TRUE(_result,_funcName);
+TEST_TRUE(count (backpackCargo _container) == 0 && count (weaponCargo _container) == 1 && count (itemCargo _container) == 2,_funcName);
+clearBackpackCargoGlobal _container;
+clearWeaponCargoGlobal _container;
+clearItemCargoGlobal _container;
+
+_container addBackpackCargoGlobal ["B_AssaultPack_mcamo", 1];
+((everyBackpack _container) select 0) addWeaponCargoGlobal ["arifle_MX_SW_F", 1]; // arifle_MX_SW_F has no non-preset parent class
+_result = [_container, "B_AssaultPack_mcamo", 1, true] call CBA_fnc_removeBackpackCargo;
+TEST_TRUE(_result,_funcName);
+TEST_TRUE(count (backpackCargo _container) == 0 && count (weaponCargo _container) == 1,_funcName);
+clearBackpackCargoGlobal _container;
+clearWeaponCargoGlobal _container;
+
 
 _funcName = "CBA_fnc_removeItemCargo";
 LOG("Testing " + _funcName);
@@ -108,12 +142,16 @@ TEST_TRUE(count (itemCargo _container) == 2,_funcName);
 clearItemCargoGlobal _container;
 
 _container addItemCargoGlobal ["V_PlateCarrier1_rgr", 1];
-{
-    (_x select 1) addItemCargoGlobal ["FirstAidKit", 5];
-} forEach (everyContainer _container);
+(((everyContainer _container) select 0) select 1) addItemCargoGlobal ["FirstAidKit", 5];
 _container addItemCargoGlobal ["FirstAidKit", 5];
 _result = [_container, "FirstAidKit", 5] call CBA_fnc_removeItemCargo;
 TEST_TRUE(count (itemCargo _container) == 1 && count (itemCargo (((everyContainer _container) select 0) select 1)) == 5,_funcName);
+clearItemCargoGlobal _container;
+
+_container addItemCargoGlobal ["V_PlateCarrier1_rgr", 1];
+(((everyContainer _container) select 0) select 1) addItemCargoGlobal ["FirstAidKit", 5];
+_result = [_container, "V_PlateCarrier1_rgr", 1, true] call CBA_fnc_removeItemCargo;
+TEST_TRUE(count (itemCargo _container) == 5,_funcName);
 clearItemCargoGlobal _container;
 
 


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #725 in `removeWeaponCargo`, `removeItemCargo` and `removeBackpackCargo` functions - limitation being that removed attachments that are in preset will reappear (engine limitation)
- Add "keep attachments/contents" functionality (new argument) to `removeWeaponCargo`, `removeItemCargo` and `removeBackpackCargo` functions, default `false` (as it was before this)
- Add further unit tests for non-existing non-preset weapon parent issue and new "keep attachments/contents" functionality
