### PR TITLE
remove default settings from settings hash

### DIFF
--- a/addons/settings/fnc_set.sqf
+++ b/addons/settings/fnc_set.sqf
@@ -59,8 +59,17 @@ switch (toLower _source) do {
                 WARNING_1("Cannot change setting %1 defined in userconfig file.",_setting);
             };
 
+            private _defaultValue = [_setting, "default"] call FUNC(get);
+            private _defaultPriority = SANITIZE_PRIORITY(_setting,0,_source);
+
             private _settingsHash = profileNamespace getVariable [QGVAR(hash), HASH_NULL];
-            [_settingsHash, toLower _setting, [_value, _priority]] call CBA_fnc_hashSet;
+
+            if ([_value, _priority] isEqualTo [_defaultValue, _defaultPriority]) then {
+                [_settingsHash, toLower _setting] call CBA_fnc_hashRem;
+            } else {
+                [_settingsHash, toLower _setting, [_value, _priority]] call CBA_fnc_hashSet;
+            };
+
             profileNamespace setVariable [QGVAR(hash), _settingsHash];
         };
 
@@ -78,8 +87,17 @@ switch (toLower _source) do {
                 WARNING_1("Cannot change setting %1 defined in mission settings file.",_setting);
             };
 
+            private _defaultValue = [_setting, "default"] call FUNC(get);
+            private _defaultPriority = SANITIZE_PRIORITY(_setting,0,_source);
+
             private _settingsHash = "Scenario" get3DENMissionAttribute QGVAR(hash);
-            [_settingsHash, toLower _setting, [_value, _priority]] call CBA_fnc_hashSet;
+
+            if ([_value, _priority] isEqualTo [_defaultValue, _defaultPriority]) then {
+                [_settingsHash, toLower _setting] call CBA_fnc_hashRem;
+            } else {
+                [_settingsHash, toLower _setting, [_value, _priority]] call CBA_fnc_hashSet;
+            };
+
             set3DENMissionAttributes [["Scenario", QGVAR(hash), _settingsHash]];
             findDisplay 313 setVariable [QGVAR(hash), _settingsHash];
         };
@@ -96,8 +114,17 @@ switch (toLower _source) do {
                     WARNING_1("Cannot change setting %1 defined in server config file.",_setting);
                 };
 
+                private _defaultValue = [_setting, "default"] call FUNC(get);
+                private _defaultPriority = SANITIZE_PRIORITY(_setting,0,_source);
+
                 private _settingsHash = profileNamespace getVariable [QGVAR(hash), HASH_NULL];
-                [_settingsHash, toLower _setting, [_value, _priority]] call CBA_fnc_hashSet;
+
+                if ([_value, _priority] isEqualTo [_defaultValue, _defaultPriority]) then {
+                    [_settingsHash, toLower _setting] call CBA_fnc_hashRem;
+                } else {
+                    [_settingsHash, toLower _setting, [_value, _priority]] call CBA_fnc_hashSet;
+                };
+
                 profileNamespace setVariable [QGVAR(hash), _settingsHash];
             };
 


### PR DESCRIPTION
**When merged this pull request will:**
- takes less storage and reduces file size of the mission.sqm (which stores arrays very ineffectively)
