### PR TITLE
Remove BOM character from stringtables

### DIFF
--- a/addons/accessory/stringtable.xml
+++ b/addons/accessory/stringtable.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project name="CBA_A3">
     <Package name="accessory">
         <Key ID="STR_CBA_accessory_Component">

--- a/addons/ai/stringtable.xml
+++ b/addons/ai/stringtable.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project name="CBA_A3">
     <Package name="AI">
         <Key ID="STR_CBA_AI_Component">

--- a/addons/arrays/stringtable.xml
+++ b/addons/arrays/stringtable.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project name="CBA_A3">
     <Package name="Arrays">
         <Key ID="STR_CBA_Arrays_Component">

--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project name="CBA_A3">
     <Package name="Common">
         <Key ID="STR_CBA_Common_Component">

--- a/addons/diagnostic/stringtable.xml
+++ b/addons/diagnostic/stringtable.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project name="CBA_A3">
     <Package name="Diagnostics">
         <Key ID="STR_CBA_Diagnostic_Component">

--- a/addons/events/stringtable.xml
+++ b/addons/events/stringtable.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project name="CBA_A3">
     <Package name="Events">
         <Key ID="STR_CBA_Events_Component">

--- a/addons/hashes/stringtable.xml
+++ b/addons/hashes/stringtable.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project name="CBA_A3">
     <Package name="Hashes">
         <Key ID="STR_CBA_Hashes_Component">

--- a/addons/help/stringtable.xml
+++ b/addons/help/stringtable.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project name="CBA_A3">
     <Package name="Help">
         <Key ID="STR_CBA_Help_Component">

--- a/addons/keybinding/stringtable.xml
+++ b/addons/keybinding/stringtable.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project name="CBA_A3">
     <Package name="Keybinding">
         <Key ID="STR_CBA_Keybinding_Component">

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project name="CBA_A3">
     <Package name="Main">
         <Key ID="STR_CBA_Author">

--- a/addons/modules/stringtable.xml
+++ b/addons/modules/stringtable.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project name="CBA_A3">
     <Package name="Modules">
         <Key ID="STR_CBA_Modules_Component">

--- a/addons/music/stringtable.xml
+++ b/addons/music/stringtable.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project name="CBA_A3">
     <Package name="Keybinding">
         <Key ID="STR_cba_music_Component">

--- a/addons/network/stringtable.xml
+++ b/addons/network/stringtable.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project name="CBA_A3">
     <Package name="Network">
         <Key ID="STR_CBA_Network_Component">

--- a/addons/settings/stringtable.xml
+++ b/addons/settings/stringtable.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project name="CBA_A3">
     <Package name="Settings">
         <Key ID="STR_cba_settings_Component">

--- a/addons/statemachine/stringtable.xml
+++ b/addons/statemachine/stringtable.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project name="CBA_A3">
     <Package name="Statemachine">
         <Key ID="STR_cba_statemachine_Component">

--- a/addons/ui/stringtable.xml
+++ b/addons/ui/stringtable.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project name="CBA_A3">
     <Package name="Ui">
         <Key ID="STR_CBA_Ui_Component">


### PR DESCRIPTION
**When merged this pull request will:**
- Remove BOM character from stringtable files

This repo `.editorconfig` is configured to encode files in UTF-8 **without** BOM, however currently most of the stringtables are encoded in UTF-8 **with** BOM character. From my tests it looks like it is due to usage of Tabler. 

Even when files are encoded without BOM the Tabler will save them with it.
