### PR TITLE
fix some issues with presets after export ui updates

### DIFF
--- a/addons/settings/fnc_export.sqf
+++ b/addons/settings/fnc_export.sqf
@@ -17,7 +17,7 @@ Author:
 ---------------------------------------------------------------------------- */
 #include "script_component.hpp"
 
-params [["_source", "client", [""]], ["_exportDefault", false, [false]]];
+params [["_source", "client", [""]], ["_exportDefault", true, [false]]];
 
 private _info = "";
 private _temp = [];

--- a/addons/settings/fnc_gui_settingOverwrite.sqf
+++ b/addons/settings/fnc_gui_settingOverwrite.sqf
@@ -41,7 +41,7 @@ _controlsGroup setVariable [QFUNC(auto_check_overwrite), {
 
         if (!cbChecked _ctrlOverwriteClient) then {
             _ctrlOverwriteClient cbSetChecked true;
-            [_ctrlOverwriteClient, true] call (_ctrlOverwriteClient getVariable QFUNC(event));
+            [_ctrlOverwriteClient, 1] call (_ctrlOverwriteClient getVariable QFUNC(event));
         };
     };
 }];


### PR DESCRIPTION
**When merged this pull request will:**
- priority would be set to `true` instead of `1` as temp setting, which would cause `1 > true` errors after loading a preset right after changing one mission scope setting and therefore automatically forcing it
- new export menu introduced _exportDefault toggle for FUNC(export), but the default value did not match the mode of the previous behavior thus causing weirdness when used in other places (presets)