### PR TITLE
Fix versioning error on dev branch

### DIFF
--- a/addons/main_a3/config.cpp
+++ b/addons/main_a3/config.cpp
@@ -19,7 +19,7 @@ class CfgSettings {
         class Versioning {
             class PREFIX {
                 class Dependencies {
-                    CBA[] = {"cba_main", { 1,0,0 },"(true)"};
+                    CBA[] = {"cba_main", { 1,0,0},"(true)"};
                 };
             };
         };


### PR DESCRIPTION
Dumb error on dev branch and it will probably be fixed before an actual release
but I don't see any harm in changing config now

Using build.py

`getArray (configfile >> "CfgSettings" >> "CBA" >> "Versioning" >> "cba" >> "dependencies" >> "CBA")`
["cba_main",[1,0,0],"(true)"] // Before
["cba_main",[1,0,"0 "],"(true)"] // After

No idea where the quotes are from, causes old version warning.