### PR TITLE
1.78 - Fix XEH compatibiity with new modules

### DIFF
--- a/addons/xeh/CfgVehicles.hpp
+++ b/addons/xeh/CfgVehicles.hpp
@@ -50,6 +50,26 @@ class CfgVehicles {
         XEH_ENABLED;
     };
 
+    class Timeline_F: Module_F {
+        XEH_ENABLED;
+    };
+
+    class Curve_F: Module_F {
+        XEH_ENABLED;
+    };
+
+    class Key_F: Module_F {
+        XEH_ENABLED;
+    };
+
+    class ControlPoint_F: Module_F {
+        XEH_ENABLED;
+    };
+
+    class Camera_F: Module_F {
+        XEH_ENABLED;
+    };
+
     class Items_base_F;
     class Skeet_Clay_F: Items_base_F {
         XEH_ENABLED;


### PR DESCRIPTION
For current 1.78 RC
```
[XEH]: Timeline_F does not support Extended Event Handlers!
[XEH]: Curve_F does not support Extended Event Handlers!
[XEH]: Key_F does not support Extended Event Handlers!
[XEH]: ControlPoint_F does not support Extended Event Handlers!
[XEH]: Camera_F does not support Extended Event Handlers!
```