### PR TITLE
fix resetting mission settings

### DIFF
--- a/addons/settings/fnc_initDisplayGameOptions.sqf
+++ b/addons/settings/fnc_initDisplayGameOptions.sqf
@@ -51,7 +51,10 @@ if (is3DEN && {FILE_EXISTS(MISSION_SETTINGS_FILE)}) then {
         private _setting = _x;
 
         (GVAR(missionConfig) getVariable [_setting, []]) params ["_value", "_priority"];
-        [_setting, _value, _priority, "mission"] call FUNC(set);
+
+        if (!isNil "_value") then {
+            [_setting, _value, _priority, "mission"] call FUNC(set);
+        };
     } forEach GVAR(allSettings);
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- fix #930

In 3DEN and if the mission settings file exists, `set` is called for all settings with the value from the mission settings file. For settings undefined in the mission settings file, this value is `nil`.
`set` handles `nil` values by changing them to the default value.
`set` is called without the "store" flag, so when using the preview or when putting the mission on a server, the correct setting would be read from mission.sqm. Only in the editor the setting would be wrong temporarily after the settings menu is opened.

This PR fixes that by not using `set` for settings that are left out of the settings file.