### PR TITLE
make starting a mission reload the userconfig settings file

### DIFF
--- a/addons/settings/fnc_initDisplayMain.sqf
+++ b/addons/settings/fnc_initDisplayMain.sqf
@@ -29,7 +29,7 @@ if (_file != "") then {
 
     if (_fileExists) then {
         INFO_1("Userconfig: File [%1] loaded successfully.",_file);
-        _userconfig = preprocessFile _file;
+        _userconfig = _file;
     } else {
         INFO_1("Userconfig: File [%1] not found or empty.",_file);
     };

--- a/addons/settings/initSettings.sqf
+++ b/addons/settings/initSettings.sqf
@@ -27,7 +27,7 @@ if (isNil QGVAR(default)) then {
         missionNamespace setVariable [QGVAR(serverConfig), true call CBA_fnc_createNamespace, true];
     };
 
-    private _userconfig = call (uiNamespace getVariable QGVAR(userconfig));
+    private _userconfig = preprocessFile call (uiNamespace getVariable QGVAR(userconfig));
 
     {
         _x params ["_setting", "_value", "_priority"];


### PR DESCRIPTION
**When merged this pull request will:**
- Same as #859, but for the userconfig, and (only) every mission restart