### PR TITLE
Don't check inputAction if we have none bound

### DIFF
--- a/addons/events/XEH_preInit.sqf
+++ b/addons/events/XEH_preInit.sqf
@@ -30,6 +30,8 @@ ADDON = true;
 
 if (!hasInterface) exitWith {};
 
+GVAR(checkUserActions) = 0;
+
 // Display Event Handlers
 // Pressing "Restart" in the editor starts a completely new mission (preInit etc. are executed). The main display is never deleted though!
 // This would cause douplicate display events to be added, because the old ones carry over while the new ones are added again.

--- a/addons/events/XEH_preInit.sqf
+++ b/addons/events/XEH_preInit.sqf
@@ -30,7 +30,7 @@ ADDON = true;
 
 if (!hasInterface) exitWith {};
 
-GVAR(checkUserActions) = 0;
+GVAR(checkUserActions) = false;
 
 // Display Event Handlers
 // Pressing "Restart" in the editor starts a completely new mission (preInit etc. are executed). The main display is never deleted though!

--- a/addons/events/fnc_addKeyHandler.sqf
+++ b/addons/events/fnc_addKeyHandler.sqf
@@ -84,4 +84,10 @@ _hashKeys pushBackUnique _hashKey; // pushBackUnique. Fixes using addKeyHander t
 
 _keyHandlers set [_key, _hashKeys];
 
+if ((_key >= 0xFA) && {_key <= 0x10D}) then {
+    GVAR(checkUserActions) = GVAR(checkUserActions) + 1;
+    diag_log text format ["[CBA] UserAction Key [%1] added, GVAR(checkUserActions): %2", _key, GVAR(checkUserActions)];
+};
+
+
 _hashKey

--- a/addons/events/fnc_addKeyHandler.sqf
+++ b/addons/events/fnc_addKeyHandler.sqf
@@ -85,9 +85,11 @@ _hashKeys pushBackUnique _hashKey; // pushBackUnique. Fixes using addKeyHander t
 _keyHandlers set [_key, _hashKeys];
 
 if ((_key >= 0xFA) && {_key <= 0x10D}) then {
-    GVAR(checkUserActions) = GVAR(checkUserActions) + 1;
-    diag_log text format ["[CBA] UserAction Key [%1] added, GVAR(checkUserActions): %2", _key, GVAR(checkUserActions)];
-};
+    private _hasUserActionsBound = {count _x > 0} count (GVAR(keyDownStates) select [0xFA, 20]) > 0;
 
+    if (_hasUserActionsBound) then {
+        GVAR(checkUserActions) = true;
+    };
+};
 
 _hashKey

--- a/addons/events/fnc_removeKeyHandler.sqf
+++ b/addons/events/fnc_removeKeyHandler.sqf
@@ -61,8 +61,11 @@ if (count _keyHandlers > _key) then {
 };
 
 if ((_key >= 0xFA) && {_key <= 0x10D}) then {
-    GVAR(checkUserActions) = GVAR(checkUserActions) - 1;
-    diag_log text format ["[CBA] UserAction Key [%1] removed, GVAR(checkUserActions): %2", _key, GVAR(checkUserActions)];
+    private _hasUserActionsBound = {count _x > 0} count (GVAR(keyDownStates) select [0xFA, 20]) > 0;
+
+    if (!_hasUserActionsBound) then {
+        GVAR(checkUserActions) = false;
+    };
 };
 
 nil

--- a/addons/events/fnc_removeKeyHandler.sqf
+++ b/addons/events/fnc_removeKeyHandler.sqf
@@ -60,4 +60,9 @@ if (count _keyHandlers > _key) then {
     _keyHandlers set [_key, _hashKeys];
 };
 
+if ((_key >= 0xFA) && {_key <= 0x10D}) then {
+    GVAR(checkUserActions) = GVAR(checkUserActions) - 1;
+    diag_log text format ["[CBA] UserAction Key [%1] removed, GVAR(checkUserActions): %2", _key, GVAR(checkUserActions)];
+};
+
 nil

--- a/addons/events/fnc_userKeyHandler.sqf
+++ b/addons/events/fnc_userKeyHandler.sqf
@@ -9,7 +9,7 @@ Author:
 ---------------------------------------------------------------------------- */
 #include "script_component.hpp"
 
-if (GVAR(checkUserActions) == 0) exitWith {};
+if (!GVAR(checkUserActions)) exitWith {};
 
 params ["_display"];
 

--- a/addons/events/fnc_userKeyHandler.sqf
+++ b/addons/events/fnc_userKeyHandler.sqf
@@ -9,6 +9,8 @@ Author:
 ---------------------------------------------------------------------------- */
 #include "script_component.hpp"
 
+if (GVAR(checkUserActions) == 0) exitWith {};
+
 params ["_display"];
 
 private _userKeyStates = [


### PR DESCRIPTION
For #828 

Checking `cba_events_fnc_userKeyHandler` isn't that bad, but it still is 20x calls to inputAction
This skips those checks if we don't have any keys bound to userActions and makes that func call about 20 times faster