### PR TITLE
FIX: cba_fnc_deleteEntity where group must be local to the machine executing deleteGroup command

### DIFF
--- a/addons/common/fnc_deleteEntity.sqf
+++ b/addons/common/fnc_deleteEntity.sqf
@@ -43,7 +43,15 @@ switch (typeName _entity) do {
     case "GROUP" : {
         (units _entity) call CBA_fnc_deleteEntity;
         {deleteWaypoint _x} forEach (wayPoints _entity);
-        deleteGroup _entity;
+        if (local _entity) then {
+            deleteGroup _entity;
+        } else {
+            if (isServer) then {
+                _entity remoteExecCall ["CBA_fnc_deleteEntity", groupOwner _entity];
+            } else {
+                _entity remoteExecCall ["CBA_fnc_deleteEntity", 2];
+            };
+        };
     };
     case "LOCATION" : {
         deleteLocation _entity;


### PR DESCRIPTION
Hello, I don't know if this function is supposed to be executed only locally but here is the fix in case group is not local to the machine trying to delete the group, or at least a solution.

**When merged this pull request will:**
- Fix [`cba_fnc_deleteEntity`](https://github.com/CBATeam/CBA_A3/blob/master/addons/common/fnc_deleteEntity.sqf)  where the group must be local to the machine executing the [`deleteGroup`](https://community.bistudio.com/wiki/deleteGroup). 
- check if group is local
- if not delete it where the group is local if we know it
- if not send the `deletegroup` to the server where `groupOwner` can be
know