### PR TITLE
Add getUniquePlayerItems function

### DIFF
--- a/addons/common/fnc_getUniquePlayerItems.sqf
+++ b/addons/common/fnc_getUniquePlayerItems.sqf
@@ -1,0 +1,44 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_getUniquePlayerItems
+
+Description:
+    A function used to retrieve a unique list of items in the units inventory
+
+Parameters:
+    _unit           - Unit to retrieve the items from
+    _weaponItems    - Include weapons, attachments, loaded magazines (Default: false)
+    _backpack       - Include items in backpack (Default: true)
+    _vest           - Include items in vest     (Default: true)
+    _uniform        - Include items in uniform  (Default: true)
+
+Example:
+    (begin example)
+    _allItems = [player, true, false] call CBA_fnc_getUniquePlayerItems
+    (end)
+
+Returns:
+    Array of item classnames <ARRAY>
+
+Author:
+    Dedmen
+---------------------------------------------------------------------------- */
+#include "script_component.hpp"
+SCRIPT(getUniquePlayerItems);
+
+params [["_unit", objNull, [objNull]], ["_weaponItems", true, [true]], ["_backpack", true, [true]], ["_vest", true, [true]], ["_uniform", true, [true]]];
+
+private _allItems = (assignedItems _unit);
+if (_uniform) then {_allItems append ((getItemCargo (uniformContainer _unit)) select 0);};
+if (_vest) then {_allItems append ((getItemCargo (vestContainer _unit)) select 0);};
+if (_backpack) then {_allItems append ((getItemCargo (backpackContainer _unit)) select 0);};
+
+if (_weaponItems) then {
+    _allItems append (primaryWeaponItems _unit);
+    _allItems append (secondaryWeaponItems _unit);
+    _allItems append (handgunItems _unit);
+    _allItems append [  primaryWeapon _unit, secondaryWeapon _unit, handgunWeapon _unit,
+                        primaryWeaponMagazine _unit, secondaryWeaponMagazine _unit, handgunMagazine _unit
+                     ];
+};
+
+_allItems arrayIntersect _allItems //Remove duplicates


### PR DESCRIPTION
Default settings return the same as `items _unit` but without duplicates.

iterating over items unit like in https://github.com/acemod/ACE3/blob/master/addons/tagging/functions/fnc_addTagActions.sqf#L36
Can be very expensive if you are just searching for whether the player has one item. Because it returns all items and multiple items as multiple strings.

Was a total perf killer in TFAR when someone had a backpack with ACE medical supplies. I'm sure this can be useful for many things.

Also made it configurable as you might want to exclude backpack or include weapon items.

I don't know how I could make unit tests for this. And I also don't quite like the current Name. My creativity has it's limits.