### PR TITLE
Workaround for settings size limitation

### DIFF
--- a/addons/settings/fnc_parse.sqf
+++ b/addons/settings/fnc_parse.sqf
@@ -27,7 +27,7 @@ private _fnc_parseAny = {
         _string = _string splitString WHITESPACE joinString "";
     };
 
-    parseSimpleArray format ["[%1]", _string] select 0
+    parseSimpleArray str (formatText ["[%1]", _string]) select 0
 };
 
 params [["_info", "", [""]], ["_validate", false, [false]], ["_source", "", [""]]];

--- a/addons/settings/fnc_parse.sqf
+++ b/addons/settings/fnc_parse.sqf
@@ -27,7 +27,7 @@ private _fnc_parseAny = {
         _string = _string splitString WHITESPACE joinString "";
     };
 
-    parseSimpleArray (["[", _string, "]"] joinString "") select 0;
+    parseSimpleArray (["[", _string, "]"] joinString "") select 0
 };
 
 params [["_info", "", [""]], ["_validate", false, [false]], ["_source", "", [""]]];

--- a/addons/settings/fnc_parse.sqf
+++ b/addons/settings/fnc_parse.sqf
@@ -27,7 +27,7 @@ private _fnc_parseAny = {
         _string = _string splitString WHITESPACE joinString "";
     };
 
-    parseSimpleArray str (formatText ["[%1]", _string]) select 0
+    parseSimpleArray (["[", _string, "]"] joinString "") select 0;
 };
 
 params [["_info", "", [""]], ["_validate", false, [false]], ["_source", "", [""]]];


### PR DESCRIPTION
this PR is a workaround that fixes an issue that settings could only be 8kb long due to the use of format.

example: https://gist.github.com/neilzar/cdf4fa7a06d43560df64eea36c2cffb5
parse throws the error
>Error Generic error in expression
Error position: <parseSimpleArray format ["[%1]", _string>
File x\cba\addons\settings\fnc_parse.sqf, line 30
