### PR TITLE
Keybinding - Highlight individual duplicate keys

### DIFF
--- a/addons/keybinding/fnc_gui_update.sqf
+++ b/addons/keybinding/fnc_gui_update.sqf
@@ -64,8 +64,6 @@ private _tablePosY = 0;
     _keybinds = _tempNamespace getVariable [_action, _keybinds];
 
     private _keyNames = [];
-    private _isDuplicated = false;
-
     {
         private _keybind = _x;
         private _keyName = _keybind call CBA_fnc_localizeKey;
@@ -77,17 +75,17 @@ private _tablePosY = 0;
 
         // search the addon for any other keybinds using this key.
         if (_keybind select 0 > DIK_ESCAPE) then {
-            {
+            if (_addonActions findIf {
                 private _duplicateAction = format ["%1$%2", _addon, _x];
                 private _duplicateKeybinds = GVAR(actions) getVariable _duplicateAction select 2;
                 _duplicateKeybinds = _tempNamespace getVariable [_duplicateAction, _duplicateKeybinds];
 
-                if (_keybind in _duplicateKeybinds && {_action != _duplicateAction}) exitWith {
-                    _isDuplicated = true;
-                };
-            } forEach _addonActions;
-
-            _keyNames pushBack _keyName;
+                _keybind in _duplicateKeybinds && {_action != _duplicateAction}
+            } > -1) then {
+                _keyNames pushBack format ["<t color='#FF0000'>%1</t>", _keyName];
+            } else {
+                _keyNames pushBack format ["<t color='#FFFFFF'>%1</t>", _keyName];
+            };
         };
     } forEach _keybinds;
 
@@ -123,12 +121,10 @@ private _tablePosY = 0;
     _edit setVariable [QGVAR(data), [_action, _displayName, _keybinds, _defaultKeybind, _forEachIndex]];
 
     private _assigned = _subcontrol controlsGroupCtrl IDC_KEY_ASSIGNED;
-    _assigned ctrlSetText (_keyNames joinString ", ");
+    _assigned ctrlSetStructuredText parseText (_keyNames joinString ", ");
     _assigned ctrlSetTooltip _tooltip;
-
-    if (_isDuplicated) then {
-        _assigned ctrlSetTextColor [1,0,0,1];
-    };
+    _assigned ctrlSetTooltipColorBox [1,1,1,1];
+    _assigned ctrlSetTooltipColorShade [0,0,0,0.7];
 
     _subcontrols pushBack _subcontrol;
     _editableSubcontrols pushBack _subcontrol;

--- a/addons/keybinding/gui.hpp
+++ b/addons/keybinding/gui.hpp
@@ -4,6 +4,7 @@ class RscText;
 class RscButton;
 class RscButtonMenu;
 class RscCombo;
+class RscStructuredText;
 
 class GVAR(key): RscControlsGroupNoScrollbars {
     idc = -1;
@@ -30,9 +31,9 @@ class GVAR(key): RscControlsGroupNoScrollbars {
             h = POS_H(1);
         };
 
-        class AssignedKey: RscText {
+        class AssignedKey: RscStructuredText {
             idc = IDC_KEY_ASSIGNED;
-            colorShadow[] = {0,0,0,0};
+            shadow = 0;
             x = POS_W(17);
             y = POS_H(0);
             w = POS_W(20);


### PR DESCRIPTION
**When merged this pull request will:**
- title
- Match tooltip box of `_edit` and `_assigned`
- Before: 
![cba_keybind_highlight_1](https://user-images.githubusercontent.com/34453221/44927125-66802400-ad21-11e8-85a7-540e2dcdc36d.png)
- After: 
![cba_keybind_highlight_2](https://user-images.githubusercontent.com/34453221/44927138-6d0e9b80-ad21-11e8-8049-81d9a3609fb3.png)


