### PR TITLE
Fix header of getNonPresetClass - does not requires lower-cased classname

### DIFF
--- a/addons/common/fnc_getNonPresetClass.sqf
+++ b/addons/common/fnc_getNonPresetClass.sqf
@@ -5,7 +5,7 @@ Description:
     Get ancestor class of a weapon or container which has no preset attachments/contents.
 
 Parameters:
-    _item       - Lower-cased classname of weapon/container <STRING>
+    _item       - Classname of weapon/container <STRING>
     _configRoot - Root config ("CfgWeapons", "CfgVehicles", ...) <STRING> (Default: "CfgWeapons")
 
 Returns:


### PR DESCRIPTION
**When merged this pull request will:**
- Title
