### PR TITLE
Use RscXListBox for target debug selection

### DIFF
--- a/addons/diagnostic/fnc_initTargetDebugConsole.sqf
+++ b/addons/diagnostic/fnc_initTargetDebugConsole.sqf
@@ -54,7 +54,8 @@ _targetWatchText ctrlCommit 0;
 
 
 // Add target selector list
-private _clientList = _display ctrlCreate ["RscCombo", -1, _debugConsole];
+private _clientList = _display ctrlCreate ["RscXListBox", -1, _debugConsole];
+// Note: RscCombo is a better choice for this, but seems to have stopped working with 1.76, try to switch back in the future
 _clientList ctrlSetPosition _basePosition;
 _clientList ctrlCommit 0;
 _basePosition set [1, (_basePosition select 1) + 1.5 * GUI_GRID_H];


### PR DESCRIPTION
Fix #752

![image](https://user-images.githubusercontent.com/9376747/30891026-21cfa5b4-a2f6-11e7-86cf-bfed94f1d867.png)

With a lot of people this will be worse because you have to click through each machine.
But it was really only designed for dev small scale testing (2-3 machines) and in that case it's actually faster than the drop down menu.