### PR TITLE
add WW2 era magwells

### DIFF
--- a/addons/jam/CfgMagazineWells.hpp
+++ b/addons/jam/CfgMagazineWells.hpp
@@ -6,26 +6,55 @@ class CfgMagazineWells {
     #include "magwells_762x39.hpp"
     #include "magwells_762x51.hpp"
     #include "magwells_762x54.hpp"
+    #include "magwells_77x58.hpp"
+    #include "magwells_792x57.hpp"
+    #include "magwells_145x114.hpp"
+    #include "magwells_303B.hpp"
+    #include "magwells_3006.hpp"
+
+    #include "magwells_762x25.hpp"
+    #include "magwells_8x22.hpp"
     #include "magwells_9x19.hpp"
+    #include "magwells_22LR.hpp"
+    #include "magwells_32ACP.hpp"
     #include "magwells_357SIG.hpp"
     #include "magwells_40SW.hpp"
+    #include "magwells_45ACP.hpp"
+
+    #include "magwells_10gauge.hpp"
+    #include "magwells_12gauge.hpp"
+    #include "magwells_16gauge.hpp"
+    #include "magwells_20gauge.hpp"
+
+    class CBA_762x38R_Nagant {};    // Nagant M1895 Revolver
+    class CBA_763x25_C96 {};        // Mauser C-96 in 7.63x25mm
+    class CBA_765x21_C96 {};        // Mauser C-96 in 7.65x21mm
+    class CBA_10x25_MP5 {};         // H&K MP5/10 10mm Auto
+    class CBA_38_200_Webley {};     // Webley Revolver in .38/200
+    class CBA_455_Webley {};        // Webley Revolver in .455 Webley
 
     class CBA_68x43_ACR {};         // 6.8mm Remington SPC
     class CBA_75x55_STGW57 {};      // SIG SG 510-1, Stgw. 57
     class CBA_762x35_STANAG {};     // .300 Blackout
-    class CBA_792x57_LINKS {};      // MG42
+    class CBA_792x33_StG {};        // StG44
+    class CBA_9x39_VSS {};          // Vintorez, Val
+    class CBA_11mm_Vickers {};      // Vickers machine gun in 11mm Vickers
     class CBA_300WM_AI {};          // AI .300 Winchester Magnum
     class CBA_338LM_AI {};          // AI .338 Lapua Magnum
     class CBA_50BMG_M107 {};        // M82, M107, G82
-    class CBA_9x39_VSS {};          // Vintorez, Val
-    class CBA_10x25_MP5 {};         // H&K MP5/10 10mm Auto
-    class CBA_12g_SAIGA {};
+
+    class CBA_35mm_Type10 {};       // Japanese Type 10 Flare Pistol
 
     #include "magwells_40mm.hpp"
+
+    class CBA_Bazooka {};       // M1, M1A1 Bazooka
 
     class CBA_RPG7 {
         BI_rockets[] = {
             "RPG7_F"
         };
     };
+
+    class CBA_PIAT {};          // PIAT
+    class CBA_Panzerschreck {}; // Panzerschreck RPzB 54
 };

--- a/addons/jam/magwells_10gauge.hpp
+++ b/addons/jam/magwells_10gauge.hpp
@@ -1,0 +1,9 @@
+    class CBA_10g_9rnds {};         // 9 loose rounds
+    class CBA_10g_8rnds {};         // 8 loose rounds
+    class CBA_10g_7rnds {};         // 7 loose rounds
+    class CBA_10g_6rnds {};         // 6 loose rounds
+    class CBA_10g_5rnds {};         // 5 loose rounds
+    class CBA_10g_4rnds {};         // 4 loose rounds
+    class CBA_10g_3rnds {};         // 3 loose rounds
+    class CBA_10g_2rnds {};         // 2 loose rounds
+    class CBA_10g_1rnd {};          // 1 loose round

--- a/addons/jam/magwells_12gauge.hpp
+++ b/addons/jam/magwells_12gauge.hpp
@@ -1,0 +1,11 @@
+    class CBA_12g_9rnds {};         // 9 loose rounds
+    class CBA_12g_8rnds {};         // 8 loose rounds
+    class CBA_12g_7rnds {};         // 7 loose rounds
+    class CBA_12g_6rnds {};         // 6 loose rounds
+    class CBA_12g_5rnds {};         // 5 loose rounds
+    class CBA_12g_4rnds {};         // 4 loose rounds
+    class CBA_12g_3rnds {};         // 3 loose rounds
+    class CBA_12g_2rnds {};         // 2 loose rounds
+    class CBA_12g_1rnd {};          // 1 loose round
+
+    class CBA_12g_SAIGA {};

--- a/addons/jam/magwells_145x114.hpp
+++ b/addons/jam/magwells_145x114.hpp
@@ -1,0 +1,2 @@
+    class CBA_145x114_PTRD {};      // PTRD-41
+    class CBA_145x114_PTRS {};      // PTRS-41

--- a/addons/jam/magwells_16gauge.hpp
+++ b/addons/jam/magwells_16gauge.hpp
@@ -1,0 +1,9 @@
+    class CBA_16g_9rnds {};         // 9 loose rounds
+    class CBA_16g_8rnds {};         // 8 loose rounds
+    class CBA_16g_7rnds {};         // 7 loose rounds
+    class CBA_16g_6rnds {};         // 6 loose rounds
+    class CBA_16g_5rnds {};         // 5 loose rounds
+    class CBA_16g_4rnds {};         // 4 loose rounds
+    class CBA_16g_3rnds {};         // 3 loose rounds
+    class CBA_16g_2rnds {};         // 2 loose rounds
+    class CBA_16g_1rnd {};          // 1 loose round

--- a/addons/jam/magwells_20gauge.hpp
+++ b/addons/jam/magwells_20gauge.hpp
@@ -1,0 +1,9 @@
+    class CBA_20g_9rnds {};         // 9 loose rounds
+    class CBA_20g_8rnds {};         // 8 loose rounds
+    class CBA_20g_7rnds {};         // 7 loose rounds
+    class CBA_20g_6rnds {};         // 6 loose rounds
+    class CBA_20g_5rnds {};         // 5 loose rounds
+    class CBA_20g_4rnds {};         // 4 loose rounds
+    class CBA_20g_3rnds {};         // 3 loose rounds
+    class CBA_20g_2rnds {};         // 2 loose rounds
+    class CBA_20g_1rnd {};          // 1 loose round

--- a/addons/jam/magwells_22LR.hpp
+++ b/addons/jam/magwells_22LR.hpp
@@ -1,0 +1,2 @@
+    class CBA_22LR_PP {};           // Walther PP in .22LR
+    class CBA_22LR_PPK {};          // Walther PPK in .22LR

--- a/addons/jam/magwells_3006.hpp
+++ b/addons/jam/magwells_3006.hpp
@@ -1,0 +1,5 @@
+    class CBA_3006_BAR {};          // M1918 BAR
+    class CBA_3006_Garand {};       // M1 Garand
+    class CBA_3006_Spring {};       // M1903 Springfield
+    class CBA_3006_Belt {};         // M1917/M1919 Browning Machine Gun
+    class CBA_3006_Vickers {};      // Vickers machine gun in .30-06

--- a/addons/jam/magwells_303B.hpp
+++ b/addons/jam/magwells_303B.hpp
@@ -1,0 +1,4 @@
+    class CBA_303B_LeeEn {};        // Lee Enfield
+    class CBA_303B_BREN {};         // BREN gun
+    class CBA_303B_Maxim {};        // Maxim gun in .303 British
+    class CBA_303B_Vickers {};      // Vickers machine gun in .303 British (might be the same as the Maxim belt in .303)

--- a/addons/jam/magwells_32ACP.hpp
+++ b/addons/jam/magwells_32ACP.hpp
@@ -1,0 +1,3 @@
+    class CBA_32ACP_PP {};          // Walther PP in .32 ACP (7.65x17mm Browning)
+    class CBA_32ACP_PPK {};         // Walther PPK in .32 ACP (7.65x17mm Browning)
+    class CBA_32ACP_Welrod {};      // Welrod pistol in .32 ACP (7.65x17mm Browning)

--- a/addons/jam/magwells_380ACP.hpp
+++ b/addons/jam/magwells_380ACP.hpp
@@ -1,0 +1,2 @@
+    class CBA_380ACP_PP {};         // Walther PP in .380 ACP (9x17mm/9mm Short/9mm Browning)
+    class CBA_380ACP_PPK {};        // Walther PPK in .380 ACP (9x17mm/9mm Short/9mm Browning)

--- a/addons/jam/magwells_45ACP.hpp
+++ b/addons/jam/magwells_45ACP.hpp
@@ -1,0 +1,7 @@
+    class CBA_45ACP_1911 {};        // Colt M1911
+    class CBA_45ACP_C96 {};         // Mauser C-96 in .45 ACP
+    class CBA_45ACP_Delisle {};     // De Lisle Carbine
+    class CBA_45ACP_Grease {};      // Grease Gun
+    class CBA_45ACP_Thompson_Stick {};  // Thompson stick magazines
+    class CBA_45ACP_Thompson_Drum {};   // Thompson drum magazines
+    class CBA_45ACP_Reising {};     // M50/M55 Reising

--- a/addons/jam/magwells_762x25.hpp
+++ b/addons/jam/magwells_762x25.hpp
@@ -1,0 +1,6 @@
+    class CBA_762x25_TT {};         // TT-30, TT-33 Tokarev
+    class CBA_762x25_PPS {};        // PPS-43
+    class CBA_762x25_PPSh_Stick {}; // PPSh-41 stick magazines
+    class CBA_762x25_PPSh_Drum {};  // PPSh-41 drum magazines
+    class CBA_762x25_PPD_Stick {};  // PPD-40 stick magazines
+    class CBA_762x25_PPD_Drum {};   // PPD-40 drum magazines

--- a/addons/jam/magwells_762x54.hpp
+++ b/addons/jam/magwells_762x54.hpp
@@ -10,3 +10,9 @@
             "150Rnd_762x54_Box_Tracer"
         };
     };
+
+    class CBA_762x54R_Mosin {};     // M91/30, M38, M44 Mosin
+    class CBA_762x54R_SVT {};       // SVT
+    class CBA_762x54R_DPM {};       // DPM
+    class CBA_762x54R_DT {};        // DT
+    class CBA_762x54R_Maxim {};     // Maxim gun in 7.62x54R

--- a/addons/jam/magwells_77x58.hpp
+++ b/addons/jam/magwells_77x58.hpp
@@ -1,0 +1,3 @@
+    class CBA_77x58_Arisaka {};     // Japanese Type 99 Arisaka
+    class CBA_77x58_Type92 {};      // Japanese Type 92 HMG
+    class CBA_77x58_Type99 {};      // Japanese Type 99 LMG

--- a/addons/jam/magwells_792x57.hpp
+++ b/addons/jam/magwells_792x57.hpp
@@ -1,0 +1,6 @@
+    class CBA_792x57_FG42 {};       // FG42
+    class CBA_792x57_G43 {};        // G43, G41
+    class CBA_792x57_K98 {};        // K98, G98
+    class CBA_792x57_LINKS {};      // MG42, MG34
+    class CBA_792x57_TROMMEL {};    // MG34 Patronentrommel 34
+    class CBA_792x57_MG08 {};       // MG08

--- a/addons/jam/magwells_8x22.hpp
+++ b/addons/jam/magwells_8x22.hpp
@@ -1,0 +1,3 @@
+    class CBA_8x22_TypeB {};        // Japanese Type B Nambu
+    class CBA_8x22_Type14 {};       // Japanese Type 14 Nambu
+    class CBA_8x22_Type100 {};      // Japanese Type 100 SMG

--- a/addons/jam/magwells_9x19.hpp
+++ b/addons/jam/magwells_9x19.hpp
@@ -3,3 +3,11 @@
     class CBA_9x19_P226 {};         // SIG P226
     class CBA_9x19_P228 {};         // SIG P228
     class CBA_9x19_P239 {};         // SIG P239
+    class CBA_9x19_MP40 {};         // MP40, MP38
+    class CBA_9x19_STEN {};         // STEN
+    class CBA_9x19_C96 {};          // Mauser C-96 in 9x19mm
+    class CBA_9x19_HiPower {};      // Browning HiPower
+    class CBA_9x19_P08 {};          // Luger P08
+    class CBA_9x19_P38 {};          // Walther P38
+    class CBA_9x19_Vis {};          // wz. 35 Vis (Radom)
+    class CBA_9x19_Welrod {};       // Welrod pistol in 9x19mm


### PR DESCRIPTION
**When merged this pull request will:**
- Add WW2 era magwells that should cover all current IFA3, FOW, LEN weapons
- Also add magwells for non-magazine fed shotguns.
All shotguns should use every magwell that is <= its tube capacity.