### PR TITLE
make settings ediable in unsaved mission

### DIFF
--- a/addons/settings/script_component.hpp
+++ b/addons/settings/script_component.hpp
@@ -95,11 +95,11 @@
 
 #define CAN_SET_SERVER_SETTINGS ((isServer || {IS_ADMIN_LOGGED}) && {!isNull GVAR(server)}) // in single player, as host (local server) or as logged in (not voted) admin connected to a dedicated server
 #define CAN_SET_CLIENT_SETTINGS !isServer // in multiplayer as dedicated client
-#define CAN_SET_MISSION_SETTINGS (is3den && {!(missionName in ["", "tempMissionSP", "tempMissionMP"])}) // in editor with existing mission.sqm
+#define CAN_SET_MISSION_SETTINGS is3den // in editor
 
 #define CAN_VIEW_SERVER_SETTINGS !isNull GVAR(server) // everyone can peak at those in multiplayer
 #define CAN_VIEW_CLIENT_SETTINGS !isServer // in multiplayer as dedicated client
-#define CAN_VIEW_MISSION_SETTINGS ((is3den || {missionVersion >= 15}) && {!(missionName in ["", "tempMissionSP", "tempMissionMP"])}) // can view those in 3den or 3den missions
+#define CAN_VIEW_MISSION_SETTINGS (is3den || {missionVersion >= 15}) // can view those in 3den or 3den missions
 
 #define HASH_NULL ([] call CBA_fnc_hashCreate)
 #define NAMESPACE_NULL objNull


### PR DESCRIPTION
**When merged this pull request will:**
- close #865

This was a limitation I made relatively early in the development of the settings, but it seems like it's no longer needed. I tested this and works as one would expect.