### PR TITLE
set focus on "configure base" button in keybinding menu after switching

### DIFF
--- a/addons/keybinding/fnc_gui_configure.sqf
+++ b/addons/keybinding/fnc_gui_configure.sqf
@@ -66,3 +66,5 @@ if !(ctrlShown _ctrlAddonsGroup) then {
     //--- change button text
     _ctrlToggleButton ctrlSetText localize LSTRING(configureAddons);
 };
+
+ctrlSetFocus _ctrlToggleButton;


### PR DESCRIPTION
**When merged this pull request will:**
- title, consistent with the settings menu

bug fix?