### PR TITLE
Add sub-categories to settings

### DIFF
--- a/addons/settings/XEH_preInit.sqf
+++ b/addons/settings/XEH_preInit.sqf
@@ -28,7 +28,7 @@ ADDON = false;
     ["Test_4", "EDITBOX", "setting 4", ["Test Category", "Evens"], "null", nil, {systemChat str [4, _this]}] call cba_settings_fnc_init;
     ["Test_5", "EDITBOX", "setting 5", "Test Category", "null",   1, {systemChat str [5, _this]}] call cba_settings_fnc_init;
     ["Test_6", "EDITBOX", "setting 6", ["Test Category", "Evens"], "null",   2, {systemChat str [6, _this]}] call cba_settings_fnc_init;
-    ["Test_6", "EDITBOX", "setting 7", ["Test Category", "Seven"], "null",   2, {systemChat str [7, _this]}] call cba_settings_fnc_init;
+    ["Test_7", "EDITBOX", "setting 7", ["Test Category", "Seven"], "null",   2, {systemChat str [7, _this]}] call cba_settings_fnc_init;
 
     ["Test_A", "EDITBOX", "setting 1", "Test Category 1", "a", nil, {systemChat str [1, _this]}] call cba_settings_fnc_init;
     ["Test_B", "EDITBOX", "setting 2", "Test Category 1", "b", nil, {systemChat str [2, _this]}] call cba_settings_fnc_init;

--- a/addons/settings/XEH_preInit.sqf
+++ b/addons/settings/XEH_preInit.sqf
@@ -23,11 +23,12 @@ ADDON = false;
     ["Test_Padding", "LIST", "Padding test", "My Category", [[0,1,2,3,4,5,6,7,8,9,10], []]] call cba_settings_fnc_init;
 
     ["Test_1", "EDITBOX", "setting 1", "Test Category", "null", nil, {systemChat str [1, _this]}] call cba_settings_fnc_init;
-    ["Test_2", "EDITBOX", "setting 2", "Test Category", "null", nil, {systemChat str [2, _this]}] call cba_settings_fnc_init;
+    ["Test_2", "EDITBOX", "setting 2", ["Test Category", "Evens"], "null", nil, {systemChat str [2, _this]}] call cba_settings_fnc_init;
     ["Test_3", "EDITBOX", "setting 3", "Test Category", "null", nil, {systemChat str [3, _this]}] call cba_settings_fnc_init;
-    ["Test_4", "EDITBOX", "setting 4", "Test Category", "null", nil, {systemChat str [4, _this]}] call cba_settings_fnc_init;
+    ["Test_4", "EDITBOX", "setting 4", ["Test Category", "Evens"], "null", nil, {systemChat str [4, _this]}] call cba_settings_fnc_init;
     ["Test_5", "EDITBOX", "setting 5", "Test Category", "null",   1, {systemChat str [5, _this]}] call cba_settings_fnc_init;
-    ["Test_6", "EDITBOX", "setting 6", "Test Category", "null",   2, {systemChat str [6, _this]}] call cba_settings_fnc_init;
+    ["Test_6", "EDITBOX", "setting 6", ["Test Category", "Evens"], "null",   2, {systemChat str [6, _this]}] call cba_settings_fnc_init;
+    ["Test_6", "EDITBOX", "setting 7", ["Test Category", "Seven"], "null",   2, {systemChat str [7, _this]}] call cba_settings_fnc_init;
 
     ["Test_A", "EDITBOX", "setting 1", "Test Category 1", "a", nil, {systemChat str [1, _this]}] call cba_settings_fnc_init;
     ["Test_B", "EDITBOX", "setting 2", "Test Category 1", "b", nil, {systemChat str [2, _this]}] call cba_settings_fnc_init;

--- a/addons/settings/fnc_init.sqf
+++ b/addons/settings/fnc_init.sqf
@@ -8,7 +8,7 @@ Parameters:
     _setting     - Unique setting name. Matches resulting variable name <STRING>
     _settingType - Type of setting. Can be "CHECKBOX", "EDITBOX", "LIST", "SLIDER" or "COLOR" <STRING>
     _title       - Display name or display name + tooltip (optional, default: same as setting name) <STRING, ARRAY>
-    _category    - Category for the settings menu <STRING>
+    _category    - Category for the settings menu + optional sub-category <STRING, ARRAY>
     _valueInfo   - Extra properties of the setting depending of _settingType. See examples below <ANY>
     _isGlobal    - 1: all clients share the same setting, 2: setting can't be overwritten (optional, default: 0) <ARRAY>
     _script      - Script to execute when setting is changed. (optional) <CODE>
@@ -53,7 +53,7 @@ params [
     ["_setting", "", [""]],
     ["_settingType", "", [""]],
     ["_title", [], ["", []]],
-    ["_category", "", [""]],
+    ["_categoryArg", "", ["", []]],
     ["_valueInfo", []],
     ["_isGlobal", false, [false, 0]],
     ["_script", {}, [{}]]
@@ -64,6 +64,7 @@ if (_setting isEqualTo "") exitWith {
     1
 };
 
+_categoryArg params [["_category", "", [""]], ["_subCategory", "", [""]]];
 if (_category isEqualTo "") exitWith {
     WARNING_1("Empty menu category for setting %1",_setting);
     1
@@ -148,7 +149,7 @@ if (isNil {GVAR(default) getVariable _setting}) then {
     GVAR(allSettings) pushBack _setting;
 };
 
-GVAR(default) setVariable [_setting, [_defaultValue, _setting, _settingType, _settingData, _category, _displayName, _tooltip, _isGlobal, _script]];
+GVAR(default) setVariable [_setting, [_defaultValue, _setting, _settingType, _settingData, _category, _displayName, _tooltip, _isGlobal, _script, _subCategory]];
 
 // --- read previous setting values from profile
 private _settingInfo = GVAR(userconfig) getVariable _setting;

--- a/addons/settings/gui.hpp
+++ b/addons/settings/gui.hpp
@@ -161,6 +161,38 @@ class GVAR(Row_Empty): RscText {
     h = POS_H(0);
 };
 
+class GVAR(subCat): RscControlsGroupNoScrollbars {
+    x = POS_W(1);
+    y = POS_H(0);
+    w = POS_W(37);
+    h = POS_H(0.75);
+    class controls {
+        class Background: RscText {
+            colorBackground[] = {0.25,0.25,0.25,0.4};
+            x = POS_W(0);
+            y = POS_H(0);
+            w = POS_W(36);
+            h = POS_H(1);
+        };
+        class Name: RscText {
+            idc = IDC_SETTING_NAME;
+            style = ST_LEFT;
+            SizeEx = POS_H(0.75);
+            x = POS_W(0);
+            y = POS_H(0);
+            w = POS_W(15.5);
+            h = POS_H(0.75);
+        };
+        class Bar: RscText {
+            colorBackground[] = {1,1,1,1};
+            style = ST_LEFT;
+            x = POS_W(0);
+            y = POS_H(0.75) - 2 * pixelH;
+            w = POS_W(36);
+            h = pixelH;
+        };
+    };
+};
 class GVAR(Row_Base): RscControlsGroupNoScrollbars {
     GVAR(script) = "";
     x = POS_W(1);

--- a/addons/settings/gui_createCategory.sqf
+++ b/addons/settings/gui_createCategory.sqf
@@ -44,133 +44,131 @@ private _lastSubCategory = "$START";
 
     (GVAR(default) getVariable _setting) params ["_defaultValue", "", "_settingType", "_settingData", "_category", "_displayName", "_tooltip", "_isGlobal"];
 
-    if (true) then { // remove
-        if (isLocalized _displayName) then {
-            _displayName = localize _displayName;
-        };
-
-        if (isLocalized _tooltip) then {
-            _tooltip = localize _tooltip;
-        };
-        if (_tooltip != _setting) then { // Append setting name to bottom line
-            if (_tooltip isEqualTo "") then {
-                _tooltip = _setting;
-            } else {
-                _tooltip = format ["%1\n%2", _tooltip, _setting];
-            };
-        };
-
-        private _settingControlsGroups = [];
-
-        {
-            private _source = toLower _x;
-
-            private _currentValue = GET_TEMP_NAMESPACE_VALUE(_setting,_source);
-            if (isNil "_currentValue") then {
-                _currentValue = [_setting, _source] call FUNC(get);
-            };
-
-            private _currentPriority = GET_TEMP_NAMESPACE_PRIORITY(_setting,_source);
-            if (isNil "_currentPriority") then {
-                _currentPriority = [_setting, _source] call FUNC(priority);
-            };
-
-            // ----- create or retrieve options "list" controls group
-            private _list = [QGVAR(list), _category, _source] joinString "$";
-
-            private _ctrlOptionsGroup = controlNull;
-
-            if !(_list in _lists) then {
-                _ctrlOptionsGroup = _display ctrlCreate [QGVAR(OptionsGroup), -1, _display displayCtrl IDC_ADDONS_GROUP];
-                _ctrlOptionsGroup ctrlEnable false;
-                _ctrlOptionsGroup ctrlShow false;
-
-                _lists pushBack _list;
-                _display setVariable [_list, _ctrlOptionsGroup];
-            } else {
-                _ctrlOptionsGroup = _display getVariable _list;
-            };
-
-            // Add sub-category header:
-            if (_createHeader) then {
-                private _header = _display ctrlCreate [QGVAR(subCat), -1, _ctrlOptionsGroup];
-                (_header controlsGroupCtrl IDC_SETTING_NAME) ctrlSetText format ["%1:", _subCategory];
-
-                private _tablePosY = (_ctrlOptionsGroup getVariable [QGVAR(tablePosY), TABLE_LINE_SPACING/2]);
-                _tablePosY = [_header, _tablePosY] call _fnc_controlSetTablePosY;
-                _ctrlOptionsGroup setVariable [QGVAR(tablePosY), _tablePosY];
-            };
-
-            // ----- create setting group
-            private _ctrlSettingGroup = switch (toUpper _settingType) do {
-                case "CHECKBOX": {
-                    _display ctrlCreate [QGVAR(Row_Checkbox), IDC_SETTING_CONTROLS_GROUP, _ctrlOptionsGroup]
-                };
-                case "EDITBOX": {
-                    _display ctrlCreate [QGVAR(Row_Editbox), IDC_SETTING_CONTROLS_GROUP, _ctrlOptionsGroup]
-                };
-                case "LIST": {
-                    _display ctrlCreate [QGVAR(Row_List), IDC_SETTING_CONTROLS_GROUP, _ctrlOptionsGroup]
-                };
-                case "SLIDER": {
-                    _display ctrlCreate [QGVAR(Row_Slider), IDC_SETTING_CONTROLS_GROUP, _ctrlOptionsGroup]
-                };
-                case "COLOR": {
-                    _display ctrlCreate [[QGVAR(Row_Color), QGVAR(Row_ColorAlpha)] select (count _defaultValue > 3), IDC_SETTING_CONTROLS_GROUP, _ctrlOptionsGroup]
-                };
-                default {controlNull};
-            };
-
-            _ctrlSettingGroup setVariable [QGVAR(setting), _setting];
-            _ctrlSettingGroup setVariable [QGVAR(source), _source];
-            _ctrlSettingGroup setVariable [QGVAR(params), _settingData];
-            _ctrlSettingGroup setVariable [QGVAR(groups), _settingControlsGroups];
-            _settingControlsGroups pushBack _ctrlSettingGroup;
-
-            // ----- adjust y position in table
-            private _tablePosY = _ctrlOptionsGroup getVariable [QGVAR(tablePosY), TABLE_LINE_SPACING/2];
-            _tablePosY = [_ctrlSettingGroup, _tablePosY] call _fnc_controlSetTablePosY;
-            _ctrlOptionsGroup setVariable [QGVAR(tablePosY), _tablePosY];
-
-            // ----- padding to make listboxes work
-            if (_settingType == "LIST") then {
-                private _ctrlEmpty = _display ctrlCreate [QGVAR(Row_Empty), -1, _ctrlOptionsGroup];
-                private _height = POS_H(count (_settingData select 0)) + TABLE_LINE_SPACING;
-                [_ctrlEmpty, _tablePosY, _height] call _fnc_controlSetTablePosY;
-            };
-
-            // ----- set setting name
-            private _ctrlSettingName = _ctrlSettingGroup controlsGroupCtrl IDC_SETTING_NAME;
-            _ctrlSettingName ctrlSetText format ["%1:", _displayName];
-            _ctrlSettingName ctrlSetTooltip _tooltip;
-
-            // ----- execute setting script
-            private _script = getText (configFile >> ctrlClassName _ctrlSettingGroup >> QGVAR(script));
-            [_ctrlSettingGroup, _setting, _source, _currentValue, _settingData] call (uiNamespace getVariable _script);
-
-            // ----- default button
-            [_ctrlSettingGroup, _setting, _source, _currentValue, _defaultValue] call FUNC(gui_settingDefault);
-
-            // ----- priority list
-            [_ctrlSettingGroup, _setting, _source, _currentPriority, _isGlobal] call FUNC(gui_settingOverwrite);
-
-            // ----- check if setting can be altered
-            private _enabled = switch (_source) do {
-                case "client": {CAN_SET_CLIENT_SETTINGS && {isNil {GVAR(userconfig) getVariable _setting}}};
-                case "mission": {CAN_SET_MISSION_SETTINGS && {isNil {GVAR(missionConfig) getVariable _setting}}};
-                case "server": {CAN_SET_SERVER_SETTINGS && {isNil {GVAR(serverConfig) getVariable _setting}}};
-            };
-
-            if !(_enabled) then {
-                _ctrlSettingName ctrlSetTextColor COLOR_TEXT_DISABLED;
-
-                //private _ctrlSettingGroupControls = allControls ctrlParent _ctrlSettingGroup select {ctrlParentControlsGroup _x == _ctrlSettingGroup};
-                private _ctrlSettingGroupControls = "true" configClasses (configFile >> ctrlClassName _ctrlSettingGroup >> "controls") apply {_ctrlSettingGroup controlsGroupCtrl getNumber (_x >> "idc")};
-
-                {
-                    _x ctrlEnable false;
-                } forEach _ctrlSettingGroupControls;
-            };
-        } forEach ["client", "mission", "server"];
+    if (isLocalized _displayName) then {
+        _displayName = localize _displayName;
     };
+
+    if (isLocalized _tooltip) then {
+        _tooltip = localize _tooltip;
+    };
+    if (_tooltip != _setting) then { // Append setting name to bottom line
+        if (_tooltip isEqualTo "") then {
+            _tooltip = _setting;
+        } else {
+            _tooltip = format ["%1\n%2", _tooltip, _setting];
+        };
+    };
+
+    private _settingControlsGroups = [];
+
+    {
+        private _source = toLower _x;
+
+        private _currentValue = GET_TEMP_NAMESPACE_VALUE(_setting,_source);
+        if (isNil "_currentValue") then {
+            _currentValue = [_setting, _source] call FUNC(get);
+        };
+
+        private _currentPriority = GET_TEMP_NAMESPACE_PRIORITY(_setting,_source);
+        if (isNil "_currentPriority") then {
+            _currentPriority = [_setting, _source] call FUNC(priority);
+        };
+
+        // ----- create or retrieve options "list" controls group
+        private _list = [QGVAR(list), _category, _source] joinString "$";
+
+        private _ctrlOptionsGroup = controlNull;
+
+        if !(_list in _lists) then {
+            _ctrlOptionsGroup = _display ctrlCreate [QGVAR(OptionsGroup), -1, _display displayCtrl IDC_ADDONS_GROUP];
+            _ctrlOptionsGroup ctrlEnable false;
+            _ctrlOptionsGroup ctrlShow false;
+
+            _lists pushBack _list;
+            _display setVariable [_list, _ctrlOptionsGroup];
+        } else {
+            _ctrlOptionsGroup = _display getVariable _list;
+        };
+
+        // Add sub-category header:
+        if (_createHeader) then {
+            private _header = _display ctrlCreate [QGVAR(subCat), -1, _ctrlOptionsGroup];
+            (_header controlsGroupCtrl IDC_SETTING_NAME) ctrlSetText format ["%1:", _subCategory];
+
+            private _tablePosY = (_ctrlOptionsGroup getVariable [QGVAR(tablePosY), TABLE_LINE_SPACING/2]);
+            _tablePosY = [_header, _tablePosY] call _fnc_controlSetTablePosY;
+            _ctrlOptionsGroup setVariable [QGVAR(tablePosY), _tablePosY];
+        };
+
+        // ----- create setting group
+        private _ctrlSettingGroup = switch (toUpper _settingType) do {
+            case "CHECKBOX": {
+                _display ctrlCreate [QGVAR(Row_Checkbox), IDC_SETTING_CONTROLS_GROUP, _ctrlOptionsGroup]
+            };
+            case "EDITBOX": {
+                _display ctrlCreate [QGVAR(Row_Editbox), IDC_SETTING_CONTROLS_GROUP, _ctrlOptionsGroup]
+            };
+            case "LIST": {
+                _display ctrlCreate [QGVAR(Row_List), IDC_SETTING_CONTROLS_GROUP, _ctrlOptionsGroup]
+            };
+            case "SLIDER": {
+                _display ctrlCreate [QGVAR(Row_Slider), IDC_SETTING_CONTROLS_GROUP, _ctrlOptionsGroup]
+            };
+            case "COLOR": {
+                _display ctrlCreate [[QGVAR(Row_Color), QGVAR(Row_ColorAlpha)] select (count _defaultValue > 3), IDC_SETTING_CONTROLS_GROUP, _ctrlOptionsGroup]
+            };
+            default {controlNull};
+        };
+
+        _ctrlSettingGroup setVariable [QGVAR(setting), _setting];
+        _ctrlSettingGroup setVariable [QGVAR(source), _source];
+        _ctrlSettingGroup setVariable [QGVAR(params), _settingData];
+        _ctrlSettingGroup setVariable [QGVAR(groups), _settingControlsGroups];
+        _settingControlsGroups pushBack _ctrlSettingGroup;
+
+        // ----- adjust y position in table
+        private _tablePosY = _ctrlOptionsGroup getVariable [QGVAR(tablePosY), TABLE_LINE_SPACING/2];
+        _tablePosY = [_ctrlSettingGroup, _tablePosY] call _fnc_controlSetTablePosY;
+        _ctrlOptionsGroup setVariable [QGVAR(tablePosY), _tablePosY];
+
+        // ----- padding to make listboxes work
+        if (_settingType == "LIST") then {
+            private _ctrlEmpty = _display ctrlCreate [QGVAR(Row_Empty), -1, _ctrlOptionsGroup];
+            private _height = POS_H(count (_settingData select 0)) + TABLE_LINE_SPACING;
+            [_ctrlEmpty, _tablePosY, _height] call _fnc_controlSetTablePosY;
+        };
+
+        // ----- set setting name
+        private _ctrlSettingName = _ctrlSettingGroup controlsGroupCtrl IDC_SETTING_NAME;
+        _ctrlSettingName ctrlSetText format ["%1:", _displayName];
+        _ctrlSettingName ctrlSetTooltip _tooltip;
+
+        // ----- execute setting script
+        private _script = getText (configFile >> ctrlClassName _ctrlSettingGroup >> QGVAR(script));
+        [_ctrlSettingGroup, _setting, _source, _currentValue, _settingData] call (uiNamespace getVariable _script);
+
+        // ----- default button
+        [_ctrlSettingGroup, _setting, _source, _currentValue, _defaultValue] call FUNC(gui_settingDefault);
+
+        // ----- priority list
+        [_ctrlSettingGroup, _setting, _source, _currentPriority, _isGlobal] call FUNC(gui_settingOverwrite);
+
+        // ----- check if setting can be altered
+        private _enabled = switch (_source) do {
+            case "client": {CAN_SET_CLIENT_SETTINGS && {isNil {GVAR(userconfig) getVariable _setting}}};
+            case "mission": {CAN_SET_MISSION_SETTINGS && {isNil {GVAR(missionConfig) getVariable _setting}}};
+            case "server": {CAN_SET_SERVER_SETTINGS && {isNil {GVAR(serverConfig) getVariable _setting}}};
+        };
+
+        if !(_enabled) then {
+            _ctrlSettingName ctrlSetTextColor COLOR_TEXT_DISABLED;
+
+            //private _ctrlSettingGroupControls = allControls ctrlParent _ctrlSettingGroup select {ctrlParentControlsGroup _x == _ctrlSettingGroup};
+            private _ctrlSettingGroupControls = "true" configClasses (configFile >> ctrlClassName _ctrlSettingGroup >> "controls") apply {_ctrlSettingGroup controlsGroupCtrl getNumber (_x >> "idc")};
+
+            {
+                _x ctrlEnable false;
+            } forEach _ctrlSettingGroupControls;
+        };
+    } forEach ["client", "mission", "server"];
 } forEach _categorySettings;

--- a/addons/settings/gui_createCategory.sqf
+++ b/addons/settings/gui_createCategory.sqf
@@ -21,10 +21,30 @@ private _fnc_controlSetTablePosY = {
 
 private _lists = _display getVariable QGVAR(lists);
 
-{
-    (GVAR(default) getVariable _x) params ["_defaultValue", "_setting", "_settingType", "_settingData", "_category", "_displayName", "_tooltip", "_isGlobal"];
+private _categorySettings = [];
 
+{
+    (GVAR(default) getVariable _x) params ["", "_setting", "", "", "_category", "", "", "", "", "_subCategory"];
     if (_category == _selectedAddon) then {
+        _categorySettings pushBack [_subCategory, _forEachIndex, _setting];
+    };
+} forEach GVAR(allSettings);
+
+_categorySettings sort true;
+private _lastSubCategory = "$START";
+
+{
+    _x params ["_subCategory", "", "_setting"];
+    private _createHeader = false;
+    if (_subCategory != _lastSubCategory) then {
+        _lastSubCategory = _subCategory;
+        if (_subCategory == "") exitWith {};
+        _createHeader = true;
+    };
+
+    (GVAR(default) getVariable _setting) params ["_defaultValue", "", "_settingType", "_settingData", "_category", "_displayName", "_tooltip", "_isGlobal"];
+
+    if (true) then { // remove
         if (isLocalized _displayName) then {
             _displayName = localize _displayName;
         };
@@ -69,6 +89,16 @@ private _lists = _display getVariable QGVAR(lists);
                 _display setVariable [_list, _ctrlOptionsGroup];
             } else {
                 _ctrlOptionsGroup = _display getVariable _list;
+            };
+
+            // Add sub-category header:
+            if (_createHeader) then {
+                private _header = _display ctrlCreate [QGVAR(subCat), -1, _ctrlOptionsGroup];
+                (_header controlsGroupCtrl IDC_SETTING_NAME) ctrlSetText format ["%1:", _subCategory];
+
+                private _tablePosY = (_ctrlOptionsGroup getVariable [QGVAR(tablePosY), TABLE_LINE_SPACING/2]);
+                _tablePosY = [_header, _tablePosY] call _fnc_controlSetTablePosY;
+                _ctrlOptionsGroup setVariable [QGVAR(tablePosY), _tablePosY];
             };
 
             // ----- create setting group
@@ -143,4 +173,4 @@ private _lists = _display getVariable QGVAR(lists);
             };
         } forEach ["client", "mission", "server"];
     };
-} forEach GVAR(allSettings);
+} forEach _categorySettings;


### PR DESCRIPTION
Adds sorted sub-categories to base categories
ACE has a lot of settings, we don't want to create more base categories than needed.
This will allow better organization while inside of a single category.

![cat](https://user-images.githubusercontent.com/9376747/34646187-353c22e0-f327-11e7-9be3-4b4b539d34d1.jpg)

(code/ui might be a little rough, mainly just looking for feedback on the idea)
From https://github.com/acemod/ACE3/pull/3563#issuecomment-193916539
We could even attempt to autogenerate these sub-categories for setting names that follow a standard `GVAR(` pattern, but I'm leaning towards leaving it to the mod-makers to fill.