### PR TITLE
Let whitelisted UIDs save server settings

### DIFF
--- a/addons/settings/fnc_set.sqf
+++ b/addons/settings/fnc_set.sqf
@@ -132,7 +132,7 @@ switch (toLower _source) do {
 
             [QGVAR(refreshSetting), _setting] call CBA_fnc_globalEvent;
         } else {
-            if (IS_ADMIN_LOGGED) then {
+            if (FUNC(whitelisted)) then {
                 [QGVAR(setSettingServer), [_setting, _value, _priority, _store]] call CBA_fnc_serverEvent;
             } else {
                 WARNING_1("Source is server, but no admin access. Setting: %1",_setting);

--- a/addons/settings/fnc_set.sqf
+++ b/addons/settings/fnc_set.sqf
@@ -132,7 +132,7 @@ switch (toLower _source) do {
 
             [QGVAR(refreshSetting), _setting] call CBA_fnc_globalEvent;
         } else {
-            if (FUNC(whitelisted)) then {
+            if ([] call FUNC(whitelisted)) then {
                 [QGVAR(setSettingServer), [_setting, _value, _priority, _store]] call CBA_fnc_serverEvent;
             } else {
                 WARNING_1("Source is server, but no admin access. Setting: %1",_setting);


### PR DESCRIPTION
**When merged this pull request will:**
- Fix `fnc_set` to allow whitelisted to save server settings
