### PR TITLE
minor last-minute tweaks for AK magwells

### DIFF
--- a/addons/jam/CfgWeapons.hpp
+++ b/addons/jam/CfgWeapons.hpp
@@ -53,14 +53,14 @@ class CfgWeapons {
     };
 
     class arifle_AK12_base_F : Rifle_Base_F {
-        magazineWell[] = {"CBA_762x39_AK"};
+        magazineWell[] = {"CBA_762x39_AK", "CBA_762x39_RPK"};
     };
     class arifle_AKM_base_F : Rifle_Base_F {
-        magazineWell[] = {"CBA_762x39_AK"};
+        magazineWell[] = {"CBA_762x39_AK", "CBA_762x39_RPK"};
     };
 
     class arifle_AKS_base_F : Rifle_Base_F {
-        magazineWell[] = {"CBA_545x39_AK", "CBA_545x39_AK_L"};
+        magazineWell[] = {"CBA_545x39_AK", "CBA_545x39_RPK"};
     };
 
     class LMG_03_base_F : Rifle_Long_Base_F {

--- a/addons/jam/magwells_545x39.hpp
+++ b/addons/jam/magwells_545x39.hpp
@@ -7,4 +7,4 @@
         };
     };
 
-    class CBA_545x39_AK_L {};    // 45rnd RPK-74
+    class CBA_545x39_RPK {};    // 45rnd RPK-74

--- a/addons/jam/magwells_762x39.hpp
+++ b/addons/jam/magwells_762x39.hpp
@@ -6,4 +6,5 @@
             "30Rnd_762x39_Mag_Tracer_Green_F"
         };
     };
-    class CBA_762x39_RPK {};   // 40/45rnd
+
+    class CBA_762x39_RPK {};   // 40/45rnd RPK


### PR DESCRIPTION
- add CBA_762x39_RPK to vanilla weapons
- rename CBA_545x39_AK_L to CBA_545x39_RPK