### PR TITLE
reenable debug console in Arsenal

### DIFF
--- a/addons/diagnostic/CfgFunctions.hpp
+++ b/addons/diagnostic/CfgFunctions.hpp
@@ -50,4 +50,11 @@ class CfgFunctions
             };
         };
     };
+    class A3 {
+        class Debug {
+            class isDebugConsoleAllowed {
+                file = PATHTOF(fnc_isDebugConsoleAllowed.sqf);
+            };
+        };
+    };
 };

--- a/addons/diagnostic/Scenarios/Arsenal.VR/description.ext
+++ b/addons/diagnostic/Scenarios/Arsenal.VR/description.ext
@@ -1,3 +1,0 @@
-#include "\A3\Missions_F_Bootcamp\Scenarios\Arsenal.VR\description.ext"
-
-enableDebugConsole = 2;

--- a/addons/diagnostic/Scenarios/Arsenal.VR/fn_closed.sqf
+++ b/addons/diagnostic/Scenarios/Arsenal.VR/fn_closed.sqf
@@ -1,1 +1,0 @@
-#include "\A3\Missions_F_Bootcamp\Scenarios\Arsenal.VR\fn_closed.sqf"

--- a/addons/diagnostic/Scenarios/Arsenal.VR/fn_createTarget.sqf
+++ b/addons/diagnostic/Scenarios/Arsenal.VR/fn_createTarget.sqf
@@ -1,1 +1,0 @@
-#include "\A3\Missions_F_Bootcamp\Scenarios\Arsenal.VR\fn_createTarget.sqf"

--- a/addons/diagnostic/Scenarios/Arsenal.VR/fn_onPauseScript.sqf
+++ b/addons/diagnostic/Scenarios/Arsenal.VR/fn_onPauseScript.sqf
@@ -1,1 +1,0 @@
-#include "\A3\Missions_F_Bootcamp\Scenarios\Arsenal.VR\fn_onPauseScript.sqf"

--- a/addons/diagnostic/Scenarios/Arsenal.VR/fn_opened.sqf
+++ b/addons/diagnostic/Scenarios/Arsenal.VR/fn_opened.sqf
@@ -1,1 +1,0 @@
-#include "\A3\Missions_F_Bootcamp\Scenarios\Arsenal.VR\fn_opened.sqf"

--- a/addons/diagnostic/Scenarios/Arsenal.VR/init.sqf
+++ b/addons/diagnostic/Scenarios/Arsenal.VR/init.sqf
@@ -1,1 +1,0 @@
-#include "\A3\Missions_F_Bootcamp\Scenarios\Arsenal.VR\init.sqf"

--- a/addons/diagnostic/Scenarios/Arsenal.VR/mission.sqm
+++ b/addons/diagnostic/Scenarios/Arsenal.VR/mission.sqm
@@ -1,1 +1,0 @@
-#include "\A3\Missions_F_Bootcamp\Scenarios\Arsenal.VR\mission.sqm"

--- a/addons/diagnostic/config.cpp
+++ b/addons/diagnostic/config.cpp
@@ -7,7 +7,7 @@ class CfgPatches {
         url = "$STR_CBA_URL";
         units[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"CBA_common","CBA_events","3DEN","A3_Missions_F"};
+        requiredAddons[] = {"CBA_common","CBA_events","3DEN","A3_Functions_F"};
         version = VERSION;
         authors[] = {"Spooner","Sickboy"};
     };

--- a/addons/diagnostic/fnc_isDebugConsoleAllowed.sqf
+++ b/addons/diagnostic/fnc_isDebugConsoleAllowed.sqf
@@ -1,0 +1,8 @@
+#include "script_component.hpp"
+
+// enable debug console in virtual arsenal
+if (str missionConfigFile == "A3\Missions_F_Bootcamp\Scenarios\Arsenal.VR\description.ext") exitWith {true};
+
+call {
+    #include "\a3\functions_f\Debug\fn_isDebugConsoleAllowed.sqf";
+};

--- a/addons/diagnostic/gui.hpp
+++ b/addons/diagnostic/gui.hpp
@@ -25,27 +25,6 @@ class RscTitles {
     };
 };
 
-// debug console in virtual arsenal
-class RscControlsGroupNoScrollbars;
-
-class RscStandardDisplay;
-class RscDisplayMain: RscStandardDisplay {
-    class controls {
-        class GroupSingleplayer: RscControlsGroupNoScrollbars {
-            class Controls;
-        };
-
-        class GroupTutorials: GroupSingleplayer {
-            class Controls: Controls {
-                class Bootcamp;
-                class Arsenal: Bootcamp {
-                    onButtonClick = QUOTE(playMission [ARR_2('','PATHTOF(Scenarios\Arsenal.VR)')]);
-                };
-            };
-        };
-    };
-};
-
 class RscEdit;
 class GVAR(watchInput): RscEdit {
     autocomplete = "scripting";


### PR DESCRIPTION
**When merged this pull request will:**

1.76 broke our hack for getting the debug console into the SP Arsenal. The description.ext is now only checked in MP, because who cares about consistency and elegant coding for that matter.
Work-around is to hijack `BIS_fnc_isDebugConsoleAllowed`. It's not as nice of a work-around, but less likely to break should they add or remove files from the Arsenal mission.
