### PR TITLE
fix error popup without other addons using settings

### DIFF
--- a/addons/settings/fnc_gui_addonChanged.sqf
+++ b/addons/settings/fnc_gui_addonChanged.sqf
@@ -8,6 +8,9 @@ private _display = ctrlParent _control;
 
 private _selectedAddon = _display getVariable (_control lbData _index);
 
+// fix error when no addons present
+if (isNil "_selectedAddon") exitWith {};
+
 if (_selectedAddon isEqualType "") then {
     uiNamespace setVariable [QGVAR(addon), _selectedAddon];
 };


### PR DESCRIPTION
**When merged this pull request will:**
- fix this:

![http://i.imgur.com/XNcIeuV.jpg](http://i.imgur.com/XNcIeuV.jpg)
You won't ever see this with ACE, because it's caused by the listbox being empty.