### PR TITLE
WIP: Arma vanilla magwells

### DIFF
--- a/addons/jam/CfgMagazineWells.hpp
+++ b/addons/jam/CfgMagazineWells.hpp
@@ -69,5 +69,10 @@ class CfgMagazineWells {
     class CBA_Panzerschreck {}; // Panzerschreck RPzB 54
     class CBA_PIAT {};          // PIAT
 
+    class CBA_RPG7 { //This is DEPRECATED! Don't use it! Use the vanilla one instead
+        BI_rockets[] = {
+            "RPG7_F"
+        };
+    };
     class RPG7 {};
 };

--- a/addons/jam/CfgMagazineWells.hpp
+++ b/addons/jam/CfgMagazineWells.hpp
@@ -69,9 +69,5 @@ class CfgMagazineWells {
     class CBA_Panzerschreck {}; // Panzerschreck RPzB 54
     class CBA_PIAT {};          // PIAT
 
-    class CBA_RPG7 {
-        BI_rockets[] = {
-            "RPG7_F"
-        };
-    };
+    class RPG7 {};
 };

--- a/addons/jam/CfgWeapons.hpp
+++ b/addons/jam/CfgWeapons.hpp
@@ -5,96 +5,96 @@ class CfgWeapons {
     class Launcher_Base_F;
 
     class mk20_base_F: Rifle_Base_F {
-        magazineWell[] = {"CBA_556x45_STANAG", "CBA_556x45_STANAG_L", "CBA_556x45_STANAG_XL", "CBA_556x45_STANAG_2D"};
+        magazineWell[] += {"CBA_556x45_STANAG", "CBA_556x45_STANAG_L", "CBA_556x45_STANAG_XL", "CBA_556x45_STANAG_2D"};
     };
     class SDAR_base_F: Rifle_Base_F {
-        magazineWell[] = {"CBA_556x45_STANAG"};
+        magazineWell[] += {"CBA_556x45_STANAG"};
     };
     class Tavor_base_F: Rifle_Base_F {
-        magazineWell[] = {"CBA_556x45_STANAG", "CBA_556x45_STANAG_L", "CBA_556x45_STANAG_XL", "CBA_556x45_STANAG_2D"};
+        magazineWell[] += {"CBA_556x45_STANAG", "CBA_556x45_STANAG_L", "CBA_556x45_STANAG_XL", "CBA_556x45_STANAG_2D"};
     };
     class arifle_SPAR_01_base_F : Rifle_Base_F {
-        magazineWell[] = {"CBA_556x45_STANAG", "CBA_556x45_STANAG_L", "CBA_556x45_STANAG_XL", "CBA_556x45_STANAG_2D", "CBA_556x45_STANAG_2D_XL"};
+        magazineWell[] += {"CBA_556x45_STANAG", "CBA_556x45_STANAG_L", "CBA_556x45_STANAG_XL", "CBA_556x45_STANAG_2D", "CBA_556x45_STANAG_2D_XL"};
     };
     class arifle_SPAR_02_base_F : Rifle_Base_F {
-        magazineWell[] = {"CBA_556x45_STANAG", "CBA_556x45_STANAG_L", "CBA_556x45_STANAG_XL", "CBA_556x45_STANAG_2D", "CBA_556x45_STANAG_2D_XL"};
+        magazineWell[] += {"CBA_556x45_STANAG", "CBA_556x45_STANAG_L", "CBA_556x45_STANAG_XL", "CBA_556x45_STANAG_2D", "CBA_556x45_STANAG_2D_XL"};
     };
 
     class UGL_F : GrenadeLauncher {
-        magazineWell[] = {"CBA_40mm_M203", "CBA_40mm_EGLM"};
+        magazineWell[] += {"CBA_40mm_M203", "CBA_40mm_EGLM"};
     };
 
     class arifle_MX_Base_F : Rifle_Base_F {
-        magazineWell[] = {"CBA_65x39_MX", "CBA_65x39_MX_XL"};
+        magazineWell[] += {"CBA_65x39_MX", "CBA_65x39_MX_XL"};
         class GL_3GL_F : UGL_F {
-            magazineWell[] = {"CBA_40mm_3GL", "CBA_40mm_M203", "CBA_40mm_EGLM"};
+            magazineWell[] += {"CBA_40mm_3GL", "CBA_40mm_M203", "CBA_40mm_EGLM"};
         };
     };
 
     class arifle_Katiba_Base_F : Rifle_Base_F {
-        magazineWell[] = {"CBA_65x39_Katiba"};
+        magazineWell[] += {"CBA_65x39_Katiba"};
     };
 
     class arifle_ARX_base_F : Rifle_Base_F {
-        magazineWell[] = {"CBA_65x39_Katiba"};
+        magazineWell[] += {"CBA_65x39_Katiba"};
     };
 
     class EBR_base_F: Rifle_Long_Base_F {
-        magazineWell[] = {"CBA_762x51_M14"};
+        magazineWell[] += {"CBA_762x51_M14"};
     };
     class DMR_03_base_F: Rifle_Long_Base_F {
-        magazineWell[] = {"CBA_762x51_MkI_EMR"};
+        magazineWell[] += {"CBA_762x51_MkI_EMR"};
     };
     class DMR_06_base_F: Rifle_Long_Base_F {
-        magazineWell[] = {"CBA_762x51_M14"};
+        magazineWell[] += {"CBA_762x51_M14"};
     };
     class arifle_SPAR_03_base_F : Rifle_Base_F {
-        magazineWell[] = {"CBA_762x51_HK417", "CBA_762x51_HK417_L", "CBA_762x51_HK417_XL"};
+        magazineWell[] += {"CBA_762x51_HK417", "CBA_762x51_HK417_L", "CBA_762x51_HK417_XL"};
     };
 
     class DMR_01_base_F : Rifle_Long_Base_F {
-        magazineWell[] = {"CBA_762x54R_SVD"};
+        magazineWell[] += {"CBA_762x54R_SVD"};
     };
 
     class arifle_CTAR_base_F : Rifle_Base_F {
-        magazineWell[] = {"CBA_580x42_TYPE95", "CBA_580x42_TYPE95_XL"};
+        magazineWell[] += {"CBA_580x42_TYPE95", "CBA_580x42_TYPE95_XL"};
     };
     class arifle_CTARS_base_F : Rifle_Base_F {
-        magazineWell[] = {"CBA_580x42_TYPE95", "CBA_580x42_TYPE95_XL"};
+        magazineWell[] += {"CBA_580x42_TYPE95", "CBA_580x42_TYPE95_XL"};
     };
 
     class arifle_AK12_base_F : Rifle_Base_F {
-        magazineWell[] = {"CBA_762x39_AK", "CBA_762x39_RPK"};
+        magazineWell[] += {"CBA_762x39_AK", "CBA_762x39_RPK"};
     };
     class arifle_AKM_base_F : Rifle_Base_F {
-        magazineWell[] = {"CBA_762x39_AK", "CBA_762x39_RPK"};
+        magazineWell[] += {"CBA_762x39_AK", "CBA_762x39_RPK"};
     };
 
     class arifle_AKS_base_F : Rifle_Base_F {
-        magazineWell[] = {"CBA_545x39_AK", "CBA_545x39_RPK"};
+        magazineWell[] += {"CBA_545x39_AK", "CBA_545x39_RPK"};
     };
 
     class LMG_03_base_F : Rifle_Long_Base_F {
-        magazineWell[] = {"CBA_556x45_MINIMI"};
+        magazineWell[] += {"CBA_556x45_MINIMI"};
     };
 
     class LMG_Mk200_F : Rifle_Long_Base_F {
-        magazineWell[] = {"CBA_65x39_Mk200"};
+        magazineWell[] += {"CBA_65x39_Mk200"};
     };
 
     class LMG_Zafir_F : Rifle_Long_Base_F {
-        magazineWell[] = {"CBA_762x54R_LINKS"};
+        magazineWell[] += {"CBA_762x54R_LINKS"};
     };
 
     class launch_RPG7_F : Launcher_Base_F {
-        magazineWell[] = {"CBA_RPG7"};
+        magazineWell[] += {"CBA_RPG7"};
     };
 
     class MMG_01_base_F : Rifle_Long_Base_F {
-        magazineWell[] = {"CBA_93x64_LINKS"};
+        magazineWell[] += {"CBA_93x64_LINKS"};
     };
 
     class MMG_02_base_F : Rifle_Long_Base_F {
-        magazineWell[] = {"CBA_338NM_LINKS"};
+        magazineWell[] += {"CBA_338NM_LINKS"};
     };
 };

--- a/addons/jam/magwells_357Mag.hpp
+++ b/addons/jam/magwells_357Mag.hpp
@@ -3,4 +3,3 @@
 
     class CBA_357_6rnds {};             // 6 loose rounds of .357 Magnum
     class CBA_357_5rnds {};             // 5 loose rounds of .357 Magnum
-    

--- a/addons/jam/magwells_545x39.hpp
+++ b/addons/jam/magwells_545x39.hpp
@@ -1,4 +1,12 @@
+    class CBA_545x39_AK {       //This is DEPRECATED! Don't use it! Use the vanilla one instead
+        BI_mags[] = {
+            "30Rnd_545x39_Mag_F",
+            "30Rnd_545x39_Mag_Green_F",
+            "30Rnd_545x39_Mag_Tracer_F",
+            "30Rnd_545x39_Mag_Tracer_Green_F"
+        };
+    };
+
     class AK_545x39 {};         // Standard AK-74 magazines
     
-
     class CBA_545x39_RPK {};    // 45rnd RPK-74

--- a/addons/jam/magwells_545x39.hpp
+++ b/addons/jam/magwells_545x39.hpp
@@ -1,10 +1,4 @@
-    class CBA_545x39_AK {       // Standard AK-74 magazines
-        BI_mags[] = {
-            "30Rnd_545x39_Mag_F",
-            "30Rnd_545x39_Mag_Green_F",
-            "30Rnd_545x39_Mag_Tracer_F",
-            "30Rnd_545x39_Mag_Tracer_Green_F"
-        };
-    };
+    class AK_545x39 {};         // Standard AK-74 magazines
+    
 
     class CBA_545x39_RPK {};    // 45rnd RPK-74

--- a/addons/jam/magwells_545x39.hpp
+++ b/addons/jam/magwells_545x39.hpp
@@ -8,5 +8,5 @@
     };
 
     class AK_545x39 {};         // Standard AK-74 magazines
-    
+
     class CBA_545x39_RPK {};    // 45rnd RPK-74

--- a/addons/jam/magwells_556x45.hpp
+++ b/addons/jam/magwells_556x45.hpp
@@ -13,22 +13,15 @@
         };
     };
 
+    class M249_556x45 {};
+    
     class CBA_556x45_TYPE97 {};         // QBZ-97 Stick Mags
     class CBA_556x45_TYPE97_XL {};      // QBB-97 LSW Drums
     class CBA_556x45_SG550 {};
 
-    class CBA_556x45_STANAG {           // STANAG mags, standard length, including small drums
-        BI_mags[] = {
-            "30Rnd_556x45_Stanag",
-            "30Rnd_556x45_Stanag_green",
-            "30Rnd_556x45_Stanag_red",
-            "30Rnd_556x45_Stanag_Tracer_Red",
-            "30Rnd_556x45_Stanag_Tracer_Green",
-            "30Rnd_556x45_Stanag_Tracer_Yellow"
-        };
-    };
+    class STANAG_556x45 {};         // STANAG mags, standard length, including small drums
 
-    class CBA_556x45_STANAG_L {};       // STANAG mags, long stick or coffin (40/60 rounds, Magpul PMAG 40, Surefire MAG5-60)
+    class STANAG_556x45_Large {};       // STANAG mags, long stick or coffin (40/60 rounds, Magpul PMAG 40, Surefire MAG5-60)
     class CBA_556x45_STANAG_XL {};      // STANAG mags, extra long stick or coffin (80/100 rounds, Surefire MAG5-100)
     class CBA_556x45_STANAG_2D {};      // STANAG mags, twin drums (100rnd Beta C-MAG)
     class CBA_556x45_STANAG_2D_XL {     // STANAG mags, extra large twin-drums (150rnd Armatac SAW-MAG)

--- a/addons/jam/magwells_556x45.hpp
+++ b/addons/jam/magwells_556x45.hpp
@@ -19,7 +19,7 @@
     class CBA_556x45_TYPE97_XL {};      // QBB-97 LSW Drums
     class CBA_556x45_SG550 {};
 
-    
+
     class CBA_556x45_STANAG {           //This is DEPRECATED! Don't use it! Use the vanilla one instead
         BI_mags[] = {
             "30Rnd_556x45_Stanag",

--- a/addons/jam/magwells_556x45.hpp
+++ b/addons/jam/magwells_556x45.hpp
@@ -19,6 +19,20 @@
     class CBA_556x45_TYPE97_XL {};      // QBB-97 LSW Drums
     class CBA_556x45_SG550 {};
 
+    
+    class CBA_556x45_STANAG {           //This is DEPRECATED! Don't use it! Use the vanilla one instead
+        BI_mags[] = {
+            "30Rnd_556x45_Stanag",
+            "30Rnd_556x45_Stanag_green",
+            "30Rnd_556x45_Stanag_red",
+            "30Rnd_556x45_Stanag_Tracer_Red",
+            "30Rnd_556x45_Stanag_Tracer_Green",
+            "30Rnd_556x45_Stanag_Tracer_Yellow"
+        };
+    };
+
+    class CBA_556x45_STANAG_L {};       //This is DEPRECATED! Don't use it! Use the vanilla one instead
+
     class STANAG_556x45 {};         // STANAG mags, standard length, including small drums
 
     class STANAG_556x45_Large {};       // STANAG mags, long stick or coffin (40/60 rounds, Magpul PMAG 40, Surefire MAG5-60)

--- a/addons/jam/magwells_580x42.hpp
+++ b/addons/jam/magwells_580x42.hpp
@@ -1,3 +1,18 @@
+    class CBA_580x42_TYPE95 {           //This is DEPRECATED! Don't use it! Use the vanilla one instead
+        BI_mags[] = {
+            "30Rnd_580x42_Mag_F",
+            "30Rnd_580x42_Mag_Tracer_F"
+        };
+    };
+
+    class CBA_580x42_TYPE95_XL {        //This is DEPRECATED! Don't use it! Use the vanilla one instead
+        BI_drums[] = {
+            "100Rnd_580x42_Mag_F",
+            "100Rnd_580x42_Mag_Tracer_F"
+        };
+    };
+    
+    
     class CTAR_580x42 {};           // QBZ-95 Stick Mags
 
     class CTAR_580x42_Large {};       // QBB-95 LSW Drums

--- a/addons/jam/magwells_580x42.hpp
+++ b/addons/jam/magwells_580x42.hpp
@@ -1,13 +1,4 @@
-    class CBA_580x42_TYPE95 {           // QBZ-95 Stick Mags
-        BI_mags[] = {
-            "30Rnd_580x42_Mag_F",
-            "30Rnd_580x42_Mag_Tracer_F"
-        };
-    };
+    class CTAR_580x42 {};           // QBZ-95 Stick Mags
 
-    class CBA_580x42_TYPE95_XL {        // QBB-95 LSW Drums
-        BI_drums[] = {
-            "100Rnd_580x42_Mag_F",
-            "100Rnd_580x42_Mag_Tracer_F"
-        };
-    };
+    class CTAR_580x42_Large {};       // QBB-95 LSW Drums
+

--- a/addons/jam/magwells_580x42.hpp
+++ b/addons/jam/magwells_580x42.hpp
@@ -11,8 +11,8 @@
             "100Rnd_580x42_Mag_Tracer_F"
         };
     };
-    
-    
+
+
     class CTAR_580x42 {};           // QBZ-95 Stick Mags
 
     class CTAR_580x42_Large {};       // QBB-95 LSW Drums

--- a/addons/jam/magwells_65x39.hpp
+++ b/addons/jam/magwells_65x39.hpp
@@ -6,35 +6,32 @@
             "30Rnd_65x39_caseless_green_mag_Tracer"
         };
     };
-    
-    
+
+
     class MX_65x39 {};
-    
+
     class CBA_65x39_MX_XL {
         BI_mags[] = {
             "100Rnd_65x39_caseless_mag",
             "100Rnd_65x39_caseless_mag_Tracer"
         };
     };
-    
-    
+
+
     class CBA_65x39_Mk200 { //This is DEPRECATED! Don't use it! Use the vanilla one instead
         BI_mags[] = {
             "200Rnd_65x39_cased_Box",
             "200Rnd_65x39_cased_Box_Tracer"
         };
     };
-    
+
     class CBA_65x39_Katiba { //This is DEPRECATED! Don't use it! Use the vanilla one instead
         BI_mags[] = {
             "30Rnd_65x39_caseless_green",
             "30Rnd_65x39_caseless_green_mag_Tracer"
         };
     };
-    
+
     class Mk200_65x39 {};
-    
+
     class Katiba_65x39 {};
-    
-    
-    

--- a/addons/jam/magwells_65x39.hpp
+++ b/addons/jam/magwells_65x39.hpp
@@ -1,11 +1,5 @@
-    class CBA_65x39_MX {
-        BI_mags[] = {
-            "30Rnd_65x39_caseless_mag",
-            "30Rnd_65x39_caseless_green",
-            "30Rnd_65x39_caseless_mag_Tracer",
-            "30Rnd_65x39_caseless_green_mag_Tracer"
-        };
-    };
+    class MX_65x39 {};
+
     class CBA_65x39_MX_XL {
         BI_mags[] = {
             "100Rnd_65x39_caseless_mag",
@@ -13,16 +7,6 @@
         };
     };
 
-    class CBA_65x39_Mk200 {
-        BI_mags[] = {
-            "200Rnd_65x39_cased_Box",
-            "200Rnd_65x39_cased_Box_Tracer"
-        };
-    };
+    class Mk200_65x39 {};
 
-    class CBA_65x39_Katiba {
-        BI_mags[] = {
-            "30Rnd_65x39_caseless_green",
-            "30Rnd_65x39_caseless_green_mag_Tracer"
-        };
-    };
+    class Katiba_65x39 {};

--- a/addons/jam/magwells_65x39.hpp
+++ b/addons/jam/magwells_65x39.hpp
@@ -1,12 +1,40 @@
+    class CBA_65x39_MX { //This is DEPRECATED! Don't use it! Use the vanilla one instead
+        BI_mags[] = {
+            "30Rnd_65x39_caseless_mag",
+            "30Rnd_65x39_caseless_green",
+            "30Rnd_65x39_caseless_mag_Tracer",
+            "30Rnd_65x39_caseless_green_mag_Tracer"
+        };
+    };
+    
+    
     class MX_65x39 {};
-
+    
     class CBA_65x39_MX_XL {
         BI_mags[] = {
             "100Rnd_65x39_caseless_mag",
             "100Rnd_65x39_caseless_mag_Tracer"
         };
     };
-
+    
+    
+    class CBA_65x39_Mk200 { //This is DEPRECATED! Don't use it! Use the vanilla one instead
+        BI_mags[] = {
+            "200Rnd_65x39_cased_Box",
+            "200Rnd_65x39_cased_Box_Tracer"
+        };
+    };
+    
+    class CBA_65x39_Katiba { //This is DEPRECATED! Don't use it! Use the vanilla one instead
+        BI_mags[] = {
+            "30Rnd_65x39_caseless_green",
+            "30Rnd_65x39_caseless_green_mag_Tracer"
+        };
+    };
+    
     class Mk200_65x39 {};
-
+    
     class Katiba_65x39 {};
+    
+    
+    

--- a/addons/jam/magwells_762x39.hpp
+++ b/addons/jam/magwells_762x39.hpp
@@ -6,8 +6,8 @@
             "30Rnd_762x39_Mag_Tracer_Green_F"
         };
     };
-	
-	class AK_762x39 {};                 // Standard AK-47/AKM magazines
+
+    class AK_762x39 {};                 // Standard AK-47/AKM magazines
 
     class CBA_762x39_RPK {};            // 40/45/75rnd RPK magazines
 

--- a/addons/jam/magwells_762x39.hpp
+++ b/addons/jam/magwells_762x39.hpp
@@ -1,11 +1,4 @@
-    class CBA_762x39_AK {               // Standard AK-47/AKM magazines
-        BI_mags[] = {
-            "30Rnd_762x39_Mag_F",
-            "30Rnd_762x39_Mag_Green_F",
-            "30Rnd_762x39_Mag_Tracer_F",
-            "30Rnd_762x39_Mag_Tracer_Green_F"
-        };
-    };
+    class AK_762x39 {};                 // Standard AK-47/AKM magazines
 
     class CBA_762x39_RPK {};            // 40/45/75rnd RPK magazines
 

--- a/addons/jam/magwells_762x39.hpp
+++ b/addons/jam/magwells_762x39.hpp
@@ -1,4 +1,13 @@
-    class AK_762x39 {};                 // Standard AK-47/AKM magazines
+    class CBA_762x39_AK {               //This is DEPRECATED! Don't use it! Use the vanilla one instead
+        BI_mags[] = {
+            "30Rnd_762x39_Mag_F",
+            "30Rnd_762x39_Mag_Green_F",
+            "30Rnd_762x39_Mag_Tracer_F",
+            "30Rnd_762x39_Mag_Tracer_Green_F"
+        };
+    };
+	
+	class AK_762x39 {};                 // Standard AK-47/AKM magazines
 
     class CBA_762x39_RPK {};            // 40/45/75rnd RPK magazines
 


### PR DESCRIPTION
This is how it would look if we replace our magwells by the vanilla ones.
Need feedback. What do we do? 

Leave the BI magwells be and just make our own duplicates? 
Add inheritance? Problem with that is, mods that already add onto the CBA classes will break when we add inheritance. But right now it's soon enough that we can still do it.

Also the BI magwells are missing the reload tracers
30Rnd_556x45_Stanag_green, 30Rnd_556x45_Stanag_red and the mx variants.