### PR TITLE
Add: Return random position in a desired direction +- an angle

### DIFF
--- a/addons/common/fnc_randPos.sqf
+++ b/addons/common/fnc_randPos.sqf
@@ -5,8 +5,10 @@ Description:
     A function used to randomize a position around a given center
 
 Parameters:
-    _position - <MARKER, OBJECT, LOCATION, GROUP, TASK or POSITION>
-    _radius   - random Radius <NUMBER>
+    _position  - <MARKER, OBJECT, LOCATION, GROUP, TASK or POSITION>
+    _radius    - random Radius <NUMBER>
+    _direction - randomization direction (optional, default: 0) <NUMBER>
+    _spreading - spreading around direction (optional, default: 360) <NUMBER>
 
 Example:
     (begin example)
@@ -26,13 +28,13 @@ params [
     ["_entity", objNull, [objNull, grpNull, "", locationNull, taskNull, []]],
     ["_radius", 0, [0]],
     ["_direction", 0, [0]],
-    ["_amplitude", 360, [0]]
+    ["_spreading", 360, [0]]
 ];
 
 private _position = _entity call CBA_fnc_getPos;
 private _doResize = _position isEqualTypeArray [0,0];
 
-_position = _position getPos [_radius * sqrt random 1, _direction - 0.5*_amplitude + random _amplitude];
+_position = _position getPos [_radius * sqrt random 1, _direction - 0.5*_spreading + random _spreading];
 
 if (_doResize) then {
     _position resize 2;

--- a/addons/common/fnc_randPos.sqf
+++ b/addons/common/fnc_randPos.sqf
@@ -8,7 +8,7 @@ Parameters:
     _position  - <MARKER, OBJECT, LOCATION, GROUP, TASK or POSITION>
     _radius    - random Radius <NUMBER>
     _direction - randomization direction (optional, default: 0) <NUMBER>
-    _spreading - spreading around direction (optional, default: 360) <NUMBER>
+    _angle     - the angle of the circular arc in which the random position will end up. (optional, default: 360) <NUMBER>
 
 Example:
     (begin example)
@@ -28,13 +28,13 @@ params [
     ["_entity", objNull, [objNull, grpNull, "", locationNull, taskNull, []]],
     ["_radius", 0, [0]],
     ["_direction", 0, [0]],
-    ["_spreading", 360, [0]]
+    ["_angle", 360, [0]]
 ];
 
 private _position = _entity call CBA_fnc_getPos;
 private _doResize = _position isEqualTypeArray [0,0];
 
-_position = _position getPos [_radius * sqrt random 1, _direction - 0.5*_spreading + random _spreading];
+_position = _position getPos [_radius * sqrt random 1, _direction - 0.5*_angle + random _angle];
 
 if (_doResize) then {
     _position resize 2;

--- a/addons/common/fnc_randPos.sqf
+++ b/addons/common/fnc_randPos.sqf
@@ -24,13 +24,15 @@ SCRIPT(randPos);
 
 params [
     ["_entity", objNull, [objNull, grpNull, "", locationNull, taskNull, []]],
-    ["_radius", 0, [0]]
+    ["_radius", 0, [0]],
+    ["_direction", 0, [0]],
+    ["_amplitude", 360, [0]]
 ];
 
 private _position = _entity call CBA_fnc_getPos;
 private _doResize = _position isEqualTypeArray [0,0];
 
-_position = _position getPos [_radius * sqrt random 1, random 360];
+_position = _position getPos [_radius * sqrt random 1, _direction - 0.5*_amplitude + random _amplitude];
 
 if (_doResize) then {
     _position resize 2;


### PR DESCRIPTION
Hello,
Now you can also search for a random position in a desired direction with a define amplitude.

Does it fit CBA ?

**When merged this pull request will:**
- Now you can also search for a random position in a desired direction with a define amplitude of angle (search in direction 100° with +- 25° angle of amplitude).
- `params` has been updated with optional parameter (default value search for a random position in the circle)
- `_direction - 0.5*_amplitude + random _amplitude` give the possibility to search in a direction with +- `_amplitude `
- Respect the [Submitting Content Guidelines](https://github.com/CBATeam/CBA_A3/wiki/Submitting%20content) --> tell me if anything is wrong 

Quick code to test the behavior with an exemple of the result: 
```
for "_i" from 1 to 1000 do { 
     private _direction = 100; 
     private _amplitude = 50; 
     private _pos = (getpos player) getPos [100*sqrt random 1 , _direction - 0.5*_amplitude + random _amplitude]; 
     deleteMarker str(_i); 
     private _marker = createmarker [str(_i), _pos]; 
     systemChat str(_pos); 
     str(_i) setMarkerSize [1,1]; 
     str(_i) setMarkerType "mil_dot"; 
     str(_i) setMarkerColor "ColorBlue"; 
     str(_i) setMarkerShape "ICON"; 
};
```
![107410_20171001005704_1](https://user-images.githubusercontent.com/14364400/31050286-0a856efe-a646-11e7-99a7-472393b0e841.png)


