### PR TITLE
fix import handling comments and padding controls

### DIFF
--- a/addons/settings/XEH_preInit.sqf
+++ b/addons/settings/XEH_preInit.sqf
@@ -20,6 +20,7 @@ ADDON = false;
     ["Test_Setting_3", "SLIDER",   ["-test slider-",   "-tooltip-"], "My Category", [0, 10, 5, 0]] call cba_settings_fnc_init;
     ["Test_Setting_4", "COLOR",    ["-test color-",    "-tooltip-"], "My Category", [1, 1 ,0], false, {diag_log text format ["Color Setting Changed: %1", _this];}] call cba_settings_fnc_init;
     ["Test_Setting_5", "COLOR",    ["-test alpha-",    "-tooltip-"], "My Category", [1, 0, 0, 0.5], false] call cba_settings_fnc_init;
+    ["Test_Padding", "LIST", "Padding test", "My Category", [[0,1,2,3,4,5,6,7,8,9,10], []]] call cba_settings_fnc_init;
 
     ["Test_1", "EDITBOX", "setting 1", "Test Category", "null", nil, {systemChat str [1, _this]}] call cba_settings_fnc_init;
     ["Test_2", "EDITBOX", "setting 2", "Test Category", "null", nil, {systemChat str [2, _this]}] call cba_settings_fnc_init;

--- a/addons/settings/fnc_parse.sqf
+++ b/addons/settings/fnc_parse.sqf
@@ -39,6 +39,12 @@ private _result = [];
     _result pushBack (_x call CBA_fnc_trim);
 } forEach (_info splitString NEWLINE);
 
+{
+    if (_x select [count _x - 1] != ";") then {
+        _result set [_forEachIndex, _x + ";"];
+    };
+} forEach _result;
+
 _info = (_result joinString NEWLINE) + NEWLINE;
 
 // separate statements (setting = value)
@@ -61,7 +67,7 @@ _result = [];
         _priority = _priority + 1;
     };
 
-    if !(_setting isEqualTo "") then {
+    if (_setting != "") then {
         if !(_validate) then {
             _result pushBack [_setting, _value, _priority];
         } else {

--- a/addons/settings/gui_createCategory.sqf
+++ b/addons/settings/gui_createCategory.sqf
@@ -104,7 +104,7 @@ private _lists = _display getVariable QGVAR(lists);
 
             // ----- padding to make listboxes work
             if (_settingType == "LIST") then {
-                private _ctrlEmpty = _display ctrlCreate [QGVAR(Row_Empty), IDC_SETTING_CONTROLS_GROUP, _ctrlOptionsGroup];
+                private _ctrlEmpty = _display ctrlCreate [QGVAR(Row_Empty), -1, _ctrlOptionsGroup];
                 private _height = POS_H(count (_settingData select 0)) + TABLE_LINE_SPACING;
                 [_ctrlEmpty, _tablePosY, _height] call _fnc_controlSetTablePosY;
             };


### PR DESCRIPTION
**When merged this pull request will:**
- close #847 by fixing both errors mentioned
- comment lines were not appended with a ";" if needed and therefore ate the setting of the next line
- list setting empty padding controls used IDC_SETTING_CONTROLS_GROUP and were therefore recognized as setting controls that lacked an ui function; which in turn causes `File x\cba\addons\settings\fnc_gui_refresh.sqf, line 11` etc.