### PR TITLE
fix issue with translated setting categories

### DIFF
--- a/addons/settings/fnc_initDisplayGameOptions.sqf
+++ b/addons/settings/fnc_initDisplayGameOptions.sqf
@@ -55,7 +55,12 @@ private _categories = [];
     (GVAR(default) getVariable _x) params ["", "", "", "", "_category"];
 
     if !(_category in _categories) then {
-        private _index = _ctrlAddonList lbAdd _category;
+        private _categoryLocalized = _category;
+        if (isLocalized _category) then {
+            _categoryLocalized = localize _category;
+        };
+
+        private _index = _ctrlAddonList lbAdd _categoryLocalized;
         _ctrlAddonList lbSetData [_index, str _index];
         _display setVariable [str _index, _category];
 

--- a/addons/settings/gui_createCategory.sqf
+++ b/addons/settings/gui_createCategory.sqf
@@ -21,10 +21,6 @@ private _lists = _display getVariable QGVAR(lists);
     (GVAR(default) getVariable _x) params ["_defaultValue", "_setting", "_settingType", "_settingData", "_category", "_displayName", "_tooltip", "_isGlobal"];
 
     if (_category == _selectedAddon) then {
-        if (isLocalized _category) then {
-            _category = localize _category;
-        };
-
         if (isLocalized _displayName) then {
             _displayName = localize _displayName;
         };


### PR DESCRIPTION
**When merged this pull request will:**
- fixes:
![https://i.imgur.com/h4pWvoI.png](https://i.imgur.com/h4pWvoI.png)

Bad logic broke settings in categories using stringkeys. The category would be translated **in the wrong place**, which causes it to appear untranslated in the ui and the setting would not be recognized either.