### PR TITLE
Handle initPost EH added during PostInit

### DIFF
--- a/addons/xeh/fnc_addClassEventHandler.sqf
+++ b/addons/xeh/fnc_addClassEventHandler.sqf
@@ -73,7 +73,7 @@ _entities = _entities arrayIntersect _entities; // entities can return duplicate
 
             //Run initReto now if the unit has already been initialized
             if (_applyInitRetroactively && {ISINITIALIZED(_unit)}) then {
-                // If PostInit has not finisehd exit as it will be run via initPostStack
+                // If PostInit has not finished exit as it will be run via initPostStack
                 if ((_eventName == "initpost") && {!(SLX_XEH_MACHINE select 8)}) exitWith {};
                 [_unit] call _eventFunc;
             };

--- a/addons/xeh/fnc_addClassEventHandler.sqf
+++ b/addons/xeh/fnc_addClassEventHandler.sqf
@@ -73,6 +73,8 @@ _entities = _entities arrayIntersect _entities; // entities can return duplicate
 
             //Run initReto now if the unit has already been initialized
             if (_applyInitRetroactively && {ISINITIALIZED(_unit)}) then {
+                // If PostInit has not finisehd exit as it will be run via initPostStack
+                if ((_eventName == "initpost") && {!(SLX_XEH_MACHINE select 8)}) exitWith {};
                 [_unit] call _eventFunc;
             };
         };


### PR DESCRIPTION
Should fix #567

Before:
PreInit Runs
Unit Init runs (unit gets initilized var set)
PostInit Starts
Adds InitPost EH to unit, which would run immediately (PROBLEM).
PostInit finishes by running through `GVAR(initPostStack)` and run all initPost EHs