### PR TITLE
let fleximenu fall back on cursorObject

### DIFF
--- a/addons/ui/flexiMenu/fnc_keyDown.sqf
+++ b/addons/ui/flexiMenu/fnc_keyDown.sqf
@@ -69,6 +69,7 @@ if (!GVAR(optionSelected) || !GVAR(holdKeyDown)) then {
             (group player) reveal _x;
         } forEach _objects;
         _potentialTarget = cursorTarget;
+        if (isNull _potentialTarget) then {_potentialTarget = cursorObject};
         if (!isNull _potentialTarget && {_potentialTarget distance player > _minObjDist(_potentialTarget)}) then {_potentialTarget = objNull};
         _vehicleTarget = vehicle player;
 

--- a/addons/ui/flexiMenu/fnc_openMenuByDef.sqf
+++ b/addons/ui/flexiMenu/fnc_openMenuByDef.sqf
@@ -45,6 +45,7 @@ if (!GVAR(optionSelected) || !GVAR(holdKeyDown)) then {
 
         // Get cursortarget.
         _potentialTarget = cursorTarget;
+        if (isNull _potentialTarget) then {_potentialTarget = cursorObject};
 
         // If the cursortarget is null and their are no object within the minObjDist,
         // there's no potential target (so _potentialTarget = objNull)


### PR DESCRIPTION
**When merged this pull request will:**
- close #348

`cursorTarget` is more generous when looking "around" the target. The cursor doesn't have to be right on the object. So only use `cursorObject` as a fallback method.