### PR TITLE
check 'overwrite clients' when changing a mission setting

### DIFF
--- a/addons/settings/fnc_gui_settingCheckbox.sqf
+++ b/addons/settings/fnc_gui_settingCheckbox.sqf
@@ -18,6 +18,9 @@ _ctrlCheckbox ctrlAddEventHandler ["CheckedChanged", {
     private _ctrlDefault = _controlsGroup controlsGroupCtrl IDC_SETTING_DEFAULT;
     private _defaultValue = [_setting, "default"] call FUNC(get);
     _ctrlDefault ctrlEnable !(_value isEqualTo _defaultValue);
+
+    // automatically check "overwrite client" for mission makers qol
+    [_controlsGroup, _source] call (_controlsGroup getVariable QFUNC(auto_check_overwrite));
 }];
 
 // set setting ui manually to new value

--- a/addons/settings/fnc_gui_settingColor.sqf
+++ b/addons/settings/fnc_gui_settingColor.sqf
@@ -38,6 +38,9 @@ for "_index" from 0 to ((count _currentValue max 3 min 4) - 1) do {
         private _ctrlDefault = _controlsGroup controlsGroupCtrl IDC_SETTING_DEFAULT;
         private _defaultValue = [_setting, "default"] call FUNC(get);
         _ctrlDefault ctrlEnable !(_currentValue isEqualTo _defaultValue);
+
+        // automatically check "overwrite client" for mission makers qol
+        [_controlsGroup, _source] call (_controlsGroup getVariable QFUNC(auto_check_overwrite));
     }];
 
     private _ctrlColorEdit = _controlsGroup controlsGroupCtrl (IDCS_SETTING_COLOR_EDIT select _index);
@@ -68,6 +71,9 @@ for "_index" from 0 to ((count _currentValue max 3 min 4) - 1) do {
         private _ctrlDefault = _controlsGroup controlsGroupCtrl IDC_SETTING_DEFAULT;
         private _defaultValue = [_setting, "default"] call FUNC(get);
         _ctrlDefault ctrlEnable !(_currentValue isEqualTo _defaultValue);
+
+        // automatically check "overwrite client" for mission makers qol
+        [_controlsGroup, _source] call (_controlsGroup getVariable QFUNC(auto_check_overwrite));
     }];
 
     _ctrlColorEdit ctrlAddEventHandler ["KillFocus", {

--- a/addons/settings/fnc_gui_settingEditbox.sqf
+++ b/addons/settings/fnc_gui_settingEditbox.sqf
@@ -36,6 +36,9 @@ _ctrlEditbox ctrlAddEventHandler ["KeyUp", {
     private _ctrlDefault = _controlsGroup controlsGroupCtrl IDC_SETTING_DEFAULT;
     private _defaultValue = [_setting, "default"] call FUNC(get);
     _ctrlDefault ctrlEnable !(_value isEqualTo _defaultValue);
+
+    // automatically check "overwrite client" for mission makers qol
+    [_controlsGroup, _source] call (_controlsGroup getVariable QFUNC(auto_check_overwrite));
 }];
 
 // set setting ui manually to new value

--- a/addons/settings/fnc_gui_settingList.sqf
+++ b/addons/settings/fnc_gui_settingList.sqf
@@ -34,6 +34,9 @@ _ctrlList ctrlAddEventHandler ["LBSelChanged", {
     private _ctrlDefault = _controlsGroup controlsGroupCtrl IDC_SETTING_DEFAULT;
     private _defaultValue = [_setting, "default"] call FUNC(get);
     _ctrlDefault ctrlEnable !(_value isEqualTo _defaultValue);
+
+    // automatically check "overwrite client" for mission makers qol
+    [_controlsGroup, _source] call (_controlsGroup getVariable QFUNC(auto_check_overwrite));
 }];
 
 // set setting ui manually to new value

--- a/addons/settings/fnc_gui_settingOverwrite.sqf
+++ b/addons/settings/fnc_gui_settingOverwrite.sqf
@@ -18,6 +18,10 @@ if !(_source isEqualTo "server") then {
 };
 
 _ctrlOverwriteClient ctrlAddEventHandler ["CheckedChanged", {
+    _this call ((_this select 0) getVariable QFUNC(event));
+}];
+
+_ctrlOverwriteClient setVariable [QFUNC(event), {
     params ["_ctrlOverwriteClient", "_state"];
     private _controlsGroup = ctrlParentControlsGroup _ctrlOverwriteClient;
     private _ctrlOverwriteMission = _controlsGroup controlsGroupCtrl IDC_SETTING_OVERWRITE_MISSION;
@@ -27,6 +31,19 @@ _ctrlOverwriteClient ctrlAddEventHandler ["CheckedChanged", {
     SET_TEMP_NAMESPACE_PRIORITY(_setting,_state,_source);
 
     _controlsGroup call (_controlsGroup getVariable QFUNC(updateUI_locked));
+}];
+
+_controlsGroup setVariable [QFUNC(auto_check_overwrite), {
+    params ["_controlsGroup", "_source"];
+
+    if (_source isEqualTo "mission") then {
+        private _ctrlOverwriteClient = _controlsGroup controlsGroupCtrl IDC_SETTING_OVERWRITE_CLIENT;
+
+        if (!cbChecked _ctrlOverwriteClient) then {
+            _ctrlOverwriteClient cbSetChecked true;
+            [_ctrlOverwriteClient, true] call (_ctrlOverwriteClient getVariable QFUNC(event));
+        };
+    };
 }];
 
 _ctrlOverwriteMission ctrlAddEventHandler ["CheckedChanged", {

--- a/addons/settings/fnc_gui_settingSlider.sqf
+++ b/addons/settings/fnc_gui_settingSlider.sqf
@@ -27,6 +27,9 @@ _ctrlSlider ctrlAddEventHandler ["SliderPosChanged", {
     private _ctrlDefault = _controlsGroup controlsGroupCtrl IDC_SETTING_DEFAULT;
     private _defaultValue = [_setting, "default"] call FUNC(get);
     _ctrlDefault ctrlEnable !(_value isEqualTo _defaultValue);
+
+    // automatically check "overwrite client" for mission makers qol
+    [_controlsGroup, _source] call (_controlsGroup getVariable QFUNC(auto_check_overwrite));
 }];
 
 private _ctrlSliderEdit = _controlsGroup controlsGroupCtrl IDC_SETTING_SLIDER_EDIT;
@@ -55,6 +58,9 @@ _ctrlSliderEdit ctrlAddEventHandler ["KeyUp", {
     private _ctrlDefault = _controlsGroup controlsGroupCtrl IDC_SETTING_DEFAULT;
     private _defaultValue = [_setting, "default"] call FUNC(get);
     _ctrlDefault ctrlEnable !(_value isEqualTo _defaultValue);
+
+    // automatically check "overwrite client" for mission makers qol
+    [_controlsGroup, _source] call (_controlsGroup getVariable QFUNC(auto_check_overwrite));
 }];
 
 _ctrlSliderEdit ctrlAddEventHandler ["KillFocus", {

--- a/addons/settings/script_component.hpp
+++ b/addons/settings/script_component.hpp
@@ -5,6 +5,7 @@
 #include "\a3\ui_f\hpp\defineCommonGrids.inc"
 #include "\a3\ui_f\hpp\defineResincl.inc"
 
+//#define DISABLE_COMPILE_CACHE
 //#define DEBUG_ENABLED_SETTINGS
 
 #ifdef DEBUG_ENABLED_SETTINGS


### PR DESCRIPTION
**When merged this pull request will:**
- title, if you change this for a mission, you probably want to apply the setting, not overwriting clients would mean the setting is useless.