### PR TITLE
add space after list settings

### DIFF
--- a/addons/settings/gui.hpp
+++ b/addons/settings/gui.hpp
@@ -153,6 +153,14 @@ class GVAR(CheckboxSound): RscCheckBox {
     soundEscape[] = {"\a3\ui_f\data\Sound\RscButtonMenu\soundEscape",0.090000004,1};
 };
 
+class GVAR(Row_Empty): RscText {
+    GVAR(script) = "";
+    x = POS_W(1);
+    y = POS_H(0);
+    w = POS_W(37);
+    h = POS_H(0);
+};
+
 class GVAR(Row_Base): RscControlsGroupNoScrollbars {
     GVAR(script) = "";
     x = POS_W(1);

--- a/addons/settings/gui_createCategory.sqf
+++ b/addons/settings/gui_createCategory.sqf
@@ -1,18 +1,22 @@
 // inline function, don't include script_component.hpp
 
 private _fnc_controlSetTablePosY = {
-    params ["_control", "_tablePosY"];
+    params ["_control", "_tablePosY", "_height"];
 
     private _config = configFile >> ctrlClassName _control;
 
     private _posX = getNumber (_config >> "x");
     private _posY = getNumber (_config >> "y") + _tablePosY;
-    private _posH = getNumber (_config >> "h");
+    private _width = getNumber (_config >> "w");
 
-    _control ctrlSetPosition [_posX, _posY];
+    if (isNil "_height") then {
+        _height = getNumber (_config >> "h");
+    };
+
+    _control ctrlSetPosition [_posX, _posY, _width, _height];
     _control ctrlCommit 0;
 
-    _posY + _posH
+    _posY + _height
 };
 
 private _lists = _display getVariable QGVAR(lists);
@@ -89,6 +93,13 @@ private _lists = _display getVariable QGVAR(lists);
             private _tablePosY = _ctrlOptionsGroup getVariable [QGVAR(tablePosY), TABLE_LINE_SPACING/2];
             _tablePosY = [_ctrlSettingGroup, _tablePosY] call _fnc_controlSetTablePosY;
             _ctrlOptionsGroup setVariable [QGVAR(tablePosY), _tablePosY];
+
+            // ----- padding to make listboxes work
+            if (_settingType == "LIST") then {
+                private _ctrlEmpty = _display ctrlCreate [QGVAR(Row_Empty), IDC_SETTING_CONTROLS_GROUP, _ctrlOptionsGroup];
+                private _height = POS_H(count (_settingData select 0)) + TABLE_LINE_SPACING;
+                [_ctrlEmpty, _tablePosY, _height] call _fnc_controlSetTablePosY;
+            };
 
             // ----- set setting name
             private _ctrlSettingName = _ctrlSettingGroup controlsGroupCtrl IDC_SETTING_NAME;

--- a/addons/settings/script_component.hpp
+++ b/addons/settings/script_component.hpp
@@ -5,6 +5,7 @@
 #include "\a3\ui_f\hpp\defineCommonGrids.inc"
 #include "\a3\ui_f\hpp\defineResincl.inc"
 
+//#define DEBUG_MODE_FULL
 //#define DISABLE_COMPILE_CACHE
 //#define DEBUG_ENABLED_SETTINGS
 


### PR DESCRIPTION
**When merged this pull request will:**

Listbox items are not selectable if they are bigger than their controls group. This adds empty space after every listbox, so that the user can scroll down and make the items selectable.

![https://i.imgur.com/XlgAX7t.png](https://i.imgur.com/XlgAX7t.png)