### PR TITLE
settings select client tab as logged admin by default

### DIFF
--- a/addons/settings/fnc_gui_configure.sqf
+++ b/addons/settings/fnc_gui_configure.sqf
@@ -74,14 +74,14 @@ if !(ctrlShown _ctrlAddonsGroup) then {
 
     //--- emulate default scope selection
     switch (true) do {
-        case CAN_SET_SERVER_SETTINGS: {
-            _ctrlServerButton call FUNC(gui_sourceChanged);
+        case CAN_SET_CLIENT_SETTINGS: {
+            _ctrlClientButton call FUNC(gui_sourceChanged);
         };
         case CAN_SET_MISSION_SETTINGS: {
             _ctrlMissionButton call FUNC(gui_sourceChanged);
         };
-        case CAN_SET_CLIENT_SETTINGS: {
-            _ctrlClientButton call FUNC(gui_sourceChanged);
+        case CAN_SET_SERVER_SETTINGS: {
+            _ctrlServerButton call FUNC(gui_sourceChanged);
         };
     };
 } else {


### PR DESCRIPTION
**When merged this pull request will:**
- title

If you're a logged in admin on a dedicated server, the client tab will be selected by default, not the server tab. This is so that @cyruz doesn't mess with everyone's view distance by accident mid mission.