### PR TITLE
Settings - Fix mouse scrolling on sub categories

### DIFF
--- a/addons/settings/gui.hpp
+++ b/addons/settings/gui.hpp
@@ -172,7 +172,7 @@ class GVAR(subCat): RscControlsGroupNoScrollbars {
             x = POS_W(0);
             y = POS_H(0);
             w = POS_W(36);
-            h = POS_H(1);
+            h = POS_H(0.75);
         };
         class Name: RscText {
             idc = IDC_SETTING_NAME;


### PR DESCRIPTION
Background was taller than control group, caused it to scroll instead of the parent control group