### PR TITLE
don't skip next PFH if current one is removed while iterating through

### DIFF
--- a/addons/common/fnc_removePerFrameHandler.sqf
+++ b/addons/common/fnc_removePerFrameHandler.sqf
@@ -9,7 +9,7 @@ Parameters:
     _handle - The function handle you wish to remove. <NUMBER>
 
 Returns:
-    None
+    true if removed successful, false otherwise <BOOLEAN>
 
 Examples:
     (begin example)
@@ -24,24 +24,31 @@ Author:
 
 params [["_handle", -1, [0]]];
 
-if (_handle < 0 || {_handle >= count GVAR(PFHhandles)}) exitWith {};
-
 [{
     params ["_handle"];
 
-    GVAR(perFrameHandlerArray) set [GVAR(PFHhandles) select _handle select 0, {}];
+    private _index = GVAR(PFHhandles) param [_handle];
+    if (isNil "_index") exitWith {false};
 
-    [{
-        params ["_handle"];
+    GVAR(PFHhandles) set [_handle, nil];
+    (GVAR(perFrameHandlerArray) select _index) set [0, {}];
 
-        GVAR(perFrameHandlerArray) deleteAt (GVAR(PFHhandles) select _handle);
-        GVAR(PFHhandles) set [_handle, nil];
+    if (GVAR(perFrameHandlersToRemove) isEqualTo []) then {
+        [{
+            {
+                GVAR(perFrameHandlerArray) set [_x, objNull];
+            } forEach GVAR(perFrameHandlersToRemove);
 
-        {
-            _x params ["", "", "", "", "", "_handle"];
-            GVAR(PFHhandles) set [_handle, _forEachIndex];
-        } forEach GVAR(perFrameHandlerArray);
-    }, _handle] call CBA_fnc_execNextFrame;
+            GVAR(perFrameHandlerArray) = GVAR(perFrameHandlerArray) - [objNull];
+            GVAR(perFrameHandlersToRemove) = [];
+
+            {
+                _x params ["", "", "", "", "", "_index"];
+                GVAR(PFHhandles) set [_index, _forEachIndex];
+            } forEach GVAR(perFrameHandlerArray);
+        }] call CBA_fnc_execNextFrame;
+    };
+
+    GVAR(perFrameHandlersToRemove) pushBackUnique _index;
+    true
 }, _handle] call CBA_fnc_directCall;
-
-nil

--- a/addons/common/fnc_removePerFrameHandler.sqf
+++ b/addons/common/fnc_removePerFrameHandler.sqf
@@ -34,7 +34,7 @@ params [["_handle", -1, [0]]];
     (GVAR(perFrameHandlerArray) select _index) set [0, {}];
 
     if (GVAR(perFrameHandlersToRemove) isEqualTo []) then {
-        [{
+        {
             {
                 GVAR(perFrameHandlerArray) set [_x, objNull];
             } forEach GVAR(perFrameHandlersToRemove);
@@ -46,7 +46,7 @@ params [["_handle", -1, [0]]];
                 _x params ["", "", "", "", "", "_index"];
                 GVAR(PFHhandles) set [_index, _forEachIndex];
             } forEach GVAR(perFrameHandlerArray);
-        }] call CBA_fnc_execNextFrame;
+        } call CBA_fnc_execNextFrame;
     };
 
     GVAR(perFrameHandlersToRemove) pushBackUnique _index;

--- a/addons/common/fnc_removePerFrameHandler.sqf
+++ b/addons/common/fnc_removePerFrameHandler.sqf
@@ -29,13 +29,19 @@ if (_handle < 0 || {_handle >= count GVAR(PFHhandles)}) exitWith {};
 [{
     params ["_handle"];
 
-    GVAR(perFrameHandlerArray) deleteAt (GVAR(PFHhandles) select _handle);
-    GVAR(PFHhandles) set [_handle, nil];
+    GVAR(perFrameHandlerArray) set [GVAR(PFHhandles) select _handle select 0, {}];
 
-    {
-        _x params ["", "", "", "", "", "_handle"];
-        GVAR(PFHhandles) set [_handle, _forEachIndex];
-    } forEach GVAR(perFrameHandlerArray);
+    [{
+        params ["_handle"];
+
+        GVAR(perFrameHandlerArray) deleteAt (GVAR(PFHhandles) select _handle);
+        GVAR(PFHhandles) set [_handle, nil];
+
+        {
+            _x params ["", "", "", "", "", "_handle"];
+            GVAR(PFHhandles) set [_handle, _forEachIndex];
+        } forEach GVAR(perFrameHandlerArray);
+    }, _handle] call CBA_fnc_execNextFrame;
 }, _handle] call CBA_fnc_directCall;
 
 nil

--- a/addons/common/init_perFrameHandler.sqf
+++ b/addons/common/init_perFrameHandler.sqf
@@ -6,6 +6,7 @@
 #define DELAY_MONITOR_THRESHOLD 1 // Frames
 
 GVAR(perFrameHandlerArray) = [];
+GVAR(perFrameHandlersToRemove) = [];
 GVAR(lastTickTime) = diag_tickTime;
 
 GVAR(waitAndExecArray) = [];


### PR DESCRIPTION
**When merged this pull request will:**
- deactivate PFH by replacing the script with `{}`, then delete NextFrame (guaranteed to happen outside of iterating through the array that is modified)
- more elegant than https://github.com/CBATeam/CBA_A3/pull/915 because doesn't change the EachFrame function
- close #915 

Needs testing, I won't have access to Arma this and the next week.