### PR TITLE
fix export dialog script error

### DIFF
--- a/addons/settings/fnc_export.sqf
+++ b/addons/settings/fnc_export.sqf
@@ -44,7 +44,7 @@ private _temp = [];
 
     if (_exportDefault || {
         !(_value isEqualTo _defaultValue) ||
-        _priority > [0,1] select IS_GLOBAL_SETTING(_setting)
+        SANITIZE_PRIORITY(_setting,_priority,_source) > SANITIZE_PRIORITY(_setting,0,_source)
     }) then {
         _temp pushBack [_category, _setting, _value, _priority];
     };

--- a/addons/settings/script_component.hpp
+++ b/addons/settings/script_component.hpp
@@ -147,8 +147,8 @@
 #define IS_LOCAL_SETTING(setting)  (GVAR(default) getVariable [setting, []] param [7, 0] == 2)
 
 #define SANITIZE_PRIORITY(setting,priority,source) (call {\
-    private priority = [0,1,2] select priority;\
-    if (IS_GLOBAL_SETTING(setting) && {source != "mission"}) exitWith {priority max 1};\
-    if (IS_LOCAL_SETTING(setting)) exitWith {priority min 0};\
-    priority\
+    private _priority = [0,1,2] select priority;\
+    if (IS_GLOBAL_SETTING(setting) && {source != "mission"}) exitWith {_priority max 1};\
+    if (IS_LOCAL_SETTING(setting)) exitWith {_priority min 0};\
+    _priority\
 })


### PR DESCRIPTION
**When merged this pull request will:**
- close #848
- by sanitizing boolean priority to number priority
- fix a bug where global settings would not show up, because it thought their default priority was 1, while it is still 0 for the mission source; which requires:
- change macro weirdness to make it work with non-variables (constants and expressions)
