### PR TITLE
Settings whitelist

### DIFF
--- a/addons/settings/XEH_PREP.sqf
+++ b/addons/settings/XEH_PREP.sqf
@@ -7,6 +7,7 @@ PREP(import);
 PREP(export);
 PREP(clear);
 PREP(priority);
+PREP(whitelisted);
 
 if (hasInterface) then {
     PREP(openSettingsMenu);

--- a/addons/settings/fnc_whitelisted.sqf
+++ b/addons/settings/fnc_whitelisted.sqf
@@ -1,0 +1,39 @@
+/* ----------------------------------------------------------------------------
+Internal Function: CBA_settings_fnc_whitelisted
+
+Description:
+    Check if local machine can edit server settings.
+
+Parameters:
+    None.
+
+Returns:
+    _return - Can change server settings? <BOOL>
+
+Examples:
+    (begin example)
+        [] call CBA_settings_fnc_whitelisted
+    (end)
+
+Author:
+    commy2
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+
+private _uid = getPlayerUID player;
+private _whitelist = getArray configFile/QGVAR(whitelist);
+
+private _cfgMissionList = missionConfigFile/QGVAR(whitelist);
+if (isArray _cfgMissionList) then {
+    _whitelist append getArray _cfgMissionList;
+};
+
+// if neither addon nor mission have white list, use wildcard for admin instead
+if (_whitelist isEqualTo []) then {
+    _whitelist = ["admin"];
+};
+
+// admin wildcard and local machine is logged in admin
+if ("admin" in _whitelist && {IS_ADMIN_LOGGED}) exitWith {true};
+
+_uid in _whitelist

--- a/addons/settings/script_component.hpp
+++ b/addons/settings/script_component.hpp
@@ -5,8 +5,8 @@
 #include "\a3\ui_f\hpp\defineCommonGrids.inc"
 #include "\a3\ui_f\hpp\defineResincl.inc"
 
-//#define DEBUG_MODE_FULL
-//#define DISABLE_COMPILE_CACHE
+#define DEBUG_MODE_FULL
+#define DISABLE_COMPILE_CACHE
 //#define DEBUG_ENABLED_SETTINGS
 
 #ifdef DEBUG_ENABLED_SETTINGS
@@ -93,7 +93,7 @@
 
 #define ICON_DEFAULT "\a3\3den\Data\Displays\Display3DEN\ToolBar\undo_ca.paa"
 
-#define CAN_SET_SERVER_SETTINGS ((isServer || {IS_ADMIN_LOGGED}) && {!isNull GVAR(server)}) // in single player, as host (local server) or as logged in (not voted) admin connected to a dedicated server
+#define CAN_SET_SERVER_SETTINGS ((isServer || FUNC(whitelisted)) && {!isNull GVAR(server)}) // in single player, as host (local server) or as logged in (not voted) admin connected to a dedicated server
 #define CAN_SET_CLIENT_SETTINGS !isServer // in multiplayer as dedicated client
 #define CAN_SET_MISSION_SETTINGS (is3den && {!(missionName in ["", "tempMissionSP", "tempMissionMP"])}) // in editor with existing mission.sqm
 

--- a/addons/settings/script_component.hpp
+++ b/addons/settings/script_component.hpp
@@ -5,8 +5,8 @@
 #include "\a3\ui_f\hpp\defineCommonGrids.inc"
 #include "\a3\ui_f\hpp\defineResincl.inc"
 
-#define DEBUG_MODE_FULL
-#define DISABLE_COMPILE_CACHE
+//#define DEBUG_MODE_FULL
+//#define DISABLE_COMPILE_CACHE
 //#define DEBUG_ENABLED_SETTINGS
 
 #ifdef DEBUG_ENABLED_SETTINGS


### PR DESCRIPTION
**When merged this pull request will:**
- close #876

Adds `cba_settings_whitelist[]` array to both addon and mission config (description.ext).
The dedicated client/player can edit server tab settings if and only if any of these apply:
- their UID (`getPlayerUID`) appears inside either array
- both arrays are either empty or undefined and the player is a logged in admin
- the "admin" wildcard was used in either array and the player is a logged in admin

If you want nobody to edit the settings, not even the logged in admin, then you can use a throwaway UID (e.g. "nobody") in either addon or mission config array.

By default, both of them are undefined/empty, so point #2 applies (logged in admin can edit the settings which is the current behavior before this PR).

In SP or as Local Host, you can edit the settings regardless of this whitelist.

This requires putting down UID's in either a global addon or the mission config, so if you're worried about spoofing, don't use it :~)

Future improvement could be made by comparing the players UID on the server instead, but I don't feel like writing a callback system for this stuff atm. This way you could use a server machine local addon to compare the UID.