### PR TITLE
Fixed missing waypointGarrison CfgFunctions entry

### DIFF
--- a/addons/ai/CfgFunctions.hpp
+++ b/addons/ai/CfgFunctions.hpp
@@ -8,6 +8,7 @@ class CfgFunctions {
             PATHTO_FNC(taskDefend);
             PATHTO_FNC(taskPatrol);
             PATHTO_FNC(taskSearchArea);
+            PATHTO_FNC(waypointGarrison);
         };
     };
 };


### PR DESCRIPTION
CBA_fnc_waypointGarrison was missing in cfgFunctions.

https://forums.bistudio.com/forums/topic/168277-cba-community-base-addons-arma-3/?page=46&tab=comments#comment-3258805

I don't see a reason to hide it from normal use as a function and have it be waypoint exclusive.