### PR TITLE
Add units[] array to CfgPatches entries

### DIFF
--- a/addons/accessory/MRT_AccFncs/config.cpp
+++ b/addons/accessory/MRT_AccFncs/config.cpp
@@ -2,5 +2,6 @@ class CfgPatches {
     class MRT_AccFncs {
         requiredAddons[] = {"cba_accessory"};
         versionDesc = "MRT Attachment Functions";
+        units[] = {};
     };
 };

--- a/addons/jr/asdg_jointmuzzles/config.cpp
+++ b/addons/jr/asdg_jointmuzzles/config.cpp
@@ -1,5 +1,6 @@
 class CfgPatches {
     class asdg_jointmuzzles {
         requiredAddons[] = {"cba_jr"};
+        units[] = {};
     };
 };

--- a/addons/jr/asdg_jointrails/config.cpp
+++ b/addons/jr/asdg_jointrails/config.cpp
@@ -1,5 +1,6 @@
 class CfgPatches {
     class asdg_jointrails {
         requiredAddons[] = {"cba_jr"};
+        units[] = {};
     };
 };

--- a/addons/ui/ui_helper/config.cpp
+++ b/addons/ui/ui_helper/config.cpp
@@ -1,5 +1,6 @@
 class CfgPatches {
     class cba_ui_helper {
         requiredAddons[] = {"cba_ui"};
+        units[] = {};
     };
 };

--- a/addons/xeh/CBA_Extended_EventHandlers/config.cpp
+++ b/addons/xeh/CBA_Extended_EventHandlers/config.cpp
@@ -1,5 +1,6 @@
 class CfgPatches {
     class CBA_Extended_EventHandlers {
         requiredAddons[] = {"cba_xeh"};
+        units[] = {};
     };
 };

--- a/addons/xeh/Extended_EventHandlers/config.cpp
+++ b/addons/xeh/Extended_EventHandlers/config.cpp
@@ -1,5 +1,6 @@
 class CfgPatches {
     class Extended_EventHandlers {
         requiredAddons[] = {"cba_xeh"};
+        units[] = {};
     };
 };

--- a/addons/xeh/ee/config.cpp
+++ b/addons/xeh/ee/config.cpp
@@ -1,5 +1,6 @@
 class CfgPatches {
     class cba_ee {
         requiredAddons[] = {"cba_xeh"};
+        units[] = {};
     };
 };

--- a/addons/xeh/xeh_a3/config.cpp
+++ b/addons/xeh/xeh_a3/config.cpp
@@ -1,5 +1,6 @@
 class CfgPatches {
     class cba_xeh_a3 {
         requiredAddons[] = {"cba_xeh"};
+        units[] = {};
     };
 };


### PR DESCRIPTION
Put down Zeus->Game Master module and it throws error
```
Warning Message: No entry 'bin\config.bin/CfgPatches/CBA_Extended_EventHandlers.units'.
Warning Message: No entry 'bin\config.bin/CfgPatches/cba_ee.units'.
Warning Message: No entry 'bin\config.bin/CfgPatches/Extended_EventHandlers.units'.
Warning Message: No entry 'bin\config.bin/CfgPatches/cba_xeh_a3.units'.
Warning Message: No entry 'bin\config.bin/CfgPatches/MRT_AccFncs.units'.
Warning Message: No entry 'bin\config.bin/CfgPatches/asdg_jointmuzzles.units'.
Warning Message: No entry 'bin\config.bin/CfgPatches/asdg_jointrails.units'.
Warning Message: No entry 'bin\config.bin/CfgPatches/cba_ui_helper.units'.
```