### PR TITLE
remove FlagChecked_F XEH_ENABLED

### DIFF
--- a/addons/xeh/CfgVehicles.hpp
+++ b/addons/xeh/CfgVehicles.hpp
@@ -149,11 +149,6 @@ class CfgVehicles {
         XEH_ENABLED;
     };
 
-    class FlagCarrierCore;
-    class FlagChecked_F: FlagCarrierCore {
-        XEH_ENABLED;
-    };
-
     class ThingX;
     class ReammoBox_F: ThingX {
         XEH_ENABLED;


### PR DESCRIPTION
There are 42 flags in the base game. They are `Static`, so they have XEH disabled. This one has it enabled and I have no idea what I was thinking. There is nothing different about this one compared to the others. Makes no sense, so get rid of it.