### PR TITLE
JAM - Added class for VZ58

### DIFF
--- a/addons/jam/magwells_762x39.hpp
+++ b/addons/jam/magwells_762x39.hpp
@@ -14,3 +14,5 @@
     class CBA_762x39_STANAG_XL {};      // 762x39mm in an extra long STANAG stick or coffin mag
     class CBA_762x39_STANAG_2D {};      // 762x39mm in a twin-drum STANAG mag
     class CBA_762x39_STANAG_2D_XL {};   // 762x39mm in an extra large twin-drum STANAG mag
+
+    class CBA_762x39_VZ58 {};           // 762x39mm VZ58 magazine, cannot be used in AKs or vice versa


### PR DESCRIPTION
I've added VZ58 class to 7.62x39mm group, because VZ58 magazines are not compatible with AK at all. Not even AK mags fit into VZ58.