### PR TITLE
add description.ext entry to enable debug console in SP

### DIFF
--- a/addons/diagnostic/fnc_initExtendedDebugConsole.sqf
+++ b/addons/diagnostic/fnc_initExtendedDebugConsole.sqf
@@ -44,9 +44,23 @@ _expression ctrlCommit 0;
 
 // Save expression when hitting enter key inside expression text field
 _expression ctrlAddEventHandler ["KeyDown", {
-    params ["", "_key", "_shift"];
+    params ["_expression", "_key", "_shift"];
 
     if (_key in [DIK_RETURN, DIK_NUMPADENTER] && {!_shift}) then { // shift + enter is newline
+        // fix for enter key not working in MP
+        private _buttonLocalExec = ctrlParentControlsGroup _expression controlsGroupCtrl IDC_RSCDEBUGCONSOLE_BUTTONEXECUTELOCAL;
+
+        if (isMultiplayer && {ctrlEnabled _buttonLocalExec}) then {
+            [
+                "executeButton",
+                [ctrlParent _buttonLocalExec, _buttonLocalExec],
+                "RscDisplayDebugPublic",
+                0
+            ] call compile preprocessFileLineNumbers "\A3\Ui_f\scripts\GUI\RscDebugConsole.sqf";
+
+            playSound "SoundClick";
+        };
+
         _this call FUNC(logStatement);
     };
     false

--- a/addons/diagnostic/fnc_isDebugConsoleAllowed.sqf
+++ b/addons/diagnostic/fnc_isDebugConsoleAllowed.sqf
@@ -2,6 +2,7 @@
 
 // enable debug console in virtual arsenal
 if (str missionConfigFile == "A3\Missions_F_Bootcamp\Scenarios\Arsenal.VR\description.ext") exitWith {true};
+if (!isMultiplayer && {getNumber (missionConfigFile >> "enableDebugConsoleSP") == 1}) exitWith {true};
 
 call {
     #include "\a3\functions_f\Debug\fn_isDebugConsoleAllowed.sqf";

--- a/addons/diagnostic/fnc_removeUnitTrackProjectiles.sqf
+++ b/addons/diagnostic/fnc_removeUnitTrackProjectiles.sqf
@@ -1,5 +1,5 @@
 /* ----------------------------------------------------------------------------
-Function: CBA_removeUnitTrackProjectiles
+Function: CBA_fnc_removeUnitTrackProjectiles
 
 Description:
     Removes projectile tracking from a given unit or vehicle.
@@ -12,7 +12,7 @@ Returns:
 
 Examples:
     (begin example)
-        [vehicle player] call CBA_removeUnitTrackProjectiles;
+        [vehicle player] call CBA_fnc_removeUnitTrackProjectiles;
     (end)
 
 Author:


### PR DESCRIPTION
**When merged this pull request will:**
- Adds `enableDebugConsoleSP` mission config entry to work around the broken isDebugConsoleEnabled script always reporting false in single player
- Used in https://github.com/acemod/ACE3/pull/5953