### PR TITLE
Cache CreditsLine entries

### DIFF
--- a/addons/help/XEH_preStart.sqf
+++ b/addons/help/XEH_preStart.sqf
@@ -2,3 +2,15 @@
 
 PREP(setVersionLine);
 PREP(setCreditsLine);
+
+
+
+//Cache for CBA_help_fnc_setCreditsLine
+if (!isClass (configFile >> "CfgPatches" >> "CBA_DisableCredits")) then {
+    uiNamespace setVariable [QGVAR(creditsCache),  
+        "isText (_x >> 'author') &&
+        {getText (_x >> 'author') != localize 'STR_A3_Bohemia_Interactive'} &&
+        {getText (_x >> 'author') != ''}
+        " configClasses (configFile >> "CfgPatches");
+    ];
+};

--- a/addons/help/fnc_setCreditsLine.sqf
+++ b/addons/help/fnc_setCreditsLine.sqf
@@ -29,11 +29,7 @@ if (CBA_DisableCredits) exitWith {};
 
 // find addon with author
 private _config = configFile >> "CfgPatches";
-private _entry = selectRandom ("
-    isText (_x >> 'author') &&
-    {getText (_x >> 'author') != localize 'STR_A3_Bohemia_Interactive'} &&
-    {getText (_x >> 'author') != ''}
-" configClasses _config);
+private _entry = selectRandom (uiNamespace getVariable [QGVAR(creditsCache), []]);
 
 if (isNil "_entry") exitWith {};
 


### PR DESCRIPTION
cba_help_fnc_setCreditsLine is the major lag cause when opening the Pause menu.
![arma3_x64_2018-05-17_20-33-03](https://user-images.githubusercontent.com/3768165/40197096-b9d62120-5a12-11e8-83eb-a83b523f4fe7.png)
This is a very simple fix to get rid of that.
Scanning all CfgPatches entries everytime a player presses Escape wasn't a good idea in the first place.
