### PR TITLE
fix / deprecate CBA_fnc_isUnitGetOutAnim

### DIFF
--- a/addons/common/fnc_isUnitGetOutAnim.sqf
+++ b/addons/common/fnc_isUnitGetOutAnim.sqf
@@ -4,6 +4,8 @@ Function: CBA_fnc_isUnitGetOutAnim
 Description:
     Checks whether a unit is turned out in a vehicle or not.
 
+    DEPRECATED. Use isTurnedOut instead.
+
 Parameters:
     _unit - Unit to check [Object]
 
@@ -12,7 +14,7 @@ Returns:
 
 Examples:
     (begin example)
-        if ( [player] call CBA_fnc_isTurnedOut ) then
+        if ( [player] call CBA_fnc_isUnitGetOutAnim ) then
         {
             player sideChat "I am turned out!";
         };
@@ -21,21 +23,9 @@ Examples:
 Author:
     (c) Denisko-Redisko
 ---------------------------------------------------------------------------- */
-
 #include "script_component.hpp"
 SCRIPT(isUnitGetOutAnim);
-params ["_unit"];
-private [
-    "_animationState",
-    "_moves",
-    "_actions",
-    "_getOutAction",
-    "_getOutState"
-];
 
-_animationState = animationState _unit;
-_moves = configFile >> getText ( configFile >> "CfgVehicles" >> typeof _unit >> "moves" );
-_actions = _moves >> "Actions" >> getText( _moves >> "States" >> _animationState >> "actions" );
-_getOutAction = getText( configFile >> "CfgVehicles" >> typeof vehicle _unit >> "getOutAction" );
-_getOutState = getText ( _actions >> _getOutAction );
-_animationState == _getOutState;
+params ["_unit"];
+
+isTurnedOut _unit


### PR DESCRIPTION
**When merged this pull request will:**
- close #289
- use isTurnedOut instead

This no longer works in A3, especially after FFV. And it's not worth bringing back now that `isTurnedOut` exists.
Previously returned always `false`. After PR the result is the same as one would expect from this when used in A2 (report true for turned out units).