### PR TITLE
Fix sliders for whole numbers

### DIFF
--- a/addons/settings/fnc_gui_settingSlider.sqf
+++ b/addons/settings/fnc_gui_settingSlider.sqf
@@ -19,7 +19,7 @@ _ctrlSlider ctrlAddEventHandler ["SliderPosChanged", {
 
     private _controlsGroup = ctrlParentControlsGroup _ctrlSlider;
     private _ctrlSliderEdit = _controlsGroup controlsGroupCtrl IDC_SETTING_SLIDER_EDIT;
-    _ctrlSliderEdit ctrlSetText ([_value, 1, _trailingDecimals] call CBA_fnc_formatNumber);
+    _ctrlSliderEdit ctrlSetText ([_value, 1, _trailingDecimals max 0] call CBA_fnc_formatNumber);
 
     SET_TEMP_NAMESPACE_VALUE(_setting,_value,_source);
 
@@ -33,7 +33,7 @@ _ctrlSlider ctrlAddEventHandler ["SliderPosChanged", {
 }];
 
 private _ctrlSliderEdit = _controlsGroup controlsGroupCtrl IDC_SETTING_SLIDER_EDIT;
-_ctrlSliderEdit ctrlSetText ([_currentValue, 1, _trailingDecimals] call CBA_fnc_formatNumber);
+_ctrlSliderEdit ctrlSetText ([_currentValue, 1, _trailingDecimals max 0] call CBA_fnc_formatNumber);
 
 _ctrlSliderEdit setVariable [QGVAR(params), [_setting, _source, _trailingDecimals]];
 _ctrlSliderEdit ctrlAddEventHandler ["KeyUp", {
@@ -76,7 +76,7 @@ _ctrlSliderEdit ctrlAddEventHandler ["KillFocus", {
         _value = round _value;
     };
 
-    _ctrlSliderEdit ctrlSetText ([_value, 1, _trailingDecimals] call CBA_fnc_formatNumber);
+    _ctrlSliderEdit ctrlSetText ([_value, 1, _trailingDecimals max 0] call CBA_fnc_formatNumber);
 
     // if new value is same as default value, grey out the default button
     private _ctrlDefault = _controlsGroup controlsGroupCtrl IDC_SETTING_DEFAULT;
@@ -93,7 +93,7 @@ _controlsGroup setVariable [QFUNC(updateUI), {
     private _ctrlSliderEdit = _controlsGroup controlsGroupCtrl IDC_SETTING_SLIDER_EDIT;
 
     _ctrlSlider sliderSetPosition _value;
-    _ctrlSliderEdit ctrlSetText ([_value, 1, _trailingDecimals] call CBA_fnc_formatNumber);
+    _ctrlSliderEdit ctrlSetText ([_value, 1, _trailingDecimals max 0] call CBA_fnc_formatNumber);
 
     // if new value is same as default value, grey out the default button
     private _ctrlDefault = _controlsGroup controlsGroupCtrl IDC_SETTING_DEFAULT;


### PR DESCRIPTION
`[3.14, 1, -2] call cba_fnc_formatNumber` = "003"
Could also fix in formatNumber?
Or we could switch to `toFixed` (`3.14 toFixed -1` = "3")