### PR TITLE
Fix CBA_fnc_weaponComponents script error and parent search and CBA_fnc_removeXCargo magazine readding

### DIFF
--- a/addons/common/fnc_removeBackpackCargo.sqf
+++ b/addons/common/fnc_removeBackpackCargo.sqf
@@ -107,18 +107,10 @@ private _fnc_addContents = {
 
         // If weapon does not have a non-preset parent, only add attachments that were custom added
         // Removed attachments cannot be handled (engine limitation) and will be readded due to having to readd preset weapon
-
         private _presetAttachments = [];
         if (_weaponNonPreset == _weapon) then {
             _presetAttachments = _weapon call CBA_fnc_weaponComponents;
-        } else {
-            _magazine params [["_magazineClass", ""], ["_magazineAmmoCount", ""]];
-            _container addMagazineAmmoCargo [_magazineClass, 1, _magazineAmmoCount];
-
-            _magazineGL params [["_magazineGLClass", ""], ["_magazineGLAmmoCount", ""]];
-            _container addMagazineAmmoCargo [_magazineGLClass, 1, _magazineGLAmmoCount];
         };
-
         if !(toLower _muzzle in _presetAttachments) then {
             _container addItemCargoGlobal [_muzzle, 1];
         };
@@ -130,6 +122,16 @@ private _fnc_addContents = {
         };
         if !(toLower _bipod in _presetAttachments) then {
             _container addItemCargoGlobal [_bipod, 1];
+        };
+
+        _magazine params [["_magazineClass", ""], ["_magazineAmmoCount", 0]];
+        if (_magazineClass != "") then {
+            _container addMagazineAmmoCargo [_magazineClass, 1, _magazineAmmoCount];
+        };
+
+        _magazineGL params [["_magazineGLClass", ""], ["_magazineGLAmmoCount", 0]];
+        if (_magazineGLClass != "") then {
+            _container addMagazineAmmoCargo [_magazineGLClass, 1, _magazineGLAmmoCount];
         };
     } forEach _weaponsItemsCargo;
 };

--- a/addons/common/fnc_removeItemCargo.sqf
+++ b/addons/common/fnc_removeItemCargo.sqf
@@ -115,18 +115,10 @@ private _fnc_addContents = {
 
         // If weapon does not have a non-preset parent, only add attachments that were custom added
         // Removed attachments cannot be handled (engine limitation) and will be readded due to having to readd preset weapon
-
         private _presetAttachments = [];
         if (_weaponNonPreset == _weapon) then {
             _presetAttachments = _weapon call CBA_fnc_weaponComponents;
-        } else {
-            _magazine params [["_magazineClass", ""], ["_magazineAmmoCount", ""]];
-            _container addMagazineAmmoCargo [_magazineClass, 1, _magazineAmmoCount];
-
-            _magazineGL params [["_magazineGLClass", ""], ["_magazineGLAmmoCount", ""]];
-            _container addMagazineAmmoCargo [_magazineGLClass, 1, _magazineGLAmmoCount];
         };
-
         if !(toLower _muzzle in _presetAttachments) then {
             _container addItemCargoGlobal [_muzzle, 1];
         };
@@ -138,6 +130,16 @@ private _fnc_addContents = {
         };
         if !(toLower _bipod in _presetAttachments) then {
             _container addItemCargoGlobal [_bipod, 1];
+        };
+
+        _magazine params [["_magazineClass", ""], ["_magazineAmmoCount", 0]];
+        if (_magazineClass != "") then {
+            _container addMagazineAmmoCargo [_magazineClass, 1, _magazineAmmoCount];
+        };
+
+        _magazineGL params [["_magazineGLClass", ""], ["_magazineGLAmmoCount", 0]];
+        if (_magazineGLClass != "") then {
+            _container addMagazineAmmoCargo [_magazineGLClass, 1, _magazineGLAmmoCount];
         };
     } forEach _weaponsItemsCargo;
 };

--- a/addons/common/fnc_removeWeaponCargo.sqf
+++ b/addons/common/fnc_removeWeaponCargo.sqf
@@ -92,29 +92,25 @@ clearWeaponCargoGlobal _container;
             _container addItemCargoGlobal [_optic, 1];
             _container addItemCargoGlobal [_bipod, 1];
 
-            _magazine params [["_magazineClass", ""], ["_magazineAmmoCount", ""]];
-            _container addMagazineAmmoCargo [_magazineClass, 1, _magazineAmmoCount];
+            _magazine params [["_magazineClass", ""], ["_magazineAmmoCount", 0]];
+            if (_magazineClass != "") then {
+                _container addMagazineAmmoCargo [_magazineClass, 1, _magazineAmmoCount];
+            };
 
-            _magazineGL params [["_magazineGLClass", ""], ["_magazineGLAmmoCount", ""]];
-            _container addMagazineAmmoCargo [_magazineGLClass, 1, _magazineGLAmmoCount];
+            _magazineGL params [["_magazineGLClass", ""], ["_magazineGLAmmoCount", 0]];
+            if (_magazineGLClass != "") then {
+                _container addMagazineAmmoCargo [_magazineGLClass, 1, _magazineGLAmmoCount];
+            };
         };
     } else {
         _container addWeaponCargoGlobal [_weaponNonPreset, 1];
 
         // If weapon does not have a non-preset parent, only add attachments that were custom added
         // Removed attachments cannot be handled (engine limitation) and will be readded due to having to readd preset weapon
-
         private _presetAttachments = [];
         if (_weaponNonPreset == _weapon) then {
             _presetAttachments = _weapon call CBA_fnc_weaponComponents;
-        } else {
-            _magazine params [["_magazineClass", ""], ["_magazineAmmoCount", ""]];
-            _container addMagazineAmmoCargo [_magazineClass, 1, _magazineAmmoCount];
-
-            _magazineGL params [["_magazineGLClass", ""], ["_magazineGLAmmoCount", ""]];
-            _container addMagazineAmmoCargo [_magazineGLClass, 1, _magazineGLAmmoCount];
         };
-
         if !(toLower _muzzle in _presetAttachments) then {
             _container addItemCargoGlobal [_muzzle, 1];
         };
@@ -126,6 +122,16 @@ clearWeaponCargoGlobal _container;
         };
         if !(toLower _bipod in _presetAttachments) then {
             _container addItemCargoGlobal [_bipod, 1];
+        };
+
+        _magazine params [["_magazineClass", ""], ["_magazineAmmoCount", 0]];
+        if (_magazineClass != "") then {
+            _container addMagazineAmmoCargo [_magazineClass, 1, _magazineAmmoCount];
+        };
+
+        _magazineGL params [["_magazineGLClass", ""], ["_magazineGLAmmoCount", 0]];
+        if (_magazineGLClass != "") then {
+            _container addMagazineAmmoCargo [_magazineGLClass, 1, _magazineGLAmmoCount];
         };
     };
 } forEach _weaponsItemsCargo;

--- a/addons/common/fnc_weaponComponents.sqf
+++ b/addons/common/fnc_weaponComponents.sqf
@@ -37,8 +37,10 @@ private _components = GVAR(weaponComponentsCache) getVariable _weapon;
 if (isNil "_components") then {
     private _config = configfile >> "CfgWeapons" >> _weapon;
 
-    // return empty array if the weapon doesn't exist
-    if (!isClass _config) exitWith {[]};
+    // Return empty array if the weapon doesn't exist
+    if (!isClass _config) exitWith {
+        _components = [];
+    };
 
     // get attachments
     private _attachments = [];

--- a/addons/common/fnc_weaponComponents.sqf
+++ b/addons/common/fnc_weaponComponents.sqf
@@ -48,7 +48,7 @@ if (isNil "_components") then {
 
     // get first parent without attachments
     private _baseWeapon = "";
-    while {isClass _config && {getNumber (_config >> "scope") == 2}} do {
+    while {isClass _config && {getNumber (_config >> "scope") > 0}} do { // Some preset weapons are scope = 1
         if (count (_config >> "LinkedItems") == 0) exitWith {
             _baseWeapon = configName _config;
         };

--- a/addons/common/test_inventory.sqf
+++ b/addons/common/test_inventory.sqf
@@ -97,7 +97,7 @@ clearBackpackCargoGlobal _container;
 _container addBackpackCargoGlobal ["B_AssaultPack_mcamo_Ammo", 1];
 _result = [_container, "B_AssaultPack_mcamo_Ammo", 1, true] call CBA_fnc_removeBackpackCargo;
 TEST_TRUE(_result,_funcName);
-TEST_TRUE(count (backpackCargo _container) == 0 && count (itemCargo _container) == 4 && count (magazineCargo _container) == 20,_funcName);
+TEST_TRUE(count (backpackCargo _container) == 0 && count (itemCargo _container) == 4 && count (magazineCargo _container) == 19,_funcName);
 clearBackpackCargoGlobal _container;
 clearItemCargoGlobal _container;
 clearMagazineCargoGlobal _container;

--- a/addons/common/test_weaponComponents.sqf
+++ b/addons/common/test_weaponComponents.sqf
@@ -1,11 +1,12 @@
+// 0 spawn compile preprocessFileLineNumbers "\x\cba\addons\common\test_weaponComponents.sqf";
 
 #define LOGF diag_log text format
 #define TESTEXP if (!isNil "_result" && {_result isEqualTo _expected}) then {LOGF ["TEST: OK - %1 result", _result]} else {LOGF ["TEST: FAIL - %1 result; %2 expected", _result, _expected]}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-_fnc_name = "CBA_fnc_weaponComponents";
-_fnc = call compile _fnc_name;
+private _fnc_name = "CBA_fnc_weaponComponents";
+private _fnc = call compile _fnc_name;
 
 LOGF ["========== TEST ========== - %1 -", _fnc_name];
 if (!isNil "_fnc") then {LOGF ["TEST: OK - %1 defined", _fnc_name]} else {LOGF ["TEST: FAIL - %1 undefined"]};
@@ -24,6 +25,10 @@ TESTEXP;
 
 _result = ["arifle_MXM_DMS_LP_BI_snds_F"] call _fnc;
 _expected = ["arifle_mxm_f","optic_dms","acc_pointer_ir","bipod_01_f_snd","muzzle_snds_h"];
+TESTEXP;
+
+_result = ["arifle_ARX_ghex_ARCO_Pointer_Snds_F"] call _fnc; // scope = 1
+_expected = ["arifle_arx_ghex_f","optic_arco_ghex_f","acc_pointer_ir","muzzle_snds_65_ti_ghex_f"];
 TESTEXP;
 
 _result = "arifle_MXC_Black_F" call _fnc;


### PR DESCRIPTION
**When merged this pull request will:**
- Fix `CBA_fnc_weaponComponents` non-preset parent search (in cases where scope is not 2 on any parent)
- Fix `CBA_fnc_weaponComponents` script error if weapon does not exist (last test)
- Fix `CBA_fnc_removeXCargo` magazine readding on non-preset weapons
- Fix `CBA_fnc_removeXCargo` magazine readding trying to use empty class (`""`) and throwing a pop-up error
- Fix `CBA_fnc_removeWeaponCargo` test (it seems that backpack changed in 1.76 and now has 19 magazines instead of 20)