### PR TITLE
Delete duplicates in console history

### DIFF
--- a/addons/diagnostic/fnc_initExtendedDebugConsole.sqf
+++ b/addons/diagnostic/fnc_initExtendedDebugConsole.sqf
@@ -159,6 +159,8 @@ FUNC(logStatement) = {
     private _prevStatements = profileNamespace getVariable [QGVAR(statements), []];
 
     if !((_prevStatements param [0, ""]) isEqualTo _statement) then {
+        _prevStatements deleteAt (_prevStatements find _statement);
+
         // pushFront
         reverse _prevStatements;
         _prevStatements pushBack _statement;


### PR DESCRIPTION
**When merged this pull request will:**
- title.

When you have to exec some commands one after another the console history becomes full of those commands. With this patch each command presents in history exactly 1 time.

Patch doesn't clear duplicates in current history.