### PR TITLE
FIX: CBA_fnc_deleteEntity looping over network and kill dedicated server

### DIFF
--- a/addons/common/fnc_deleteEntity.sqf
+++ b/addons/common/fnc_deleteEntity.sqf
@@ -51,7 +51,7 @@ switch (typeName _entity) do {
                 if (_groupOwner isEqualTo 0) then {
                     [{groupOwner _this != 0}, {
                         _this call CBA_fnc_deleteEntity;
-                    }, _entity, 1] call CBA_fnc_waitUntilAndExecute;
+                    }, _entity] call CBA_fnc_waitUntilAndExecute;
                 } else {
                    _entity remoteExecCall ["CBA_fnc_deleteEntity", _groupOwner];
                 };

--- a/addons/common/fnc_deleteEntity.sqf
+++ b/addons/common/fnc_deleteEntity.sqf
@@ -49,7 +49,7 @@ switch (typeName _entity) do {
             if (isServer) then {
                 private _groupOwner = groupOwner _entity;
                 if (_groupOwner isEqualTo 0) then {
-                    [{groupOwner _this != 0}, {
+                    [{groupOwner _this != 0 || isNull _this}, {
                         _this call CBA_fnc_deleteEntity;
                     }, _entity] call CBA_fnc_waitUntilAndExecute;
                 } else {
@@ -64,7 +64,7 @@ switch (typeName _entity) do {
         deleteLocation _entity;
     };
     case "STRING" : {
-        deleteMarker _entity
+        deleteMarker _entity;
     };
     default {};
 };

--- a/addons/common/fnc_deleteEntity.sqf
+++ b/addons/common/fnc_deleteEntity.sqf
@@ -47,7 +47,14 @@ switch (typeName _entity) do {
             deleteGroup _entity;
         } else {
             if (isServer) then {
-                _entity remoteExecCall ["CBA_fnc_deleteEntity", groupOwner _entity];
+                private _groupOwner = groupOwner _entity;
+                if (_groupOwner isEqualTo 0) then {
+                    [{groupOwner _this != 0}, {
+                        _this call CBA_fnc_deleteEntity;
+                    }, _entity, 1] call CBA_fnc_waitUntilAndExecute;
+                } else {
+                   _entity remoteExecCall ["CBA_fnc_deleteEntity", _groupOwner];
+                };
             } else {
                 _entity remoteExecCall ["CBA_fnc_deleteEntity", 2];
             };


### PR DESCRIPTION
When a unit is created inside a group, the group locality isn't immediately the same as the unit. It is `0`, which mean the `CBA_fnc_deleteEntity` is `remoteExecCall` to every client. So because the unit is only local  to server or one client, all others clients will `remeteExecCall` again the `CBA_fnc_deleteEntity` to server because `groupOwner` can only be tested on it. So the remote execution is starting to loop between all client and server, until the `groupOwner` return a real client (not `0`).

Code testing the `groupOwner` command (executed server side in debug console):
```sqf
private _group = createGroup west;
_group createUnit ["B_officer_F", [0, 0, 0], [], 0, "CARGO"];
diag_log format ["Locality test without delay: isLocalUnit %1, groupOwner %2", local ((units _group) select 0), groupOwner _group];
//_group call CBA_fnc_deleteEntity;
[{
	params ["_args"];
	diag_log format ["Locality test with delay: isLocalUnit %1, groupOwner %2", local ((units _args) select 0), groupOwner _args];
}, _group, 2] call CBA_fnc_waitAndExecute;
```
Returned:
```rpt
12:56:54 "Locality test without delay: isLocalUnit true, groupOwner 0"
12:56:56 "Locality test with delay: isLocalUnit true, groupOwner 2"
```

This loop can dramatically kill the network (>500kbits) and the dedicated server FPS.
![20180617180828_1](https://user-images.githubusercontent.com/14364400/41808928-9e753494-76e5-11e8-837a-a845baf97063.jpg)


**When merged this pull request will:**
- To prevent that the `CBA_fnc_deleteEntity` execution is waiting until the `groupOwner` is correct (not `0`)
- Test if `groupOwner` isn't `0` before `remoteExecCall` 
- If  `groupOwner` is `0` wait until it isn't. Then `_group call CBA_fnc_deleteEntity;`
- Bug introduced by this https://github.com/CBATeam/CBA_A3/pull/916