### PR TITLE
addon options button tooltip

### DIFF
--- a/addons/settings/XEH_preInit.sqf
+++ b/addons/settings/XEH_preInit.sqf
@@ -98,6 +98,6 @@ if (isServer) then {
     [_setting, _value, _priority, "mission", _store] call FUNC(set);
 }] call CBA_fnc_addEventHandler;
 
-[[LLSTRING(menu_button)], QGVAR(MainMenuHelper)] call CBA_fnc_addPauseMenuOption;
+[[LLSTRING(menu_button), LLSTRING(menu_button_tooltip)], QGVAR(MainMenuHelper)] call CBA_fnc_addPauseMenuOption;
 
 ADDON = true;

--- a/addons/settings/stringtable.xml
+++ b/addons/settings/stringtable.xml
@@ -41,6 +41,10 @@
             <French>Addon Options</French>
             <Polish>Ustawienia addonów</Polish>
         </Key>
+        <Key ID="STR_cba_settings_menu_button_tooltip">
+            <English>Adjust addon settings.</English>
+            <German>Addon-Einstellungen anpassen.</German>
+        </Key>
         <Key ID="STR_cba_settings_3den_shortcut">
             <English>Addon Options...</English>
             <German>Addon-Optionen...</German>


### PR DESCRIPTION
**When merged this pull request will:**
- All other entries in the pause menu have tooltips, so this needs one too.