### PR TITLE
Exit early for invalid PFH handle

### DIFF
--- a/addons/common/fnc_removePerFrameHandler.sqf
+++ b/addons/common/fnc_removePerFrameHandler.sqf
@@ -23,6 +23,7 @@ Author:
 ---------------------------------------------------------------------------- */
 
 params [["_handle", -1, [0]]];
+if (_handle isEqualTo -1) exitWith {false};
 
 [{
     params ["_handle"];


### PR DESCRIPTION
**When merged this pull request will:**
title, avoid the directCall

Might just be me but for repeating-temporary PFHs I use RETDEF() with -1 quite often