### PR TITLE
 Add basic functions for change of basis in 3D

### DIFF
--- a/addons/vectors/CfgFunctions.hpp
+++ b/addons/vectors/CfgFunctions.hpp
@@ -2,6 +2,8 @@
 class CfgFunctions {
     class CBA {
         class Vectors {
+            PATHTO_FNC(matrixProduct3D);
+            PATHTO_FNC(matrixTranspose);
             PATHTO_FNC(polar2vect);
             PATHTO_FNC(scaleVect);
             PATHTO_FNC(scaleVectTo);
@@ -16,6 +18,7 @@ class CfgFunctions {
             PATHTO_FNC(vectElev);
             PATHTO_FNC(vectMagn);
             PATHTO_FNC(vectMagn2D);
+            PATHTO_FNC(vectMap3D);
             PATHTO_FNC(vectRotate2D);
             PATHTO_FNC(vectRotate3D);
             PATHTO_FNC(vectSubtract);

--- a/addons/vectors/fnc_matrixProduct3D.sqf
+++ b/addons/vectors/fnc_matrixProduct3D.sqf
@@ -22,7 +22,6 @@ Examples:
 Author:
     Kex
 ---------------------------------------------------------------------------- */
-
 #include "script_component.hpp"
 
 params [["_matrixA", [], [[]], 3], ["_matrixB", [], [[]], 3]];

--- a/addons/vectors/fnc_matrixProduct3D.sqf
+++ b/addons/vectors/fnc_matrixProduct3D.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /* ----------------------------------------------------------------------------
 Function: CBA_fnc_matrixProduct3D
 
@@ -22,7 +23,6 @@ Examples:
 Author:
     Kex
 ---------------------------------------------------------------------------- */
-#include "script_component.hpp"
 
 params [["_matrixA", [], [[]], 3], ["_matrixB", [], [[]], 3]];
 

--- a/addons/vectors/fnc_matrixProduct3D.sqf
+++ b/addons/vectors/fnc_matrixProduct3D.sqf
@@ -1,0 +1,43 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_matrixProduct3D
+
+Description:
+   Returns the resulting matrix from the matrix-matrix product.
+
+   Only accepts a 3x3 matrices.
+
+Parameters:
+    _matrixA       - first 3x3 matrix. <ARRAY>
+    _matrixB       - second 3x3 matrix. <ARRAY>
+
+Returns:
+     _returnMatrix - 3x3 matrix returned after matrix multiplication <ARRAY>
+
+Examples:
+    (begin example)
+    // point reflection at origin [0,0,0] for every vector in matrix B
+    [[[-1,0,0],[0,-1,0],[0,0,-1]], [[1,2,3], [3,1,2], [2,3,1]]] call CBA_fnc_matrixProduct3D;
+    (end)
+
+Author:
+    Kex
+---------------------------------------------------------------------------- */
+
+#include "script_component.hpp"
+
+params [["_matrixA", [], [[]], 3], ["_matrixB", [], [[]], 3]];
+
+_matrixB = [_matrixB] call CBA_fnc_matrixTranspose;
+
+private _returnMatrix = [];
+for "_i" from 0 to (count _matrixA -1) do
+{
+    private _returnRow = [];
+    private _rowA = _matrixA select _i;
+	  for "_j" from 0 to (count _matrixB -1) do
+	  {
+	      _returnRow pushBack (_rowA vectorDotProduct ( _matrixB select _j));
+	  };
+	  _returnMatrix pushBack _returnRow;
+};
+_returnMatrix;

--- a/addons/vectors/fnc_matrixProduct3D.sqf
+++ b/addons/vectors/fnc_matrixProduct3D.sqf
@@ -2,16 +2,16 @@
 Function: CBA_fnc_matrixProduct3D
 
 Description:
-   Returns the resulting matrix from the matrix-matrix product.
+    Returns the resulting matrix from the matrix-matrix product.
 
-   Only accepts a 3x3 matrices.
+    Only accepts a 3x3 matrices.
 
 Parameters:
-    _matrixA       - first 3x3 matrix. <ARRAY>
-    _matrixB       - second 3x3 matrix. <ARRAY>
+    _matrixA      - first 3x3 matrix. <ARRAY>
+    _matrixB      - second 3x3 matrix. <ARRAY>
 
 Returns:
-     _returnMatrix - 3x3 matrix returned after matrix multiplication <ARRAY>
+    _returnMatrix - 3x3 matrix returned after matrix multiplication <ARRAY>
 
 Examples:
     (begin example)

--- a/addons/vectors/fnc_matrixProduct3D.sqf
+++ b/addons/vectors/fnc_matrixProduct3D.sqf
@@ -30,5 +30,5 @@ params [["_matrixA", [], [[]], 3], ["_matrixB", [], [[]], 3]];
 _matrixB = [_matrixB] call CBA_fnc_matrixTranspose;
 _matrixA apply {
     private _rowA = _x; 
-    _matrixB apply {_rowA vectorDotProduct _x};
-};
+    _matrixB apply {_rowA vectorDotProduct _x}
+} // return

--- a/addons/vectors/fnc_matrixProduct3D.sqf
+++ b/addons/vectors/fnc_matrixProduct3D.sqf
@@ -4,7 +4,7 @@ Function: CBA_fnc_matrixProduct3D
 Description:
     Returns the resulting matrix from the matrix-matrix product.
 
-    Only accepts a 3x3 matrices.
+    Only accepts 3x3 matrices.
 
 Parameters:
     _matrixA      - first 3x3 matrix. <ARRAY>

--- a/addons/vectors/fnc_matrixProduct3D.sqf
+++ b/addons/vectors/fnc_matrixProduct3D.sqf
@@ -28,16 +28,7 @@ Author:
 params [["_matrixA", [], [[]], 3], ["_matrixB", [], [[]], 3]];
 
 _matrixB = [_matrixB] call CBA_fnc_matrixTranspose;
-
-private _returnMatrix = [];
-for "_i" from 0 to (count _matrixA -1) do
-{
-    private _returnRow = [];
-    private _rowA = _matrixA select _i;
-    for "_j" from 0 to (count _matrixB -1) do
-    {
-        _returnRow pushBack (_rowA vectorDotProduct ( _matrixB select _j));
-    };
-    _returnMatrix pushBack _returnRow;
+_matrixA apply {
+    private _rowA = _x; 
+    _matrixB apply {_rowA vectorDotProduct _x};
 };
-_returnMatrix;

--- a/addons/vectors/fnc_matrixProduct3D.sqf
+++ b/addons/vectors/fnc_matrixProduct3D.sqf
@@ -34,10 +34,10 @@ for "_i" from 0 to (count _matrixA -1) do
 {
     private _returnRow = [];
     private _rowA = _matrixA select _i;
-	  for "_j" from 0 to (count _matrixB -1) do
-	  {
-	      _returnRow pushBack (_rowA vectorDotProduct ( _matrixB select _j));
-	  };
-	  _returnMatrix pushBack _returnRow;
+    for "_j" from 0 to (count _matrixB -1) do
+    {
+        _returnRow pushBack (_rowA vectorDotProduct ( _matrixB select _j));
+    };
+    _returnMatrix pushBack _returnRow;
 };
 _returnMatrix;

--- a/addons/vectors/fnc_matrixTranspose.sqf
+++ b/addons/vectors/fnc_matrixTranspose.sqf
@@ -21,7 +21,6 @@ Examples:
 Author:
     Kyle Kotowick, Kex
 ---------------------------------------------------------------------------- */
-
 #include "script_component.hpp"
 
 params [["_matrix", [], [[]]]];

--- a/addons/vectors/fnc_matrixTranspose.sqf
+++ b/addons/vectors/fnc_matrixTranspose.sqf
@@ -26,19 +26,10 @@ Author:
 
 params [["_matrix", [], [[]]]];
 
-private _m = count _matrix;
-private _n = count (_matrix select 0);
-
 private _returnMatrix = [];
 
-for "_j" from 0 to (_n - 1) do
-{
-    private _returnRow = [];
-    for "_i" from 0 to (_m - 1) do
-    {
-        _returnRow pushBack ((_matrix select _i) select _j);
-    };
-    _returnMatrix pushBack _returnRow;
+for "_j" from 0 to (count (_matrix select 0) -1) do {
+    _returnMatrix pushBack (_matrix apply {_x select _j});
 };
 
 _returnMatrix;

--- a/addons/vectors/fnc_matrixTranspose.sqf
+++ b/addons/vectors/fnc_matrixTranspose.sqf
@@ -28,8 +28,8 @@ params [["_matrix", [], [[]]]];
 
 private _returnMatrix = [];
 
-for "_j" from 0 to (count (_matrix select 0) -1) do {
+for "_j" from 0 to (count (_matrix select 0) - 1) do {
     _returnMatrix pushBack (_matrix apply {_x select _j});
 };
 
-_returnMatrix;
+_returnMatrix

--- a/addons/vectors/fnc_matrixTranspose.sqf
+++ b/addons/vectors/fnc_matrixTranspose.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /* ----------------------------------------------------------------------------
 Function: CBA_fnc_matrixTranspose
 
@@ -21,7 +22,6 @@ Examples:
 Author:
     Kyle Kotowick, Kex
 ---------------------------------------------------------------------------- */
-#include "script_component.hpp"
 
 params [["_matrix", [], [[]]]];
 

--- a/addons/vectors/fnc_matrixTranspose.sqf
+++ b/addons/vectors/fnc_matrixTranspose.sqf
@@ -2,15 +2,15 @@
 Function: CBA_fnc_matrixTranspose
 
 Description:
-   Returns the transposed matrix.
+    Returns the transposed matrix.
 
-   Accepts any mxn matrix.
+    Accepts any mxn matrix.
 
 Parameters:
-    _matrix        - mxn matrix to transpose. <ARRAY>
+    _matrix       - mxn matrix to transpose. <ARRAY>
 
 Returns:
-     _returnMatrix - nxm matrix <ARRAY>
+    _returnMatrix - nxm matrix <ARRAY>
 
 Examples:
     (begin example)

--- a/addons/vectors/fnc_matrixTranspose.sqf
+++ b/addons/vectors/fnc_matrixTranspose.sqf
@@ -1,0 +1,44 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_matrixTranspose
+
+Description:
+   Returns the transposed matrix.
+
+   Accepts any mxn matrix.
+
+Parameters:
+    _matrix        - mxn matrix to transpose. <ARRAY>
+
+Returns:
+     _returnMatrix - nxm matrix <ARRAY>
+
+Examples:
+    (begin example)
+    // returns the transposed matrix [[1,3,2], [2,1,3], [3,2,1]]
+    [[[1,2,3], [3,1,2], [2,3,1]]] call CBA_fnc_matrixTranspose;
+    (end)
+
+Author:
+    Kyle Kotowick, Kex
+---------------------------------------------------------------------------- */
+
+#include "script_component.hpp"
+
+params [["_matrix", [], [[]]]];
+
+private _m = count _matrix;
+private _n = count (_matrix select 0);
+
+private _returnMatrix = [];
+
+for "_j" from 0 to (_n - 1) do
+{
+    private _returnRow = [];
+    for "_i" from 0 to (_m - 1) do
+    {
+        _returnRow pushBack ((_matrix select _i) select _j);
+    };
+    _returnMatrix pushBack _returnRow;
+};
+
+_returnMatrix;

--- a/addons/vectors/fnc_vectMap3D.sqf
+++ b/addons/vectors/fnc_vectMap3D.sqf
@@ -22,8 +22,8 @@ Examples:
 Author:
     Kex
 ---------------------------------------------------------------------------- */
-
 #include "script_component.hpp"
 
-params[["_matrix", [], [[]], 3], ["_vector", [], [[]], 3]];
-_matrix apply {_x vectorDotProduct _vector};
+params [["_matrix", [], [[]], 3], ["_vector", [], [[]], 3]];
+
+_matrix apply {_x vectorDotProduct _vector} // return

--- a/addons/vectors/fnc_vectMap3D.sqf
+++ b/addons/vectors/fnc_vectMap3D.sqf
@@ -1,0 +1,29 @@
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_vectMap3D
+
+Description:
+   Returns the resulting vector of the product matrix-vector product.
+
+   Only accepts a 3x3 matrices and 3D vector.
+
+Parameters:
+    _matrix       - 3x3 matrix, which serves as a map. <ARRAY>
+    _vector       - 3D vector that is mapped. <ARRAY>
+
+Returns:
+     _returnVector - 3D vector returned after matrix multiplication <ARRAY>
+
+Examples:
+    (begin example)
+    // point reflection at origin [0,0,0]
+    [[[-1,0,0],[0,-1,0],[0,0,-1]], [1,2,3]] call CBA_fnc_vectMap3D;
+    (end)
+
+Author:
+    Kex
+---------------------------------------------------------------------------- */
+
+#include "script_component.hpp"
+
+params[["_matrix", [], [[]], 3], ["_vector", [], [[]], 3]];
+_matrix apply {_x vectorDotProduct _vector};

--- a/addons/vectors/fnc_vectMap3D.sqf
+++ b/addons/vectors/fnc_vectMap3D.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /* ----------------------------------------------------------------------------
 Function: CBA_fnc_vectMap3D
 
@@ -22,7 +23,6 @@ Examples:
 Author:
     Kex
 ---------------------------------------------------------------------------- */
-#include "script_component.hpp"
 
 params [["_matrix", [], [[]], 3], ["_vector", [], [[]], 3]];
 

--- a/addons/vectors/fnc_vectMap3D.sqf
+++ b/addons/vectors/fnc_vectMap3D.sqf
@@ -2,16 +2,16 @@
 Function: CBA_fnc_vectMap3D
 
 Description:
-   Returns the resulting vector of the product matrix-vector product.
+    Returns the resulting vector of the product matrix-vector product.
 
-   Only accepts a 3x3 matrices and 3D vector.
+    Only accepts a 3x3 matrices and 3D vector.
 
 Parameters:
     _matrix       - 3x3 matrix, which serves as a map. <ARRAY>
     _vector       - 3D vector that is mapped. <ARRAY>
 
 Returns:
-     _returnVector - 3D vector returned after matrix multiplication <ARRAY>
+    _returnVector - 3D vector returned after matrix multiplication <ARRAY>
 
 Examples:
     (begin example)

--- a/addons/vectors/fnc_vectMap3D.sqf
+++ b/addons/vectors/fnc_vectMap3D.sqf
@@ -2,9 +2,9 @@
 Function: CBA_fnc_vectMap3D
 
 Description:
-    Returns the resulting vector of the product matrix-vector product.
+    Returns the resulting vector of the matrix-vector product.
 
-    Only accepts a 3x3 matrices and 3D vector.
+    Only accepts a 3x3 matrix and 3D vector.
 
 Parameters:
     _matrix       - 3x3 matrix, which serves as a map. <ARRAY>

--- a/addons/vectors/test_vectors.sqf
+++ b/addons/vectors/test_vectors.sqf
@@ -311,4 +311,39 @@ _result = _temp call CBA_fnc_polar2vect;
 TEST_TRUE([ARR_2(_result,_expected)] call _fnc_vectorEquals, "complex polar 2");
 
 
+// UNIT TESTS (vectMap3D)
+_fn = "CBA_fnc_vectMap3D";
+TEST_DEFINED("CBA_fnc_vectMap3D","");
+
+_result = [[[0,1,0],[0,0,1],[1,0,0]], [1,2,3]] call CBA_fnc_vectMap3D;
+_expected = [2,3,1];
+TEST_TRUE([ARR_2(_result,_expected)] call _fnc_vectorEquals, _fn);
+
+_result = [[[1,2,5],[2,-1,3],[5,6,-1]], [1,2,3]] call CBA_fnc_vectMap3D;
+_expected = [20,9,14];
+TEST_TRUE([ARR_2(_result,_expected)] call _fnc_vectorEquals, _fn);
+
+// UNIT TESTS (matrixTranspose)
+_fn = "CBA_fnc_matrixTranspose";
+TEST_DEFINED("CBA_fnc_matrixTranspose","");
+
+_result = [[[1,2,5],[-2,4,3],[5,6,8]]] call CBA_fnc_matrixTranspose;
+_expected = [[1,-2,5],[2,4,6],[5,3,8]];
+TEST_TRUE([ARR_2(_result,_expected)] call _fnc_matrixEquals, _fn);
+
+// UNIT TESTS (matrixProduct3D)
+_fn = "CBA_fnc_matrixProduct3D";
+TEST_DEFINED("CBA_fnc_matrixProduct3D","");
+
+_result = [[[1,2,5],[2,-1,3],[5,6,-1]], [[1,2,3],[3,1,2],[2,3,1]]] call CBA_fnc_matrixProduct3D;
+_expected = [[17,19,12],[5,12,7],[21,13,26]];
+TEST_TRUE([ARR_2(_result,_expected)] call _fnc_matrixEquals, _fn);
+
+private _orthogonalMatrix = [[2/3,-1/3,2/3],[2/3,2/3,-1/3],[-1/3,2/3,2/3]];
+private _orthogonalMatrixTransposed = [_orthogonalMatrix] call CBA_fnc_matrixTranspose;
+_result = [_orthogonalMatrix, _orthogonalMatrixTransposed] call CBA_fnc_matrixProduct3D;
+_expected = [[1,0,0],[0,1,0],[0,0,1]];
+TEST_TRUE([ARR_2(_result,_expected)] call _fnc_matrixEquals, _fn);
+
+
 nil;

--- a/addons/vectors/test_vectors.sqf
+++ b/addons/vectors/test_vectors.sqf
@@ -12,10 +12,25 @@ private _fnc_vectorEquals = {
     if ((count _vector1) != (count _vector2)) exitWith {false};
     private _equal = true;
     {
-        if ((abs (_x - (_vector2 select _forEachIndex))) > 0.00001) then {
+        if ((abs (_x - (_vector2 select _forEachIndex))) > 0.00001) exitWith {
             _equal = false;
         };
     } forEach _vector1;
+    _equal
+};
+
+//Need custom func to compare matrices to handle floating point errors
+private _fnc_matrixEquals = {
+    params ["_matrix1", "_matrix2"];
+    if ((isNil "_matrix1") || {isNil "_matrix2"}) exitWith {false};
+    if (!(_matrix1 isEqualTypeArray _matrix2)) exitWith {false};
+    if ((count _matrix1) != (count _matrix2)) exitWith {false};
+    private _equal = true;
+    {
+        if !([ARR_2(_x, _matrix2 select _forEachIndex)] call _fnc_vectorEquals) exitWith {
+            _equal = false;
+        };
+    } forEach _matrix1;
     _equal
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add `CBA_fnc_matrixProduct3D` for the product of two 3x3-matrices.
- Add `CBA_fnc_matrixTranspose` for transposing a mxn-matrix.
- Add `CBA_fnc_vectMap3D` for 3x3-matrix - 3D-vector multiplication.
