### PR TITLE
XEH compatibility for 1.76 classes

### DIFF
--- a/addons/xeh/CfgVehicles.hpp
+++ b/addons/xeh/CfgVehicles.hpp
@@ -361,4 +361,34 @@ class CfgVehicles {
     class Land_Laptop_02_unfolded_F: Land_Laptop_02_F {
         XEH_ENABLED;
     };
+
+    // Orange
+    class Land_Orange_01_Base_F;
+    class Land_Orange_01_F: Land_Orange_01_Base_F {
+        XEH_ENABLED;
+    };
+
+    class Land_Pumpkin_01_Base_F;
+    class Land_Pumpkin_01_F: Land_Pumpkin_01_Base_F {
+        XEH_ENABLED;
+    };
+
+    class B_G_Soldier_F;
+    class B_G_Story_Guerilla_01_F: B_G_Soldier_F {
+        XEH_ENABLED;
+    };
+
+    class I_officer_F;
+    class I_Story_Officer_01_F: I_officer_F {
+        XEH_ENABLED;
+    };
+
+    class C_IDAP_Man_EOD_01_F;
+    class C_Story_EOD_01_F: C_IDAP_Man_EOD_01_F {
+        XEH_ENABLED;
+    };
+
+    class C_Story_Mechanic_01_F: Civilian_F {
+        XEH_ENABLED;
+    };
 };

--- a/addons/xeh/config.cpp
+++ b/addons/xeh/config.cpp
@@ -7,7 +7,7 @@ class CfgPatches {
         url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};
-        requiredAddons[] = {"A3_Data_F","A3_Characters_F","A3_Air_F","A3_Armor_F","A3_Boat_F","A3_Soft_F","A3_Air_F_Heli_Heli_Transport_04","A3_Characters_F_exp"};
+        requiredAddons[] = {"A3_Data_F","A3_Characters_F","A3_Air_F","A3_Armor_F","A3_Boat_F","A3_Soft_F","A3_Air_F_Heli_Heli_Transport_04","A3_Characters_F_exp","A3_Props_F_Argo","A3_Props_F_Orange","A3_Characters_F_Orange"};
         requiredVersion = 0.1;
         version = "4.0.0"; // Due to older mod versions requiring > 3,3,3 etc
         versionStr = "4.0.0";


### PR DESCRIPTION
**When merged this pull request will:**
- `A3_Props_F_Argo` is for `Land_Laptop_02_F` and was forgotten the last time...