### PR TITLE
remove watch field pause

### DIFF
--- a/addons/diagnostic/fnc_initExtendedDebugConsole.sqf
+++ b/addons/diagnostic/fnc_initExtendedDebugConsole.sqf
@@ -191,3 +191,14 @@ FUNC(nextStatement) = {
     _prevButton ctrlEnable (_statementIndex < count _prevStatements - 1);
     _nextButton ctrlEnable (_statementIndex > 0);
 };
+
+// remove forced pause for watch fields
+{
+    (_display displayCtrl _x) ctrlAddEventHandler ["SetFocus", {
+        _this spawn {
+            isNil {
+                (_this select 0) setVariable ["RscDebugConsole_watchPaused", false];
+            };
+        };
+    }];
+} forEach [IDC_RSCDEBUGCONSOLE_WATCHINPUT1, IDC_RSCDEBUGCONSOLE_WATCHINPUT2, IDC_RSCDEBUGCONSOLE_WATCHINPUT3, IDC_RSCDEBUGCONSOLE_WATCHINPUT4];


### PR DESCRIPTION
**When merged this pull request will:**
- removes the very frustrating pause when the focus is set on the watch fields input lines, which is a thing now in 1.76