### PR TITLE
pause game in SP when Addon Options menu is shown

### DIFF
--- a/addons/settings/gui.hpp
+++ b/addons/settings/gui.hpp
@@ -3,6 +3,10 @@ class RscControlsGroupNoScrollbars;
 class RscText;
 
 class RscDisplayGameOptions {
+    // pause game in SP while this menu is shown
+    // usually paused by other displays present for the vanilla options menu
+    enableSimulation = 0;
+
     class controls {
         class CBA_ButtonConfigureAddons: RscButtonMenu {
             idc = IDC_BTN_CONFIGURE_ADDONS;


### PR DESCRIPTION
**When merged this pull request will:**
- title

Noticed this while debugging a parachute related setting for ACE. The vanilla options menu pauses the game, while ours does not (it even resumes, because the esc menu itself pauses it).