### PR TITLE
read mission settings file every menu load

### DIFF
--- a/addons/settings/fnc_gui_export.sqf
+++ b/addons/settings/fnc_gui_export.sqf
@@ -14,7 +14,7 @@ private _ctrlToggleDefaultText = _display displayCtrl IDC_EXPORT_TOGGLE_DEFAULT_
 
 // --- scripted buttons
 if (_mode == "import") then {
-    _ctrlTitle ctrlSetText localize LSTRING(ButtonImport);
+    _ctrlTitle ctrlSetText format ["%1 (%2)", localize LSTRING(ButtonImport), localize STR_SOURCE];
 
     _ctrlToggleDefault ctrlEnable false;
     _ctrlToggleDefault ctrlShow false;
@@ -31,7 +31,7 @@ if (_mode == "import") then {
         _display closeDisplay IDC_OK;
     }];
 } else {
-    _ctrlTitle ctrlSetText localize LSTRING(ButtonExport);
+    _ctrlTitle ctrlSetText format ["%1 (%2)", localize LSTRING(ButtonExport), localize STR_SOURCE];
 
     _ctrlToggleDefault cbSetChecked (uiNamespace getVariable [QGVAR(showDefault), true]);
     _ctrlToggleDefault ctrlAddEventHandler ["CheckedChanged", {

--- a/addons/settings/fnc_gui_preset.sqf
+++ b/addons/settings/fnc_gui_preset.sqf
@@ -15,7 +15,7 @@ private _ctrlCancel = _display displayCtrl IDC_PRESETS_CANCEL;
 private _ctrlDelete = _display displayCtrl IDC_PRESETS_DELETE;
 
 if (_mode == "save") then {
-    _ctrlTitle ctrlSetText localize "STR_DISP_INT_SAVE";
+    _ctrlTitle ctrlSetText format ["%1 (%2)", localize "STR_DISP_INT_SAVE", localize STR_SOURCE];
 
     // --- generate default name
     _ctrlEdit ctrlSetText format ["New: %1",
@@ -36,7 +36,7 @@ if (_mode == "save") then {
 
     ctrlSetFocus _ctrlEdit;
 } else {
-    _ctrlTitle ctrlSetText localize "STR_DISP_INT_LOAD";
+    _ctrlTitle ctrlSetText format ["%1 (%2)", localize "STR_DISP_INT_LOAD", localize STR_SOURCE];
 
     // --- hide edit box in "load" mode
     _ctrlName ctrlEnable false;

--- a/addons/settings/fnc_initDisplay3DEN.sqf
+++ b/addons/settings/fnc_initDisplay3DEN.sqf
@@ -11,8 +11,13 @@ private _fnc_resetMissionSettings = {
     private _missionConfig = "";
 
     if (getMissionConfigValue [QGVAR(hasSettingsFile), false] in [true, 1]) then {
-        INFO("Loading mission settings file ...");
         _missionConfig = preprocessFile MISSION_SETTINGS_FILE;
+
+        if (_missionConfig isEqualTo "") then {
+            INFO_1("Mission Config: File [%1] not found or empty.",MISSION_SETTINGS_FILE);
+        } else {
+            INFO_1("Mission Config: File [%1] loaded successfully.",MISSION_SETTINGS_FILE);
+        };
     };
 
     {

--- a/addons/settings/fnc_initDisplayGameOptions.sqf
+++ b/addons/settings/fnc_initDisplayGameOptions.sqf
@@ -34,12 +34,20 @@ if (isServer) then {
     _ctrlClientButton ctrlSetTooltip "";
 };
 
-// ----- reload settings file
-if (is3DEN && {getMissionConfigValue [QGVAR(hasSettingsFile), false] in [true, 1]}) then {
+// ----- reload settings file if in editor
+#define FILE_EXISTS(file) \
+call {\
+    private _control = findDisplay 313 ctrlCreate ["RscHTML", -1];\
+    _control htmlLoad file;\
+    private _return = ctrlHTMLLoaded _control;\
+    ctrlDelete _control;\
+    _return\
+};
+
+if (is3DEN && {FILE_EXISTS(MISSION_SETTINGS_FILE)}) then {
     GVAR(missionConfig) call CBA_fnc_deleteNamespace;
     GVAR(missionConfig) = [] call CBA_fnc_createNamespace;
 
-    INFO("Loading mission settings file ...");
     private _missionConfig = preprocessFile MISSION_SETTINGS_FILE;
 
     {

--- a/addons/settings/fnc_initDisplayGameOptions.sqf
+++ b/addons/settings/fnc_initDisplayGameOptions.sqf
@@ -34,6 +34,28 @@ if (isServer) then {
     _ctrlClientButton ctrlSetTooltip "";
 };
 
+// ----- reload settings file
+if (is3DEN && {getMissionConfigValue [QGVAR(hasSettingsFile), false] in [true, 1]}) then {
+    GVAR(missionConfig) call CBA_fnc_deleteNamespace;
+    GVAR(missionConfig) = [] call CBA_fnc_createNamespace;
+
+    INFO("Loading mission settings file ...");
+    private _missionConfig = preprocessFile MISSION_SETTINGS_FILE;
+
+    {
+        _x params ["_setting", "_value", "_priority"];
+
+        GVAR(missionConfig) setVariable [_setting, [_value, _priority]];
+    } forEach ([_missionConfig, false] call FUNC(parse));
+
+    {
+        private _setting = _x;
+
+        (GVAR(missionConfig) getVariable [_setting, []]) params ["_value", "_priority"];
+        [_setting, _value, _priority, "mission"] call FUNC(set);
+    } forEach GVAR(allSettings);
+};
+
 // ----- create temporary setting namespaces
 with uiNamespace do {
     GVAR(clientTemp)  = _display ctrlCreate ["RscText", -1];

--- a/addons/settings/fnc_initDisplayMain.sqf
+++ b/addons/settings/fnc_initDisplayMain.sqf
@@ -29,7 +29,7 @@ if (_file != "") then {
 
     if (_fileExists) then {
         INFO_1("Userconfig: File [%1] loaded successfully.",_file);
-        _userconfig = preprocessFile _file;
+        _userconfig = _file;
     } else {
         INFO_1("Userconfig: File [%1] not found or empty.",_file);
     };

--- a/addons/settings/fnc_set.sqf
+++ b/addons/settings/fnc_set.sqf
@@ -43,8 +43,8 @@ if !([_setting, _value] call FUNC(check)) exitWith {
 private _currentValue = [_setting, _source] call FUNC(get);
 private _currentPriority = [_setting, _source] call FUNC(priority);
 
-if (_value isEqualTo _currentValue && {_priority isEqualTo _currentPriority}) exitWith {
-    WARNING_3("Value %1 and priority %2 are the same as previously for setting %3.",TO_STRING(_value),_priority,_setting);
+if ([_value, _priority] isEqualTo [_currentValue, _currentPriority]) exitWith {
+    //WARNING_3("Value %1 and priority %2 are the same as previously for setting %3.",TO_STRING(_value),_priority,_setting);
     false
 };
 

--- a/addons/settings/initSettings.sqf
+++ b/addons/settings/initSettings.sqf
@@ -45,8 +45,13 @@ if (isNil QGVAR(default)) then {
     private _missionConfig = "";
 
     if (getMissionConfigValue [QGVAR(hasSettingsFile), false] in [true, 1]) then {
-        INFO("Loading mission settings file ...");
         _missionConfig = preprocessFile MISSION_SETTINGS_FILE;
+
+        if (_missionConfig isEqualTo "") then {
+            INFO_1("Mission Config: File [%1] not found or empty.",MISSION_SETTINGS_FILE);
+        } else {
+            INFO_1("Mission Config: File [%1] loaded successfully.",MISSION_SETTINGS_FILE);
+        };
     };
 
     {

--- a/addons/settings/initSettings.sqf
+++ b/addons/settings/initSettings.sqf
@@ -27,7 +27,7 @@ if (isNil QGVAR(default)) then {
         missionNamespace setVariable [QGVAR(serverConfig), true call CBA_fnc_createNamespace, true];
     };
 
-    private _userconfig = call (uiNamespace getVariable QGVAR(userconfig));
+    private _userconfig = preprocessFile call (uiNamespace getVariable QGVAR(userconfig));
 
     {
         _x params ["_setting", "_value", "_priority"];

--- a/addons/settings/script_component.hpp
+++ b/addons/settings/script_component.hpp
@@ -152,3 +152,5 @@
     if (IS_LOCAL_SETTING(setting)) exitWith {_priority min 0};\
     _priority\
 })
+
+#define STR_SOURCE ([LSTRING(ButtonMission),LSTRING(ButtonClient)] param [["mission","client"] find (uiNamespace getVariable QGVAR(source)), LSTRING(ButtonServer)])

--- a/addons/settings/script_component.hpp
+++ b/addons/settings/script_component.hpp
@@ -5,8 +5,8 @@
 #include "\a3\ui_f\hpp\defineCommonGrids.inc"
 #include "\a3\ui_f\hpp\defineResincl.inc"
 
-//#define DEBUG_MODE_FULL
-//#define DISABLE_COMPILE_CACHE
+#define DEBUG_MODE_FULL
+#define DISABLE_COMPILE_CACHE
 //#define DEBUG_ENABLED_SETTINGS
 
 #ifdef DEBUG_ENABLED_SETTINGS

--- a/addons/settings/script_component.hpp
+++ b/addons/settings/script_component.hpp
@@ -5,8 +5,8 @@
 #include "\a3\ui_f\hpp\defineCommonGrids.inc"
 #include "\a3\ui_f\hpp\defineResincl.inc"
 
-#define DEBUG_MODE_FULL
-#define DISABLE_COMPILE_CACHE
+//#define DEBUG_MODE_FULL
+//#define DISABLE_COMPILE_CACHE
 //#define DEBUG_ENABLED_SETTINGS
 
 #ifdef DEBUG_ENABLED_SETTINGS


### PR DESCRIPTION
**When merged this pull request will:**
- in 3den, when opening the settings menu, read the settings file again and recreate the missionConfig
- refresh all mission scope settings using the new missionConfig
- clarified some logging akin to Pabst's PR
- simplified a check and mute some excessive logging