### PR TITLE
delete a unused config

### DIFF
--- a/addons/network/CfgSettings.hpp
+++ b/addons/network/CfgSettings.hpp
@@ -1,7 +1,0 @@
-class CfgSettings {
-    class CBA {
-        class COMPONENT {
-            disableGlobalExecute = 0;
-        };
-    };
-};

--- a/addons/network/config.cpp
+++ b/addons/network/config.cpp
@@ -15,4 +15,3 @@ class CfgPatches {
 };
 
 #include "CfgFunctions.hpp"
-#include "CfgSettings.hpp"


### PR DESCRIPTION
This doesn't work (anymore). There is no reason to bring it back, as `CBA_fnc_globalExecute` is now just a wrapper for `remoteExec BIS_fnc_call`, and that can already be disabled using: https://community.bistudio.com/wiki/CfgRemoteExec