### PR TITLE
Show varName in setting tooltip

### DIFF
--- a/addons/settings/gui_createCategory.sqf
+++ b/addons/settings/gui_createCategory.sqf
@@ -32,6 +32,9 @@ private _lists = _display getVariable QGVAR(lists);
         if (isLocalized _tooltip) then {
             _tooltip = localize _tooltip;
         };
+        if (_tooltip != _setting) then { // Append setting name to bottom line
+            _tooltip = format ["%1\n%2",_tooltip, _setting];
+        };
 
         private _settingControlsGroups = [];
 


### PR DESCRIPTION
Not sure if we want this, but I think this is an improvement
The raw var name can help users understand what the setting is actually for if the displayName is short / unclear

![image](https://user-images.githubusercontent.com/9376747/32930711-e9101e36-cb25-11e7-93cd-d696436b547c.png)
