### PR TITLE
Add support for arbitrary character trimming

### DIFF
--- a/addons/strings/fnc_leftTrim.sqf
+++ b/addons/strings/fnc_leftTrim.sqf
@@ -2,12 +2,13 @@
 Function: CBA_fnc_leftTrim
 
 Description:
-    Trims white-space (space, tab, newline) from the left end of a string.
+    Trims specified characters (all whitespace by default) from the left end of a string.
 
     See <CBA_fnc_rightTrim> and <CBA_fnc_trim>.
 
 Parameters:
     _string - String to trim [String]
+    _trim - Characters to trim [String] (default: "")
 
 Returns:
     Trimmed string [String]
@@ -19,7 +20,7 @@ Example:
     (end)
 
 Author:
-    Spooner, joko // Jonas
+    Spooner, joko // Jonas, SilentSpike
 ---------------------------------------------------------------------------- */
 
 #include "script_component.hpp"
@@ -29,28 +30,22 @@ SCRIPT(leftTrim);
 
 // ----------------------------------------------------------------------------
 
-params ["_string"];
+params ["_string", ["_trim", "", [""]]];
 
-private ["_chars", "_charCount"];
+private _chars = toArray _string;
+private _numChars = count _chars;
 
-// Convert String to Array for Find White Spaces
-_chars = ToArray _string;
-// count String input
-_charCount = count _string;
-
-if (_charCount > 0) then {
-    private "_numWhiteSpaces";
-    // Set Base number for White Spaces
-    _numWhiteSpaces = _charCount;
-
-    // find Last White Space
-    for "_i" from 0 to (_charCount - 1) do {
-        if !((_chars select _i) in WHITE_SPACE) exitWith {_numWhiteSpaces = _i};
-    };
-    // if a White space exist than they are deselected
-    if (_numWhiteSpaces > 0) then {
-        _string = _string select [_numWhiteSpaces];
-    };
+// Trim all whitespace characters by default
+if (_trim == "") then {
+    _trim = WHITE_SPACE;
+} else {
+    _trim = toArray _trim;
 };
 
-_string; // Return.
+// We have to process the string in array form because it could differ in length (if there are non-ASCII characters)
+private _trimIndex = 0;
+{
+    if !(_x in _trim) exitWith { _trimIndex = _forEachIndex; };
+} forEach _chars;
+
+toString (_chars select [_trimIndex, _numChars - _trimIndex])

--- a/addons/strings/fnc_rightTrim.sqf
+++ b/addons/strings/fnc_rightTrim.sqf
@@ -2,12 +2,13 @@
 Function: CBA_fnc_rightTrim
 
 Description:
-    Trims white-space (space, tab, newline) from the right end of a string.
+    Trims specified characters (all whitespace by default) from the right end of a string.
 
     See <CBA_fnc_leftTrim> and <CBA_fnc_trim>.
 
 Parameters:
     _string - String to trim [String]
+    _trim - Characters to trim [String] (default: "")
 
 Returns:
     Trimmed string [String]
@@ -19,7 +20,7 @@ Example:
     (end)
 
 Author:
-    Spooner, joko // Jonas
+    Spooner, joko // Jonas, SilentSpike
 ---------------------------------------------------------------------------- */
 
 #include "script_component.hpp"
@@ -29,25 +30,28 @@ SCRIPT(rightTrim);
 
 // ----------------------------------------------------------------------------
 
-params ["_string"];
+params ["_string", ["_trim", "", [""]]];
 
-private ["_char", "_charCount", "_charCount2", "_pos", "_numWhiteSpaces"];
-// Convert String to Array for Find White Spaces
-_char = toArray _string;
+private _chars = toArray _string;
+private _numChars = count _chars;
 
-// Count String Lenth
-_charCount = count _string;
+// Trim from the right
+reverse _chars;
 
-// substract 1 for faster for(L46)
-_charCount2 = _charCount - 1;
-
-// find White Spaces and count than
-for "_i" from _charCount2 to 0 step -1 do {
-    if !((_char select _i) in WHITE_SPACE) exitWith {_numWhiteSpaces = _charCount2 - _i};
+// Trim all whitespace characters by default
+if (_trim == "") then {
+    _trim = WHITE_SPACE;
+} else {
+    _trim = toArray _trim;
 };
 
-// exit if every tab is White Space
-if (isNil "_numWhiteSpaces") exitWith {""};
+// We have to process the string in array form because it could differ in length (if there are non-ASCII characters)
+private _trimIndex = 0;
+{
+    if !(_x in _trim) exitWith { _trimIndex = _forEachIndex; };
+} forEach _chars;
 
-// select Only None White Space Part
-_string select [0, _charCount - _numWhiteSpaces]; // Return.
+// Convert string back to original order
+reverse _chars;
+
+toString (_chars select [0, _numChars - _trimIndex])

--- a/addons/strings/fnc_trim.sqf
+++ b/addons/strings/fnc_trim.sqf
@@ -2,12 +2,13 @@
 Function: CBA_fnc_trim
 
 Description:
-    Trims white-space (space, tab, newline) from the both ends of a string.
+    Trims specified characters (all whitespace by default) from the both ends of a string.
 
     See <CBA_fnc_leftTrim> and <CBA_fnc_rightTrim>.
 
 Parameters:
     _string - String to trim [String]
+    _trim - Characters to trim [String] (default: "")
 
 Returns:
     Trimmed string [String]
@@ -19,7 +20,7 @@ Example:
     (end)
 
 Author:
-    Spooner
+    Spooner, SilentSpike
 ---------------------------------------------------------------------------- */
 
 #include "script_component.hpp"
@@ -28,9 +29,8 @@ SCRIPT(trim);
 
 // ----------------------------------------------------------------------------
 
-params ["_string"];
+params ["_string", ["_trim", "", [""]]];
 
-// Rtrim first for efficiency.
-_string = [_string] call CBA_fnc_rightTrim;
+_string = [_string, _trim] call CBA_fnc_rightTrim;
 
-[_string] call CBA_fnc_leftTrim; // Return.
+[_string, _trim] call CBA_fnc_leftTrim


### PR DESCRIPTION
**When merged this pull request will:**
- Add support for arbitrary character trimming
- This will also fix the functions for strings with non-ASCII characters where the `toArray` length is different from the length of the original string

Tested and working perfectly (tried with non-ASCII too)