### PR TITLE
Support # command in SQF Validator

### DIFF
--- a/tools/sqf_validator.py
+++ b/tools/sqf_validator.py
@@ -88,7 +88,7 @@ def check_sqf_syntax(filepath):
                             isInString = True
                             inStringType = c
                         elif (c == '#'):
-                            ignoreTillEndOfLine = True
+                            checkForSemiColumn = False
                         elif (c == '/'):
                             checkIfInComment = True
                         elif (c == '('):


### PR DESCRIPTION
**When merged this pull request will:**
- Support `#` command in SQF Validator (instead of ignore because we don't care about preprocessor directives)
- Will miss missing semi-colons on actual `#` command