### PR TITLE
Add CBA_loadingScreenDone event

### DIFF
--- a/addons/xeh/CfgFunctions.hpp
+++ b/addons/xeh/CfgFunctions.hpp
@@ -66,5 +66,13 @@ class CfgFunctions {
                 file = PATHTOF(fnc_initDisplay.sqf);
             };
         };
+        class Misc {
+            class startLoadingScreen {
+                file = PATHTOF(fnc_startLoadingScreen.sqf);
+            };
+            class endLoadingScreen {
+                file = PATHTOF(fnc_endLoadingScreen.sqf);
+            };
+        };
     };
 };

--- a/addons/xeh/fnc_endLoadingScreen.sqf
+++ b/addons/xeh/fnc_endLoadingScreen.sqf
@@ -5,7 +5,7 @@ private _return = call {
 };
 
 isNil {
-    ["CBA_LoadingScreenEnded", _this] call CBA_fnc_localEvent;
+    [QGVAR(LoadingScreenEnded), _this] call CBA_fnc_localEvent;
 };
 
-_return
+RETNIL(_return) //scheduler safe

--- a/addons/xeh/fnc_endLoadingScreen.sqf
+++ b/addons/xeh/fnc_endLoadingScreen.sqf
@@ -1,0 +1,11 @@
+#include "script_component.hpp"
+
+private _return = call {
+    #include "\a3\functions_f\Misc\fn_endLoadingScreen.sqf";
+};
+
+isNil {
+    ["CBA_LoadingScreenEnded", _this] call CBA_fnc_localEvent;
+};
+
+_return

--- a/addons/xeh/fnc_preInit.sqf
+++ b/addons/xeh/fnc_preInit.sqf
@@ -131,8 +131,35 @@ SLX_XEH_MACHINE set [7, true]; // PreInit passed
 
 #define DEBUG_MODE_FULL
 #ifdef DEBUG_MODE_FULL
-    ["CBA_LoadingScreenStarted", {diag_log ["CBA_LoadingScreenStarted", _this]}] call CBA_fnc_addEventHandler;
-    ["CBA_LoadingScreenEnded", {diag_log ["CBA_LoadingScreenEnded", _this]}] call CBA_fnc_addEventHandler;
+    [QGVAR(LoadingScreenStarted), {diag_log [QGVAR(LoadingScreenStarted), _this]}] call CBA_fnc_addEventHandler;
+    [QGVAR(LoadingScreenEnded), {diag_log [QGVAR(LoadingScreenEnded), _this]}] call CBA_fnc_addEventHandler;
+#endif
+
+// CBA_loadingScreenDone event
+GVAR(expectedLoadingScreens) = ["bis_fnc_preload", "bis_fnc_initRespawn"];
+
+if (!isServer) then { // only on client
+    GVAR(expectedLoadingScreens) pushBack "bis_fnc_initFunctions";
+};
+
+// check if this was the last loading screen, if so, fire event
+[QGVAR(LoadingScreenEnded), {
+    params ["_loadingScreen"];
+
+    if (!isNil QGVAR(expectedLoadingScreens)) then {
+        GVAR(expectedLoadingScreens) deleteAt (GVAR(expectedLoadingScreens) find _loadingScreen);
+
+        if (count GVAR(expectedLoadingScreens) == 0) then {
+            GVAR(expectedLoadingScreens) = nil;
+            ["CBA_loadingScreenDone", []] call CBA_fnc_localEvent;
+        };
+    };
+}] call CBA_fnc_addEventHandler;
+
+#ifdef DEBUG_MODE_FULL
+    ["CBA_loadingScreenDone", {
+        playSound "Beep_Target";
+    }] call CBA_fnc_addEventHandler;
 #endif
 
 XEH_LOG("XEH: PreInit finished.");

--- a/addons/xeh/fnc_preInit.sqf
+++ b/addons/xeh/fnc_preInit.sqf
@@ -129,4 +129,10 @@ GVAR(initPostStack) = [];
 
 SLX_XEH_MACHINE set [7, true]; // PreInit passed
 
+#define DEBUG_MODE_FULL
+#ifdef DEBUG_MODE_FULL
+    ["CBA_LoadingScreenStarted", {diag_log ["CBA_LoadingScreenStarted", _this]}] call CBA_fnc_addEventHandler;
+    ["CBA_LoadingScreenEnded", {diag_log ["CBA_LoadingScreenEnded", _this]}] call CBA_fnc_addEventHandler;
+#endif
+
 XEH_LOG("XEH: PreInit finished.");

--- a/addons/xeh/fnc_preInit.sqf
+++ b/addons/xeh/fnc_preInit.sqf
@@ -129,7 +129,6 @@ GVAR(initPostStack) = [];
 
 SLX_XEH_MACHINE set [7, true]; // PreInit passed
 
-#define DEBUG_MODE_FULL
 #ifdef DEBUG_MODE_FULL
     [QGVAR(LoadingScreenStarted), {diag_log [QGVAR(LoadingScreenStarted), _this]}] call CBA_fnc_addEventHandler;
     [QGVAR(LoadingScreenEnded), {diag_log [QGVAR(LoadingScreenEnded), _this]}] call CBA_fnc_addEventHandler;

--- a/addons/xeh/fnc_startLoadingScreen.sqf
+++ b/addons/xeh/fnc_startLoadingScreen.sqf
@@ -5,7 +5,7 @@ private _return = call {
 };
 
 isNil {
-    ["CBA_LoadingScreenStarted", _this] call CBA_fnc_localEvent;
+    [QGVAR(LoadingScreenStarted), _this] call CBA_fnc_localEvent;
 };
 
-_return
+RETNIL(_return) //scheduler safe

--- a/addons/xeh/fnc_startLoadingScreen.sqf
+++ b/addons/xeh/fnc_startLoadingScreen.sqf
@@ -1,0 +1,11 @@
+#include "script_component.hpp"
+
+private _return = call {
+    #include "\a3\functions_f\Misc\fn_startLoadingScreen.sqf";
+};
+
+isNil {
+    ["CBA_LoadingScreenStarted", _this] call CBA_fnc_localEvent;
+};
+
+_return


### PR DESCRIPTION
**When merged this pull request will:**
- title

I sometimes get asked if there is a way to execute code when Arma is done with the loading screen at the start of the mission. This PR adds a cba event for that by hooking into BI's internal framework for loading screens (`BIS_fnc_start/endLoadingScreen`).

There are up to 3 loading screens that happen at the start of the mission. `bis_fnc_preload`, `bis_fnc_initRespawn` and `bis_fnc_initFunctions`, named after the scripts that initiates them.
`bis_fnc_preload` is started before even preInit runs and it essentially makes clients wait for the server to load the mission first. It waits for a dummy public global variable to be synched.
`bis_fnc_initRespawn` sets up some kind of respawn screen, which is done even in SP surprisingly, and is for some insane reason done in scheduled environment (hence the need for a loading screen I guess).
`bis_fnc_initFunctions` makes the client wait for all postInit functions to be finished. But it only appears on dedicated clients, which is a very strange choice, because it means that someone could make an eternal loop in postInit stalling all other postInit scripts forever in SP. But it also means that the mission still ends the loading screen in SP if a script error occured which is helpful for debugging in some way - no need to kill the game (reminder that postInit CfgFunctions is scheduled).
There is no way to tell which of these finishes first, so we just wait for all 3.

During the mission there can be many more of course, but this event is only supposed to fire once. Perfect for mission intros etc.

I can't decide if the demand is there or if it would be bloat.

Note that the debug beep sound seems to happen right before the loading screen disappears. This is because the `endLoadingScreen` command BI uses makes it fade out slowly. The event is triggered when the loading screen starts fading.

WIP, because it has debug enabled.