### PR TITLE
CBA_fnc_getVolume not calculating volume correctly

### DIFF
--- a/addons/common/fnc_getVolume.sqf
+++ b/addons/common/fnc_getVolume.sqf
@@ -14,7 +14,7 @@ Returns:
 
 Examples:
     (begin example)
-        volume = _vehicle call CBA_fnc_getVolume
+        private _volume = _vehicle call CBA_fnc_getVolume
     (end)
 
 Author:

--- a/addons/common/fnc_getVolume.sqf
+++ b/addons/common/fnc_getVolume.sqf
@@ -4,22 +4,17 @@ Function: CBA_fnc_getVolume
 
 Description:
     Return the volume of the bounding box of an object's model.
-    An optional parameter can specify the calculation to use either boundingBox or boundingBoxReal.
+    The bounding box is retrieved using boundingBoxReal instead of boundingBox for more precise measurements.
 
 Parameters:
-    0: _object - Object to calculate the volume of <OBJECT>
-    1: _real   - false: use boundingBox, true: use boundingBoxReal (optional, default: true) <BOOLEAN>
+    _object - Object to calculate the volume of <OBJECT>
 
 Returns:
     _volume - Volume of the bounding box <NUMBER>
 
 Examples:
     (begin example)
-        // Less precise volume using boundingBox
-        _volume = [_vehicle, false] call CBA_fnc_getVolume
-
-        // More precise volume using boundingBoxReal
-        volume = [_vehicle] call CBA_fnc_getVolume
+        volume = _vehicle call CBA_fnc_getVolume
     (end)
 
 Author:
@@ -27,12 +22,8 @@ Author:
 ---------------------------------------------------------------------------- */
 SCRIPT(getVolume);
 
-params [
-    ["_object", objNull, [objNull]],
-    ["_real", true, [true]]
-];
+params [["_object", objNull, [objNull]]];
 
-private _boundingBox = [boundingBox _object, boundingBoxReal _object] select _real;
-_boundingBox params ["_leftBackBottom", "_rightFrontTop"];
+(boundingBoxReal _object) params ["_leftBackBottom", "_rightFrontTop"];
 (_rightFrontTop vectorDiff _leftBackBottom) params ["_width", "_length", "_height"];
 _width * _length * _height

--- a/addons/common/fnc_getVolume.sqf
+++ b/addons/common/fnc_getVolume.sqf
@@ -3,26 +3,36 @@
 Function: CBA_fnc_getVolume
 
 Description:
-    Return the volume of an object based on the object's model's bounding box.
+    Return the volume of the bounding box of an object's model.
+    An optional parameter can specify the calculation to use either boundingBox or boundingBoxReal.
 
 Parameters:
-    _object - an object to calculate the volume of <OBJECT>
+    0: _object - Object to calculate the volume of <OBJECT>
+    1: _real   - false: use boundingBox, true: use boundingBoxReal (optional, default: true) <BOOLEAN>
 
 Returns:
-    _volume - the volume <NUMBER>
+    _volume - Volume of the bounding box <NUMBER>
 
 Examples:
     (begin example)
-        _volume = _vehicle call CBA_fnc_getVolume
+        // Less precise volume using boundingBox
+        _volume = [_vehicle, false] call CBA_fnc_getVolume
+
+        // More precise volume using boundingBoxReal
+        volume = [_vehicle] call CBA_fnc_getVolume
     (end)
 
 Author:
-    Rommel
+    Anton
 ---------------------------------------------------------------------------- */
 SCRIPT(getVolume);
 
-params [["_object", objNull, [objNull]]];
+params [
+    ["_object", objNull, [objNull]],
+    ["_real", true, [true]]
+];
 
-private _bounds = (boundingBox _object) select 1;
-
-(_bounds select 0) * (_bounds select 1) * (_bounds select 2)
+private _boundingBox = [boundingBox _object, boundingBoxReal _object] select _real;
+_boundingBox params ["_leftBackBottom", "_rightFrontTop"];
+(_rightFrontTop vectorDiff _leftBackBottom) params ["_width", "_length", "_height"];
+_width * _length * _height


### PR DESCRIPTION
**When merged this pull request will:**
- Fix [CBA_fnc_getVolume](https://github.com/CBATeam/CBA_A3/blob/master/addons/common/fnc_getVolume.sqf) not calculating volume correctly
- Add an optional parameter to use greater or less precision in the calculation

The commands [boundingBox](https://community.bistudio.com/wiki/boundingBox) and [boundingBoxReal](https://community.bistudio.com/wiki/boundingBoxReal) return an array with the extreme points of a model in the format `[[x1, y1, z1], [x2, y2, z2]]` (left–back–bottom, right–front–top). The current implementation of `CBA_fnc_getVolume` returns the product `x2 * y2 * z2`. That is the formula for the volume of a cuboid given `x1`, `y1`, and `z1` are all `0`. However, for [boundingBox](https://community.bistudio.com/wiki/boundingBox) and [boundingBoxReal](https://community.bistudio.com/wiki/boundingBoxReal) they are not `0` but negative.

The proposed implementation calculates [vectorDiff](https://community.bistudio.com/wiki/vectorDiff) between `[x2, y2, z2]` and `[x1, y1, z1]` and returns the product of those elements. Similar calculations, for size instead of volume, can be seen in [BIS_fnc_boundingBoxMarker](https://community.bistudio.com/wiki/BIS_fnc_boundingBoxMarker) (although that function takes for each element [vectorDotProduct](https://community.bistudio.com/wiki/vectorDotProduct) between the difference and its corresponding units vector—overcomplicated and slower) and [BIS_fnc_objectHeight](https://community.bistudio.com/wiki/BIS_fnc_objectHeight) where the height is calculated as `z2-z1`. It is worth nothing however that in the vast majority of [BIS functions](https://community.bistudio.com/wiki/Category:Arma_3:_Functions) [abs](https://community.bistudio.com/wiki/abs) is used on the difference between the elements, which appears completely unnecessary as of all to judge the difference cannot be negative.

The proposed implementation uses [boundingBoxReal](https://community.bistudio.com/wiki/boundingBoxReal) by default for greater precision, while the current implementation uses [boundingBox](https://community.bistudio.com/wiki/boundingBox). This is motivated and does not break backwards compatability, as the current implementation does not return the volume in the first place.

The docstring does not explain the difference between [boundingBox](https://community.bistudio.com/wiki/boundingBox) and [boundingBoxReal](https://community.bistudio.com/wiki/boundingBoxReal) other than in the example. This is intentional, as the user is assumed to have prior knowledge of those engine commands. Feel free to include it in the function description or parameter description if it is considered suitable.

As the proposed implementation is written from scratch the previous author has been omitted. If this is uncalled for, feel free to include the previous author for historical reasons.

Example output from the current and proposed functions on a Strider follows below.

**Current implementation**
`[_strider] call CBA_fnc_getVolume`
22.5603

**Proposed implementation with less precision (using [boundingBox](https://community.bistudio.com/wiki/boundingBox))**
`[_strider, false] call CBA_fnc_getVolume`
180.483

**Proposed implementation with greater precision (using [boundingBoxReal](https://community.bistudio.com/wiki/boundingBoxReal))**
`[_strider, true] call CBA_fnc_getVolume`
104.446
`[_strider] call CBA_fnc_getVolume`
104.446