### PR TITLE
Fix uniqueUnitItems typo and add assignedItems switch

### DIFF
--- a/addons/common/fnc_uniqueUnitItems.sqf
+++ b/addons/common/fnc_uniqueUnitItems.sqf
@@ -10,6 +10,7 @@ Parameters:
     _backpack       - Include items in backpack (Default: true)
     _vest           - Include items in vest     (Default: true)
     _uniform        - Include items in uniform  (Default: true)
+    _assignedItems        - Include assigned items  (Default: true)
 
 Example:
     (begin example)
@@ -25,12 +26,12 @@ Author:
 #include "script_component.hpp"
 SCRIPT(uniqueUnitItems);
 
-params [["_unit", objNull, [objNull]], ["_weaponItems", true, [true]], ["_backpack", true, [true]], ["_vest", true, [true]], ["_uniform", true, [true]]];
+params [["_unit", objNull, [objNull]], ["_weaponItems", false, [true]], ["_backpack", true, [true]], ["_vest", true, [true]], ["_uniform", true, [true]], ["_assignedItems", true, [true]]];
 
-private _allItems = (assignedItems _unit);
-if (_uniform) then {_allItems append ((getItemCargo (uniformContainer _unit)) select 0);};
-if (_vest) then {_allItems append ((getItemCargo (vestContainer _unit)) select 0);};
-if (_backpack) then {_allItems append ((getItemCargo (backpackContainer _unit)) select 0);};
+private _allItems = if (_assignedItems) then {assignedItems _unit} else {[]};
+if (_uniform) then {_allItems append ((getItemCargo (uniformContainer _unit)) select 0)};
+if (_vest) then {_allItems append ((getItemCargo (vestContainer _unit)) select 0)};
+if (_backpack) then {_allItems append ((getItemCargo (backpackContainer _unit)) select 0)};
 
 if (_weaponItems) then {
     _allItems append (primaryWeaponItems _unit);


### PR DESCRIPTION
- Fixes typo https://github.com/CBATeam/CBA_A3/pull/902/files#r187768475

Not a critical bug. Just causes the function to return more items that advertised. Which given it's inteded use case doesn't matter much.

- Add's switch to disable assignedItems because these half a dozen items matter for some users

Do you prefer to keep the useless semicolons that I removed?