### PR TITLE
Add FILE_EXISTS macro to common macros

### DIFF
--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -1726,7 +1726,6 @@ Author:
 ------------------------------------------- */
 #define IS_ADMIN_LOGGED serverCommandAvailable "#shutdown"
 
-
 /* -------------------------------------------
 Macro: FILE_EXISTS
     Check if a file exists

--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -1725,3 +1725,31 @@ Author:
     commy2
 ------------------------------------------- */
 #define IS_ADMIN_LOGGED serverCommandAvailable "#shutdown"
+
+
+/* -------------------------------------------
+Macro: FILE_EXISTS
+    Check if a file exists
+
+    Reports "false" if the file does not exist.
+
+Parameters:
+    FILE - Path to the file
+
+Example:
+    (begin example)
+        // print "true" if file exists
+        systemChat str FILE_EXISTS("\A3\ui_f\data\igui\cfg\cursors\weapon_ca.paa");
+    (end)
+
+Author:
+    commy2
+------------------------------------------- */
+#define FILE_EXISTS(FILE) \
+call {\
+    private _control = findDisplay 313 ctrlCreate ["RscHTML", -1];\
+    _control htmlLoad FILE;\
+    private _return = ctrlHTMLLoaded _control;\
+    ctrlDelete _control;\
+    _return\
+};

--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -1730,7 +1730,7 @@ Author:
 Macro: FILE_EXISTS
     Check if a file exists
 
-    Reports "false" if the file does not exist.
+    Reports "false" if the file does not exist and throws an error in RPT.
 
 Parameters:
     FILE - Path to the file

--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -1728,7 +1728,7 @@ Author:
 
 /* -------------------------------------------
 Macro: FILE_EXISTS
-    Check if a file exists
+    Check if a file exists on machines with interface
 
     Reports "false" if the file does not exist and throws an error in RPT.
 
@@ -1747,6 +1747,9 @@ Author:
 #define FILE_EXISTS(FILE) \
 call {\
     private _control = findDisplay 313 ctrlCreate ["RscHTML", -1];\
+    if (isNull _control) then {\
+        _control = findDisplay 0 ctrlCreate ["RscHTML", -1];\
+    };\
     _control htmlLoad FILE;\
     private _return = ctrlHTMLLoaded _control;\
     ctrlDelete _control;\

--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -1750,6 +1750,9 @@ call {\
     if (isNull _control) then {\
         _control = findDisplay 0 ctrlCreate ["RscHTML", -1];\
     };\
+    if (isNull _control) exitWith {\
+        loadFile FILE != "";\
+    };\
     _control htmlLoad FILE;\
     private _return = ctrlHTMLLoaded _control;\
     ctrlDelete _control;\

--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -1744,12 +1744,8 @@ Example:
 Author:
     commy2
 ------------------------------------------- */
-#define FILE_EXISTS(FILE) \
-call {\
-    private _control = findDisplay 313 ctrlCreate ["RscHTML", -1];\
-    if (isNull _control) then {\
-        _control = findDisplay 0 ctrlCreate ["RscHTML", -1];\
-    };\
+#define FILE_EXISTS(FILE) (call {\
+    private _control = (uiNamespace getVariable ["RscDisplayMain", displayNull]) ctrlCreate ["RscHTML", -1];\
     if (isNull _control) exitWith {\
         loadFile FILE != "";\
     };\
@@ -1757,4 +1753,4 @@ call {\
     private _return = ctrlHTMLLoaded _control;\
     ctrlDelete _control;\
     _return\
-};
+})

--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -1745,12 +1745,16 @@ Author:
     commy2
 ------------------------------------------- */
 #define FILE_EXISTS(FILE) (call {\
-    private _control = (uiNamespace getVariable ["RscDisplayMain", displayNull]) ctrlCreate ["RscHTML", -1];\
-    if (isNull _control) exitWith {\
-        loadFile FILE != "";\
+    private _return = false;\
+    isNil {\
+        private _control = (uiNamespace getVariable ["RscDisplayMain", displayNull]) ctrlCreate ["RscHTML", -1];\
+        if (isNull _control) then {\
+            _return = loadFile (FILE) != "";\
+        } else {\
+            _control htmlLoad (FILE);\
+            _return = ctrlHTMLLoaded _control;\
+            ctrlDelete _control;\
+        };\
     };\
-    _control htmlLoad FILE;\
-    private _return = ctrlHTMLLoaded _control;\
-    ctrlDelete _control;\
     _return\
 })

--- a/addons/settings/fnc_initDisplay3DEN.sqf
+++ b/addons/settings/fnc_initDisplay3DEN.sqf
@@ -71,15 +71,6 @@ add3DENEventHandler ["OnMissionLoad", _fnc_resetMissionSettingsMissionChanged];
 #define MESSAGE_EXPORTED_SP 5
 #define MESSAGE_EXPORTED_MP 6
 
-#define FILE_EXISTS(file) \
-call {\
-    private _control = findDisplay 313 ctrlCreate ["RscHTML", -1];\
-    _control htmlLoad file;\
-    private _return = ctrlHTMLLoaded _control;\
-    ctrlDelete _control;\
-    _return\
-};
-
 add3DENEventHandler ["OnMessage", {
     params ["_message"];
 

--- a/addons/settings/fnc_initDisplayGameOptions.sqf
+++ b/addons/settings/fnc_initDisplayGameOptions.sqf
@@ -35,15 +35,6 @@ if (isServer) then {
 };
 
 // ----- reload settings file if in editor
-#define FILE_EXISTS(file) \
-call {\
-    private _control = findDisplay 313 ctrlCreate ["RscHTML", -1];\
-    _control htmlLoad file;\
-    private _return = ctrlHTMLLoaded _control;\
-    ctrlDelete _control;\
-    _return\
-};
-
 if (is3DEN && {FILE_EXISTS(MISSION_SETTINGS_FILE)}) then {
     GVAR(missionConfig) call CBA_fnc_deleteNamespace;
     GVAR(missionConfig) = [] call CBA_fnc_createNamespace;

--- a/addons/settings/fnc_initDisplayMain.sqf
+++ b/addons/settings/fnc_initDisplayMain.sqf
@@ -16,18 +16,7 @@ if (isClass (configFile >> "CfgPatches" >> QGVAR(userconfig))) then {
 private _userconfig = "";
 
 if (_file != "") then {
-    private _fileExists = false;
-
-    if (!isNull _display) then {
-        private _control = _display ctrlCreate ["RscHTML", -1];
-        _control htmlLoad _file;
-        _fileExists = ctrlHTMLLoaded _control;
-        ctrlDelete _control;
-    } else {
-        _fileExists = loadFile _file != "";
-    };
-
-    if (_fileExists) then {
+    if (FILE_EXISTS(_file)) then {
         INFO_1("Userconfig: File [%1] loaded successfully.",_file);
         _userconfig = _file;
     } else {


### PR DESCRIPTION
**When merged this pull request will:**
- Remove the macro `FILE_EXISTS` from cba settings and add it to common macros

There are some useful cases where a developer would like to load a file but wants to check first if it exists to prevent error screens popping up.