### PR TITLE
don't make mission automatically force default for global setting

### DIFF
--- a/addons/settings/fnc_gui_settingOverwrite.sqf
+++ b/addons/settings/fnc_gui_settingOverwrite.sqf
@@ -124,12 +124,17 @@ _ctrlOverwriteClient setVariable [QGVAR(state), cbChecked _ctrlOverwriteClient];
 
 // disable certain checkboxes
 if (_isGlobal > 0) then {
-    _ctrlOverwriteClient ctrlEnable false;
-    _ctrlOverwriteClient setVariable [QGVAR(enabled), false];
+    if (_source != "mission") then {
+        _ctrlOverwriteClient ctrlEnable false;
+        _ctrlOverwriteClient setVariable [QGVAR(enabled), false];
+    };
 
     if (_isGlobal > 1) then {
+        _ctrlOverwriteClient ctrlEnable false;
         _ctrlOverwriteClient ctrlSetPosition [0, 0, -1, -1];
         _ctrlOverwriteClient ctrlCommit 0;
+
+        _ctrlOverwriteClient setVariable [QGVAR(enabled), false];
 
         _ctrlOverwriteMission ctrlEnable false;
         _ctrlOverwriteMission ctrlSetPosition [0, 0, -1, -1];

--- a/addons/settings/fnc_parse.sqf
+++ b/addons/settings/fnc_parse.sqf
@@ -73,7 +73,7 @@ _result = [];
                 ERROR_2("Error parsing settings file. Value %1 is invalid for setting %2.",TO_STRING(_value),_setting);
             };
 
-            _priority = SANITIZE_PRIORITY(_setting,_priority);
+            _priority = SANITIZE_PRIORITY(_setting,_priority,"");
             _result pushBack [_setting, _value, _priority];
         };
     };

--- a/addons/settings/fnc_priority.sqf
+++ b/addons/settings/fnc_priority.sqf
@@ -23,15 +23,15 @@ params [["_setting", "", [""]], ["_source", "priority", [""]]];
 switch (toLower _source) do {
     case "client": {
         private _priority = GVAR(client)  getVariable [_setting, [nil, 0]] select 1;
-        SANITIZE_PRIORITY(_setting,_priority) min 0
+        SANITIZE_PRIORITY(_setting,_priority,_source) min 0
     };
     case "mission": {
         private _priority = GVAR(mission) getVariable [_setting, [nil, 0]] select 1;
-        SANITIZE_PRIORITY(_setting,_priority) min 1
+        SANITIZE_PRIORITY(_setting,_priority,_source) min 1
     };
     case "server": {
         private _priority = GVAR(server)  getVariable [_setting, [nil, 0]] select 1;
-        SANITIZE_PRIORITY(_setting,_priority) min 2
+        SANITIZE_PRIORITY(_setting,_priority,_source) min 2
     };
     case "priority": {
         private _arr = [

--- a/addons/settings/script_component.hpp
+++ b/addons/settings/script_component.hpp
@@ -136,9 +136,9 @@
 #define IS_GLOBAL_SETTING(setting) (GVAR(default) getVariable [setting, []] param [7, 0] == 1)
 #define IS_LOCAL_SETTING(setting)  (GVAR(default) getVariable [setting, []] param [7, 0] == 2)
 
-#define SANITIZE_PRIORITY(setting,priority) (call {\
+#define SANITIZE_PRIORITY(setting,priority,source) (call {\
     private priority = [0,1,2] select priority;\
-    if IS_GLOBAL_SETTING(setting) exitWith {priority max 1};\
-    if IS_LOCAL_SETTING(setting)  exitWith {priority min 0};\
+    if (IS_GLOBAL_SETTING(setting) && {source != "mission"}) exitWith {priority max 1};\
+    if (IS_LOCAL_SETTING(setting)) exitWith {priority min 0};\
     priority\
 })


### PR DESCRIPTION
**When merged this pull request will:**
- instead enable the checkbox to be toggled (while unchecking it by default) / force keyword