### PR TITLE
Fix a issue that a PFH could be skip

### DIFF
--- a/addons/common/fnc_addPerFrameHandler.sqf
+++ b/addons/common/fnc_addPerFrameHandler.sqf
@@ -43,6 +43,6 @@ if (count GVAR(PFHhandles) >= 999999) exitWith {
 
 private _handle = GVAR(PFHhandles) pushBack count GVAR(perFrameHandlerArray);
 
-GVAR(perFrameHandlerArray) pushBack [_function, _delay, diag_tickTime, diag_tickTime, _args, _handle, false];
+GVAR(perFrameHandlerArray) pushBack [_function, _delay, diag_tickTime, diag_tickTime, _args, _handle, true];
 
 _handle

--- a/addons/common/fnc_addPerFrameHandler.sqf
+++ b/addons/common/fnc_addPerFrameHandler.sqf
@@ -43,6 +43,6 @@ if (count GVAR(PFHhandles) >= 999999) exitWith {
 
 private _handle = GVAR(PFHhandles) pushBack count GVAR(perFrameHandlerArray);
 
-GVAR(perFrameHandlerArray) pushBack [_function, _delay, diag_tickTime, diag_tickTime, _args, _handle, true];
+GVAR(perFrameHandlerArray) pushBack [_function, _delay, diag_tickTime, diag_tickTime, _args, _handle];
 
 _handle

--- a/addons/common/fnc_addPerFrameHandler.sqf
+++ b/addons/common/fnc_addPerFrameHandler.sqf
@@ -43,6 +43,6 @@ if (count GVAR(PFHhandles) >= 999999) exitWith {
 
 private _handle = GVAR(PFHhandles) pushBack count GVAR(perFrameHandlerArray);
 
-GVAR(perFrameHandlerArray) pushBack [_function, _delay, diag_tickTime, diag_tickTime, _args, _handle];
+GVAR(perFrameHandlerArray) pushBack [_function, _delay, diag_tickTime, diag_tickTime, _args, _handle, false];
 
 _handle

--- a/addons/common/fnc_removePerFrameHandler.sqf
+++ b/addons/common/fnc_removePerFrameHandler.sqf
@@ -33,8 +33,7 @@ if (_handle < 0 || {_handle >= count GVAR(PFHhandles)}) exitWith {};
     if (isNil "_index") exitWith {};
     GVAR(deletedPFHIndices) pushback _index;
 
-    private _oldData = GVAR(perFrameHandlerArray) select _index;
-    _oldData set [6, false];
+    (GVAR(perFrameHandlerArray) select _index) set [0, {}];
 
     GVAR(PFHhandles) set [_handle, nil];
 }, _handle] call CBA_fnc_directCall;

--- a/addons/common/fnc_removePerFrameHandler.sqf
+++ b/addons/common/fnc_removePerFrameHandler.sqf
@@ -34,9 +34,7 @@ if (_handle < 0 || {_handle >= count GVAR(PFHhandles)}) exitWith {};
     GVAR(deletedPFHIndices) pushback _index;
 
     private _oldData = GVAR(perFrameHandlerArray) select _index;
-    _oldData set [5, false];
-
-    GVAR(perFrameHandlerArray) set [_index, _oldData];
+    _oldData set [6, false];
 
     GVAR(PFHhandles) set [_handle, nil];
 }, _handle] call CBA_fnc_directCall;

--- a/addons/common/fnc_removePerFrameHandler.sqf
+++ b/addons/common/fnc_removePerFrameHandler.sqf
@@ -34,7 +34,7 @@ if (_handle < 0 || {_handle >= count GVAR(PFHhandles)}) exitWith {};
     GVAR(deletedPFHIndices) pushback _index;
 
     private _oldData = GVAR(perFrameHandlerArray) select _index;
-    _oldData set [5, true];
+    _oldData set [5, false];
 
     GVAR(perFrameHandlerArray) set [_index, _oldData];
 

--- a/addons/common/fnc_removePerFrameHandler.sqf
+++ b/addons/common/fnc_removePerFrameHandler.sqf
@@ -31,7 +31,7 @@ if (_handle < 0 || {_handle >= count GVAR(PFHhandles)}) exitWith {};
     private _index = GVAR(PFHhandles) select _handle;
 
     if (isNil "_index") exitWith {};
-    GVAR(deletedPFHIndices) pushback _index;
+    GVAR(deletedPFHIndices) pushBack _index;
 
     (GVAR(perFrameHandlerArray) select _index) set [0, {}];
 

--- a/addons/common/fnc_removePerFrameHandler.sqf
+++ b/addons/common/fnc_removePerFrameHandler.sqf
@@ -28,14 +28,17 @@ if (_handle < 0 || {_handle >= count GVAR(PFHhandles)}) exitWith {};
 
 [{
     params ["_handle"];
+    private _index = GVAR(PFHhandles) select _handle;
 
-    GVAR(perFrameHandlerArray) deleteAt (GVAR(PFHhandles) select _handle);
+    if (isNil "_index") exitWith {};
+    GVAR(deletedPFHIndices) pushback _index;
+
+    private _oldData = GVAR(perFrameHandlerArray) select _index;
+    _oldData set [5, true];
+
+    GVAR(perFrameHandlerArray) set [_index, _oldData];
+
     GVAR(PFHhandles) set [_handle, nil];
-
-    {
-        _x params ["", "", "", "", "", "_handle"];
-        GVAR(PFHhandles) set [_handle, _forEachIndex];
-    } forEach GVAR(perFrameHandlerArray);
 }, _handle] call CBA_fnc_directCall;
 
 nil

--- a/addons/common/init_perFrameHandler.sqf
+++ b/addons/common/init_perFrameHandler.sqf
@@ -15,6 +15,7 @@ GVAR(nextFrameNo) = diag_frameno + 1;
 GVAR(nextFrameBufferA) = [[[], {GVAR(nextFrameNo) = diag_frameno;}]];
 GVAR(nextFrameBufferB) = [];
 GVAR(waitUntilAndExecArray) = [];
+
 GVAR(deletedPFHIndices) = [];
 // per frame handler system
 [QFUNC(onFrame), {
@@ -23,19 +24,19 @@ GVAR(deletedPFHIndices) = [];
 
     // Execute per frame handlers
     {
-        _x params ["_function", "_delay", "_delta", "", "_args", "_handle", "_isDeleted"];
+        _x params ["_function", "_delay", "_delta", "", "_args", "_handle", "_isActiv"];
 
-        if (diag_tickTime > _delta && !_isDeleted) then {
+        if (diag_tickTime > _delta && _isActiv) then {
             _x set [2, _delta + _delay];
             [_args, _handle] call _function;
             false
         };
     } count GVAR(perFrameHandlerArray);
 
-    if !(GVAR(deletedIndices) isEqualTo []) then {
+    if !(GVAR(deletedPFHIndices) isEqualTo []) then {
         {
             GVAR(perFrameHandlerArray) set [_x, objNull];
-        } count GVAR(deletedIndices);
+        } count GVAR(deletedPFHIndices);
 
         GVAR(perFrameHandlerArray) = GVAR(perFrameHandlerArray) - [objNull];
 
@@ -43,7 +44,7 @@ GVAR(deletedPFHIndices) = [];
             _x params ["", "", "", "", "", "_handle"];
             GVAR(PFHhandles) set [_handle, _forEachIndex];
         } forEach GVAR(perFrameHandlerArray);
-        GVAR(deletedIndices) = [];
+        GVAR(deletedPFHIndices) = [];
     };
 
     // Execute wait and execute functions

--- a/addons/common/init_perFrameHandler.sqf
+++ b/addons/common/init_perFrameHandler.sqf
@@ -24,9 +24,9 @@ GVAR(deletedPFHIndices) = [];
 
     // Execute per frame handlers
     {
-        _x params ["_function", "_delay", "_delta", "", "_args", "_handle", "_isActive"];
+        _x params ["_function", "_delay", "_delta", "", "_args", "_handle"];
 
-        if (diag_tickTime > _delta && _isActive) then {
+        if (diag_tickTime > _delta) then {
             _x set [2, _delta + _delay];
             [_args, _handle] call _function;
             false

--- a/addons/common/init_perFrameHandler.sqf
+++ b/addons/common/init_perFrameHandler.sqf
@@ -24,9 +24,9 @@ GVAR(deletedPFHIndices) = [];
 
     // Execute per frame handlers
     {
-        _x params ["_function", "_delay", "_delta", "", "_args", "_handle", "_isActiv"];
+        _x params ["_function", "_delay", "_delta", "", "_args", "_handle", "_isActive"];
 
-        if (diag_tickTime > _delta && _isActiv) then {
+        if (diag_tickTime > _delta && _isActive) then {
             _x set [2, _delta + _delay];
             [_args, _handle] call _function;
             false


### PR DESCRIPTION
This PR fixes an issue that a Frame handler is skipped when the PFH that got executed before is deleted.
```sqf
{
    diag_log "delete FrameHandler No 1 Frame: " + str diag_frameNo;
    (_this select 1) call CBA_fnc_removePerFrameHandler;
} call CBA_fnc_addPerFrameHandler;

{
    diag_log "FrameHandler No 2 Frame: " + str diag_frameNo;
} call CBA_fnc_addPerFrameHandler;
```
Current Output:
>delete FrameHandler No 1 Frame: 5101
FrameHandler No 2 Frame:5102
FrameHandler No 2 Frame:5103
...

Expected Output:
>delete FrameHandler No 1 Frame: 5101
FrameHandler No 2 Frame:5101
FrameHandler No 2 Frame:5102
FrameHandler No 2 Frame:5103