### PR TITLE
fix v1.78 enum popup on xeh incompatible objects by fallback loop

### DIFF
--- a/addons/xeh/fnc_initEvents.sqf
+++ b/addons/xeh/fnc_initEvents.sqf
@@ -36,7 +36,7 @@ if !(ISPROCESSED(_unit)) then {
     if (!isClass _eventClass) then {
         {
             _unit addEventHandler [_x, format ['call FUNC(%1)', _x]];
-        } forEach [XEH_EVENTS];
+        } forEach ([XEH_EVENTS] - ["FiredBis", "InitPost"]);
     };
 
     while {isClass _class} do {


### PR DESCRIPTION
**When merged this pull request will:**
- Adding events that don't exist doesn't matter, except that it does now by creating that enum error. This PR makes it so we don't.
