### PR TITLE
settings tooltip, don't put a newline as first character

### DIFF
--- a/addons/settings/gui_createCategory.sqf
+++ b/addons/settings/gui_createCategory.sqf
@@ -33,7 +33,11 @@ private _lists = _display getVariable QGVAR(lists);
             _tooltip = localize _tooltip;
         };
         if (_tooltip != _setting) then { // Append setting name to bottom line
-            _tooltip = format ["%1\n%2",_tooltip, _setting];
+            if (_tooltip isEqualTo "") then {
+                _tooltip = _setting;
+            } else {
+                _tooltip = format ["%1\n%2", _tooltip, _setting];
+            };
         };
 
         private _settingControlsGroups = [];


### PR DESCRIPTION
**When merged this pull request will:**
- avoids: ![https://i.imgur.com/21y7HZV.png](https://i.imgur.com/21y7HZV.png)