### PR TITLE
disable compile cache in script_macros_mission.hpp

### DIFF
--- a/addons/main/script_macros_mission.hpp
+++ b/addons/main/script_macros_mission.hpp
@@ -1,3 +1,4 @@
+#define DISABLE_COMPILE_CACHE
 #include "\x\cba\addons\main\script_macros_common.hpp"
 
 /*


### PR DESCRIPTION
**When merged this pull request will:**
- Title

Any reason one would want this enabled for missions?