### PR TITLE
fix findMax for arrays with duplicates

### DIFF
--- a/addons/arrays/fnc_findMax.sqf
+++ b/addons/arrays/fnc_findMax.sqf
@@ -32,5 +32,4 @@ private _reverse = + _array;
 reverse _reverse;
 
 private _max = selectMax _reverse;
-
 [_max, count _array - (_reverse find _max) - 1]

--- a/addons/arrays/fnc_findMax.sqf
+++ b/addons/arrays/fnc_findMax.sqf
@@ -28,5 +28,9 @@ SCRIPT(findMax);
 
 if !(_array isEqualTypeAll 0) exitWith {nil};
 
-private _max = selectMax _array;
-[_max, _array find _max]
+private _reverse = + _array;
+reverse _reverse;
+
+private _max = selectMax _reverse;
+
+[_max, count _array - (_reverse find _max) - 1]

--- a/addons/arrays/test_findMax.sqf
+++ b/addons/arrays/test_findMax.sqf
@@ -41,7 +41,7 @@ TEST_OP(_result,isEqualTo,_expected,_fn);
 
 // Test unordered array with duplicate max values
 _result = [2, 15, 15, -3, -3] call CBA_fnc_findMax;
-_expected = [15, 1];
+_expected = [15, 2];
 TEST_OP(_result,isEqualTo,_expected,_fn);
 
 // Test invalid parameter array with bool


### PR DESCRIPTION
**When merged this pull request will:**
- In case of duplicates, findMax should report the rightmost maximum, while findMin should report the leftmost minimum.

Same reasoning as https://stackoverflow.com/questions/26584510/why-does-stdmax-return-the-wrong-value

>min of two equivalent elements should return the first parameter, and max should return the [last]. This definition preserves a few properties that you'd expect, most notably
>-   the pair (min(x,y), max(x,y)) is either (x,y) or (y,x),
>and
>-   if x and y are distinct, then min(x,y) and max(x,y) are distinct