### PR TITLE
add tooltip about required mission start

### DIFF
--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -10,5 +10,9 @@
             <French>Community Base Addons - Composants communs</French>
             <Polish>Community Base Addons - Ogólne Komponenty</Polish>
         </Key>
+        <Key ID="STR_cba_common_need_mission_start">
+            <English>You must first start a mission.</English>
+            <German>Sie müssen zuerst eine Mission starten.</German>
+        </Key>
     </Package>
 </Project>

--- a/addons/keybinding/fnc_initDisplayConfigure.sqf
+++ b/addons/keybinding/fnc_initDisplayConfigure.sqf
@@ -23,6 +23,7 @@ if (isNil QUOTE(ADDON)) exitWith {
     private _ctrlToggleButton = _display displayCtrl IDC_BTN_CONFIGURE_ADDONS;
 
     _ctrlToggleButton ctrlEnable false;
+    _ctrlToggleButton ctrlSetTooltip LELSTRING(common,need_mission_start);
 };
 
 // ----- fill addon combo box

--- a/addons/settings/fnc_initDisplayGameOptions.sqf
+++ b/addons/settings/fnc_initDisplayGameOptions.sqf
@@ -19,6 +19,7 @@ if (isNil QUOTE(ADDON)) exitWith {
     private _ctrlToggleButton = _display displayCtrl IDC_BTN_CONFIGURE_ADDONS;
 
     _ctrlToggleButton ctrlEnable false;
+    _ctrlToggleButton ctrlSetTooltip LELSTRING(common,need_mission_start);
 };
 
 // ----- situational tooltips


### PR DESCRIPTION
**When merged this pull request will:**
- Adds this revolutionary new concept called "tooltip" explaining why you cannot edit the addon settings or addon keybinds in main menu or mission select screen
