### PR TITLE
fix script error from whitelist

### DIFF
--- a/addons/settings/fnc_whitelisted.sqf
+++ b/addons/settings/fnc_whitelisted.sqf
@@ -21,9 +21,9 @@ Author:
 #include "script_component.hpp"
 
 private _uid = getPlayerUID player;
-private _whitelist = getArray configFile/QGVAR(whitelist);
+private _whitelist = getArray (configFile >> QGVAR(whitelist));
 
-private _cfgMissionList = missionConfigFile/QGVAR(whitelist);
+private _cfgMissionList = missionConfigFile >> QGVAR(whitelist);
 if (isArray _cfgMissionList) then {
     _whitelist append getArray _cfgMissionList;
 };


### PR DESCRIPTION
**When merged this pull request will:**
- fixes:
```
1:33:48 Error in expression <private _whitelist = getArray configFile/"cba_settings_whitelist";
private _cfg>
 1:33:48   Error position: </"cba_settings_whitelist";
private _cfg>
 1:33:48   Error /: Type Array, expected Number,Not a Number,Config entry
 1:33:48 File x\cba\addons\settings\fnc_whitelisted.sqf, line 5
 1:33:48 Error in expression <private _whitelist = getArray configFile/"cba_settings_whitelist";
private _cfg>
 1:33:48   Error position: </"cba_settings_whitelist";
private _cfg>
 1:33:48   Error Generic error in expression
 1:33:48 File x\cba\addons\settings\fnc_whitelisted.sqf, line 5
```

While `/`  has a higher priority than `>>`, both are lower than the unary `getArray`.

