### PR TITLE
JAM update for 1.86

### DIFF
--- a/addons/jam/CfgMagazineWells.hpp
+++ b/addons/jam/CfgMagazineWells.hpp
@@ -69,9 +69,12 @@ class CfgMagazineWells {
     class CBA_Panzerschreck {}; // Panzerschreck RPzB 54
     class CBA_PIAT {};          // PIAT
 
-    class CBA_RPG7 {
+    class RPG7;
+    class CBA_RPG7: RPG7 {
+    /*
         BI_rockets[] = {
             "RPG7_F"
         };
+    */
     };
 };

--- a/addons/jam/CfgWeapons.hpp
+++ b/addons/jam/CfgWeapons.hpp
@@ -5,19 +5,19 @@ class CfgWeapons {
     class Launcher_Base_F;
 
     class mk20_base_F: Rifle_Base_F {
-        magazineWell[] = {"CBA_556x45_STANAG", "CBA_556x45_STANAG_L", "CBA_556x45_STANAG_XL", "CBA_556x45_STANAG_2D"};
+        magazineWell[] += {"CBA_556x45_STANAG", "CBA_556x45_STANAG_L", "CBA_556x45_STANAG_XL", "CBA_556x45_STANAG_2D"};
     };
     class SDAR_base_F: Rifle_Base_F {
-        magazineWell[] = {"CBA_556x45_STANAG"};
+        magazineWell[] += {"CBA_556x45_STANAG"};
     };
     class Tavor_base_F: Rifle_Base_F {
-        magazineWell[] = {"CBA_556x45_STANAG", "CBA_556x45_STANAG_L", "CBA_556x45_STANAG_XL", "CBA_556x45_STANAG_2D"};
+        magazineWell[] += {"CBA_556x45_STANAG", "CBA_556x45_STANAG_L", "CBA_556x45_STANAG_XL", "CBA_556x45_STANAG_2D"};
     };
     class arifle_SPAR_01_base_F : Rifle_Base_F {
-        magazineWell[] = {"CBA_556x45_STANAG", "CBA_556x45_STANAG_L", "CBA_556x45_STANAG_XL", "CBA_556x45_STANAG_2D", "CBA_556x45_STANAG_2D_XL"};
+        magazineWell[] += {"CBA_556x45_STANAG", "CBA_556x45_STANAG_L", "CBA_556x45_STANAG_XL", "CBA_556x45_STANAG_2D", "CBA_556x45_STANAG_2D_XL"};
     };
     class arifle_SPAR_02_base_F : Rifle_Base_F {
-        magazineWell[] = {"CBA_556x45_STANAG", "CBA_556x45_STANAG_L", "CBA_556x45_STANAG_XL", "CBA_556x45_STANAG_2D", "CBA_556x45_STANAG_2D_XL"};
+        magazineWell[] += {"CBA_556x45_STANAG", "CBA_556x45_STANAG_L", "CBA_556x45_STANAG_XL", "CBA_556x45_STANAG_2D", "CBA_556x45_STANAG_2D_XL"};
     };
 
     class UGL_F : GrenadeLauncher {
@@ -25,18 +25,21 @@ class CfgWeapons {
     };
 
     class arifle_MX_Base_F : Rifle_Base_F {
-        magazineWell[] = {"CBA_65x39_MX", "CBA_65x39_MX_XL"};
+        magazineWell[] += {"CBA_65x39_MX", "CBA_65x39_MX_XL"};
         class GL_3GL_F : UGL_F {
             magazineWell[] = {"CBA_40mm_3GL", "CBA_40mm_M203", "CBA_40mm_EGLM"};
         };
     };
+    class arifle_MX_SW_F : arifle_MX_Base_F {
+        magazineWell[] = {"CBA_65x39_MX", "CBA_65x39_MX_XL"};
+    };
 
     class arifle_Katiba_Base_F : Rifle_Base_F {
-        magazineWell[] = {"CBA_65x39_Katiba"};
+        magazineWell[] += {"CBA_65x39_Katiba"};
     };
 
     class arifle_ARX_base_F : Rifle_Base_F {
-        magazineWell[] = {"CBA_65x39_Katiba"};
+        magazineWell[] += {"CBA_65x39_Katiba"};
     };
 
     class EBR_base_F: Rifle_Long_Base_F {
@@ -57,21 +60,21 @@ class CfgWeapons {
     };
 
     class arifle_CTAR_base_F : Rifle_Base_F {
-        magazineWell[] = {"CBA_580x42_TYPE95", "CBA_580x42_TYPE95_XL"};
+        magazineWell[] += {"CBA_580x42_TYPE95", "CBA_580x42_TYPE95_XL"};
     };
     class arifle_CTARS_base_F : Rifle_Base_F {
-        magazineWell[] = {"CBA_580x42_TYPE95", "CBA_580x42_TYPE95_XL"};
+        magazineWell[] += {"CBA_580x42_TYPE95", "CBA_580x42_TYPE95_XL"};
     };
 
     class arifle_AK12_base_F : Rifle_Base_F {
-        magazineWell[] = {"CBA_762x39_AK", "CBA_762x39_RPK"};
+        magazineWell[] += {"CBA_762x39_AK", "CBA_762x39_RPK"};
     };
     class arifle_AKM_base_F : Rifle_Base_F {
-        magazineWell[] = {"CBA_762x39_AK", "CBA_762x39_RPK"};
+        magazineWell[] += {"CBA_762x39_AK", "CBA_762x39_RPK"};
     };
 
     class arifle_AKS_base_F : Rifle_Base_F {
-        magazineWell[] = {"CBA_545x39_AK", "CBA_545x39_RPK"};
+        magazineWell[] += {"CBA_545x39_AK", "CBA_545x39_RPK"};
     };
 
     class LMG_03_base_F : Rifle_Long_Base_F {
@@ -87,7 +90,7 @@ class CfgWeapons {
     };
 
     class launch_RPG7_F : Launcher_Base_F {
-        magazineWell[] = {"CBA_RPG7"};
+        magazineWell[] += {"CBA_RPG7"};
     };
 
     class MMG_01_base_F : Rifle_Long_Base_F {

--- a/addons/jam/magwells_10gauge.hpp
+++ b/addons/jam/magwells_10gauge.hpp
@@ -1,9 +1,9 @@
-    class CBA_10g_9rnds {};         // 9 loose rounds
-    class CBA_10g_8rnds {};         // 8 loose rounds
-    class CBA_10g_7rnds {};         // 7 loose rounds
-    class CBA_10g_6rnds {};         // 6 loose rounds
-    class CBA_10g_5rnds {};         // 5 loose rounds
-    class CBA_10g_4rnds {};         // 4 loose rounds
-    class CBA_10g_3rnds {};         // 3 loose rounds
-    class CBA_10g_2rnds {};         // 2 loose rounds
-    class CBA_10g_1rnd {};          // 1 loose round
+class CBA_10g_9rnds {};         // 9 loose rounds
+class CBA_10g_8rnds {};         // 8 loose rounds
+class CBA_10g_7rnds {};         // 7 loose rounds
+class CBA_10g_6rnds {};         // 6 loose rounds
+class CBA_10g_5rnds {};         // 5 loose rounds
+class CBA_10g_4rnds {};         // 4 loose rounds
+class CBA_10g_3rnds {};         // 3 loose rounds
+class CBA_10g_2rnds {};         // 2 loose rounds
+class CBA_10g_1rnd {};          // 1 loose round

--- a/addons/jam/magwells_10mmAuto.hpp
+++ b/addons/jam/magwells_10mmAuto.hpp
@@ -1,3 +1,3 @@
-    class CBA_10mmAuto_Glock_Cpct {};    // Compact Glock in 10mm Auto (Glock 29)
-    class CBA_10mmAuto_Glock_Full {};    // Fullsize Glock in 10mm Auto (Glock 20, 40)
-    class CBA_10mmAuto_MP5 {};           // H&K MP5/10 10mm Auto
+class CBA_10mmAuto_Glock_Cpct {};    // Compact Glock in 10mm Auto (Glock 29)
+class CBA_10mmAuto_Glock_Full {};    // Fullsize Glock in 10mm Auto (Glock 20, 40)
+class CBA_10mmAuto_MP5 {};           // H&K MP5/10 10mm Auto

--- a/addons/jam/magwells_11x59R.hpp
+++ b/addons/jam/magwells_11x59R.hpp
@@ -1,1 +1,1 @@
-    class CBA_11mm_Vickers {};      // Vickers machine gun in 11mm Vickers
+class CBA_11mm_Vickers {};      // Vickers machine gun in 11mm Vickers

--- a/addons/jam/magwells_12gauge.hpp
+++ b/addons/jam/magwells_12gauge.hpp
@@ -1,12 +1,12 @@
-    class CBA_12g_9rnds {};         // 9 loose rounds
-    class CBA_12g_8rnds {};         // 8 loose rounds
-    class CBA_12g_7rnds {};         // 7 loose rounds
-    class CBA_12g_6rnds {};         // 6 loose rounds
-    class CBA_12g_5rnds {};         // 5 loose rounds
-    class CBA_12g_4rnds {};         // 4 loose rounds
-    class CBA_12g_3rnds {};         // 3 loose rounds
-    class CBA_12g_2rnds {};         // 2 loose rounds
-    class CBA_12g_1rnd {};          // 1 loose round
+class CBA_12g_9rnds {};         // 9 loose rounds
+class CBA_12g_8rnds {};         // 8 loose rounds
+class CBA_12g_7rnds {};         // 7 loose rounds
+class CBA_12g_6rnds {};         // 6 loose rounds
+class CBA_12g_5rnds {};         // 5 loose rounds
+class CBA_12g_4rnds {};         // 4 loose rounds
+class CBA_12g_3rnds {};         // 3 loose rounds
+class CBA_12g_2rnds {};         // 2 loose rounds
+class CBA_12g_1rnd {};          // 1 loose round
 
-    class CBA_12g_SAIGA {};         // Saiga Stick Magazines
-    class CBA_12g_SAIGA_XL {};      // Saiga Drum Magazines
+class CBA_12g_SAIGA {};         // Saiga Stick Magazines
+class CBA_12g_SAIGA_XL {};      // Saiga Drum Magazines

--- a/addons/jam/magwells_145x114.hpp
+++ b/addons/jam/magwells_145x114.hpp
@@ -1,2 +1,2 @@
-    class CBA_145x114_PTRD {};      // PTRD-41
-    class CBA_145x114_PTRS {};      // PTRS-41
+class CBA_145x114_PTRD {};      // PTRD-41
+class CBA_145x114_PTRS {};      // PTRS-41

--- a/addons/jam/magwells_16gauge.hpp
+++ b/addons/jam/magwells_16gauge.hpp
@@ -1,9 +1,9 @@
-    class CBA_16g_9rnds {};         // 9 loose rounds
-    class CBA_16g_8rnds {};         // 8 loose rounds
-    class CBA_16g_7rnds {};         // 7 loose rounds
-    class CBA_16g_6rnds {};         // 6 loose rounds
-    class CBA_16g_5rnds {};         // 5 loose rounds
-    class CBA_16g_4rnds {};         // 4 loose rounds
-    class CBA_16g_3rnds {};         // 3 loose rounds
-    class CBA_16g_2rnds {};         // 2 loose rounds
-    class CBA_16g_1rnd {};          // 1 loose round
+class CBA_16g_9rnds {};         // 9 loose rounds
+class CBA_16g_8rnds {};         // 8 loose rounds
+class CBA_16g_7rnds {};         // 7 loose rounds
+class CBA_16g_6rnds {};         // 6 loose rounds
+class CBA_16g_5rnds {};         // 5 loose rounds
+class CBA_16g_4rnds {};         // 4 loose rounds
+class CBA_16g_3rnds {};         // 3 loose rounds
+class CBA_16g_2rnds {};         // 2 loose rounds
+class CBA_16g_1rnd {};          // 1 loose round

--- a/addons/jam/magwells_20gauge.hpp
+++ b/addons/jam/magwells_20gauge.hpp
@@ -1,9 +1,9 @@
-    class CBA_20g_9rnds {};         // 9 loose rounds
-    class CBA_20g_8rnds {};         // 8 loose rounds
-    class CBA_20g_7rnds {};         // 7 loose rounds
-    class CBA_20g_6rnds {};         // 6 loose rounds
-    class CBA_20g_5rnds {};         // 5 loose rounds
-    class CBA_20g_4rnds {};         // 4 loose rounds
-    class CBA_20g_3rnds {};         // 3 loose rounds
-    class CBA_20g_2rnds {};         // 2 loose rounds
-    class CBA_20g_1rnd {};          // 1 loose round
+class CBA_20g_9rnds {};         // 9 loose rounds
+class CBA_20g_8rnds {};         // 8 loose rounds
+class CBA_20g_7rnds {};         // 7 loose rounds
+class CBA_20g_6rnds {};         // 6 loose rounds
+class CBA_20g_5rnds {};         // 5 loose rounds
+class CBA_20g_4rnds {};         // 4 loose rounds
+class CBA_20g_3rnds {};         // 3 loose rounds
+class CBA_20g_2rnds {};         // 2 loose rounds
+class CBA_20g_1rnd {};          // 1 loose round

--- a/addons/jam/magwells_22LR.hpp
+++ b/addons/jam/magwells_22LR.hpp
@@ -1,2 +1,2 @@
-    class CBA_22LR_PP {};           // Walther PP in .22LR
-    class CBA_22LR_PPK {};          // Walther PPK in .22LR
+class CBA_22LR_PP {};           // Walther PP in .22LR
+class CBA_22LR_PPK {};          // Walther PPK in .22LR

--- a/addons/jam/magwells_3006.hpp
+++ b/addons/jam/magwells_3006.hpp
@@ -1,5 +1,5 @@
-    class CBA_3006_BAR {};          // M1918 BAR
-    class CBA_3006_Belt {};         // M1917/M1919 Browning Machine Gun
-    class CBA_3006_Garand {};       // M1 Garand
-    class CBA_3006_Spring {};       // M1903 Springfield
-    class CBA_3006_Vickers {};      // Vickers machine gun in .30-06
+class CBA_3006_BAR {};          // M1918 BAR
+class CBA_3006_Belt {};         // M1917/M1919 Browning Machine Gun
+class CBA_3006_Garand {};       // M1 Garand
+class CBA_3006_Spring {};       // M1903 Springfield
+class CBA_3006_Vickers {};      // Vickers machine gun in .30-06

--- a/addons/jam/magwells_300BLK.hpp
+++ b/addons/jam/magwells_300BLK.hpp
@@ -1,8 +1,8 @@
-    class CBA_300BLK_STANAG {};         // .300 Blackout in a normal length STANAG mag, including small drums
-    class CBA_300BLK_STANAG_L {};       // .300 Blackout in a long STANAG stick or coffin
-    class CBA_300BLK_STANAG_XL {};      // .300 Blackout in an extra long STANAG stick or coffin mag
-    class CBA_300BLK_STANAG_2D {};      // .300 Blackout in a twin-drum STANAG mag
-    class CBA_300BLK_STANAG_2D_XL {};   // .300 Blackout in an extra large twin-drum STANAG mag
+class CBA_300BLK_STANAG {};         // .300 Blackout in a normal length STANAG mag, including small drums
+class CBA_300BLK_STANAG_L {};       // .300 Blackout in a long STANAG stick or coffin
+class CBA_300BLK_STANAG_XL {};      // .300 Blackout in an extra long STANAG stick or coffin mag
+class CBA_300BLK_STANAG_2D {};      // .300 Blackout in a twin-drum STANAG mag
+class CBA_300BLK_STANAG_2D_XL {};   // .300 Blackout in an extra large twin-drum STANAG mag
 
-    //Deprecated classes do not use
-    class CBA_762x35_STANAG {};         // DEPRECATED, use CBA_300BLK_STANAG
+//Deprecated classes do not use
+class CBA_762x35_STANAG {};         // DEPRECATED, use CBA_300BLK_STANAG

--- a/addons/jam/magwells_300WM.hpp
+++ b/addons/jam/magwells_300WM.hpp
@@ -1,4 +1,4 @@
-    class CBA_300WM_AICS {};        // AICS long action mag (5 rounds)
+class CBA_300WM_AICS {};        // AICS long action mag (5 rounds)
 
-    //Deprecated classes do not use
-    class CBA_300WM_AI {};          // DEPRECATED, use CBA_300WM_AICS instead.
+//Deprecated classes do not use
+class CBA_300WM_AI {};          // DEPRECATED, use CBA_300WM_AICS instead.

--- a/addons/jam/magwells_303B.hpp
+++ b/addons/jam/magwells_303B.hpp
@@ -1,4 +1,4 @@
-    class CBA_303B_BREN {};         // BREN gun
-    class CBA_303B_LeeEn {};        // Lee Enfield
-    class CBA_303B_Maxim {};        // Maxim gun in .303 British
-    class CBA_303B_Vickers {};      // Vickers machine gun in .303 British (might be the same as the Maxim belt in .303)
+class CBA_303B_BREN {};         // BREN gun
+class CBA_303B_LeeEn {};        // Lee Enfield
+class CBA_303B_Maxim {};        // Maxim gun in .303 British
+class CBA_303B_Vickers {};      // Vickers machine gun in .303 British (might be the same as the Maxim belt in .303)

--- a/addons/jam/magwells_32ACP.hpp
+++ b/addons/jam/magwells_32ACP.hpp
@@ -1,8 +1,8 @@
-    class CBA_32ACP_CZ82 {};        // CZ 83
-    class CBA_32ACP_P83 {};         // FB P-83 Wanad
-    class CBA_32ACP_PA63 {};        // FEG PA-63
-    class CBA_32ACP_PM63 {};        // FB PM-63 RAK
-    class CBA_32ACP_PP {};          // Walther PP in .32 ACP (7.65x17mm Browning)
-    class CBA_32ACP_PPK {};         // Walther PPK in .32 ACP (7.65x17mm Browning)
-    class CBA_32ACP_Vz61 {};        // Škorpion (vz. 61), M84
-    class CBA_32ACP_Welrod {};      // Welrod pistol in .32 ACP (7.65x17mm Browning)
+class CBA_32ACP_CZ82 {};        // CZ 83
+class CBA_32ACP_P83 {};         // FB P-83 Wanad
+class CBA_32ACP_PA63 {};        // FEG PA-63
+class CBA_32ACP_PM63 {};        // FB PM-63 RAK
+class CBA_32ACP_PP {};          // Walther PP in .32 ACP (7.65x17mm Browning)
+class CBA_32ACP_PPK {};         // Walther PPK in .32 ACP (7.65x17mm Browning)
+class CBA_32ACP_Vz61 {};        // Škorpion (vz. 61), M84
+class CBA_32ACP_Welrod {};      // Welrod pistol in .32 ACP (7.65x17mm Browning)

--- a/addons/jam/magwells_338LM.hpp
+++ b/addons/jam/magwells_338LM.hpp
@@ -1,2 +1,2 @@
-    class CBA_338LM_AI {};          // AI .338 Lapua Magnum
-    class CBA_338LM_T5000 {};       // ORSIS T-5000
+class CBA_338LM_AI {};          // AI .338 Lapua Magnum
+class CBA_338LM_T5000 {};       // ORSIS T-5000

--- a/addons/jam/magwells_357Mag.hpp
+++ b/addons/jam/magwells_357Mag.hpp
@@ -1,6 +1,5 @@
-    class CBA_357_Clip_6rnds {};        // 6 round .357 Magnum moon clip
-    class CBA_357_Clip_5rnds {};        // 5 round .357 Magnum moon clip
+class CBA_357_Clip_6rnds {};        // 6 round .357 Magnum moon clip
+class CBA_357_Clip_5rnds {};        // 5 round .357 Magnum moon clip
 
-    class CBA_357_6rnds {};             // 6 loose rounds of .357 Magnum
-    class CBA_357_5rnds {};             // 5 loose rounds of .357 Magnum
-    
+class CBA_357_6rnds {};             // 6 loose rounds of .357 Magnum
+class CBA_357_5rnds {};             // 5 loose rounds of .357 Magnum

--- a/addons/jam/magwells_357SIG.hpp
+++ b/addons/jam/magwells_357SIG.hpp
@@ -1,6 +1,6 @@
-    class CBA_375SIG_Glock_SubC {};     // Subcompact Glock in 375SIGmm (Glock 33)
-    class CBA_375SIG_Glock_Cpct {};     // Compact Glock in 375SIGmm (Glock 32)
-    class CBA_375SIG_Glock_Full {};     // Fullsize Glock in 375SIGmm (Glock 31)
-    class CBA_357SIG_P226 {};           // SIG P226
-    class CBA_357SIG_P229 {};           // SIG P229
-    class CBA_357SIG_P239 {};           // SIG P239
+class CBA_375SIG_Glock_SubC {};     // Subcompact Glock in 375SIGmm (Glock 33)
+class CBA_375SIG_Glock_Cpct {};     // Compact Glock in 375SIGmm (Glock 32)
+class CBA_375SIG_Glock_Full {};     // Fullsize Glock in 375SIGmm (Glock 31)
+class CBA_357SIG_P226 {};           // SIG P226
+class CBA_357SIG_P229 {};           // SIG P229
+class CBA_357SIG_P239 {};           // SIG P239

--- a/addons/jam/magwells_35mm.hpp
+++ b/addons/jam/magwells_35mm.hpp
@@ -1,1 +1,1 @@
-    class CBA_35mm_Type10 {};       // Japanese Type 10 Flare Pistol
+class CBA_35mm_Type10 {};       // Japanese Type 10 Flare Pistol

--- a/addons/jam/magwells_380ACP.hpp
+++ b/addons/jam/magwells_380ACP.hpp
@@ -1,15 +1,15 @@
-    class CBA_380ACP_CZ82 {};           // CZ 83
-    class CBA_380ACP_Fort12 {};         // Fort-12
-    class CBA_380ACP_Glock_Slim {};     // Slimline Glock in .380 ACP (Glock 42)
-    class CBA_380ACP_Glock_SubC {};     // Subcompact Glock in .380 ACP (Glock 28)
-    class CBA_380ACP_Glock_Cpct {};     // Compact Glock in .380 ACP (Glock 25)
-    class CBA_380ACP_Ots01 {};          // OTs-01 Kobalt
-    class CBA_380ACP_P83 {};            // FB P-83 Wanad
-    class CBA_380ACP_PA63 {};           // FEG PA-63
-    class CBA_380ACP_PM {};             // Makarov PM in .380 ACP
-    class CBA_380ACP_PM63 {};           // FB PM-63 RAK
-    class CBA_380ACP_PMM {};            // Makarov PMM in .380 ACP
-    class CBA_380ACP_PP {};             // Walther PP in .380 ACP
-    class CBA_380ACP_PP19 {};           // PP-19 Bizon-2-02
-    class CBA_380ACP_PPK {};            // Walther PPK in .380 ACP
-    class CBA_380ACP_Vz64 {};           // Škorpion (vz. 64, vz. 83)
+class CBA_380ACP_CZ82 {};           // CZ 83
+class CBA_380ACP_Fort12 {};         // Fort-12
+class CBA_380ACP_Glock_Slim {};     // Slimline Glock in .380 ACP (Glock 42)
+class CBA_380ACP_Glock_SubC {};     // Subcompact Glock in .380 ACP (Glock 28)
+class CBA_380ACP_Glock_Cpct {};     // Compact Glock in .380 ACP (Glock 25)
+class CBA_380ACP_Ots01 {};          // OTs-01 Kobalt
+class CBA_380ACP_P83 {};            // FB P-83 Wanad
+class CBA_380ACP_PA63 {};           // FEG PA-63
+class CBA_380ACP_PM {};             // Makarov PM in .380 ACP
+class CBA_380ACP_PM63 {};           // FB PM-63 RAK
+class CBA_380ACP_PMM {};            // Makarov PMM in .380 ACP
+class CBA_380ACP_PP {};             // Walther PP in .380 ACP
+class CBA_380ACP_PP19 {};           // PP-19 Bizon-2-02
+class CBA_380ACP_PPK {};            // Walther PPK in .380 ACP
+class CBA_380ACP_Vz64 {};           // Škorpion (vz. 64, vz. 83)

--- a/addons/jam/magwells_38Spec.hpp
+++ b/addons/jam/magwells_38Spec.hpp
@@ -1,5 +1,5 @@
-    class CBA_38_Special_Clip_6rnds {}; // 6 round .38 Special moon clip
-    class CBA_38_Special_Clip_5rnds {}; // 5 round .38 Special moon clip
+class CBA_38_Special_Clip_6rnds {}; // 6 round .38 Special moon clip
+class CBA_38_Special_Clip_5rnds {}; // 5 round .38 Special moon clip
 
-    class CBA_38_Special_6rnds {};      // 6 loose rounds of .38 Special
-    class CBA_38_Special_5rnds {};      // 5 loose rounds of .38 Special
+class CBA_38_Special_6rnds {};      // 6 loose rounds of .38 Special
+class CBA_38_Special_5rnds {};      // 5 loose rounds of .38 Special

--- a/addons/jam/magwells_38_200.hpp
+++ b/addons/jam/magwells_38_200.hpp
@@ -1,1 +1,1 @@
-    class CBA_38_200_Webley {};     // Webley Revolver in .38/200
+class CBA_38_200_Webley {};     // Webley Revolver in .38/200

--- a/addons/jam/magwells_408CT.hpp
+++ b/addons/jam/magwells_408CT.hpp
@@ -1,1 +1,1 @@
-    class CBA_408CT_Inter {};           // CheyTac Intervention in .408 Chey Tac
+class CBA_408CT_Inter {};           // CheyTac Intervention in .408 Chey Tac

--- a/addons/jam/magwells_40SW.hpp
+++ b/addons/jam/magwells_40SW.hpp
@@ -1,6 +1,6 @@
-    class CBA_40SW_Glock_SubC {};   // Subcompact Glock in .40 S&W (Glock 27)
-    class CBA_40SW_Glock_Cpct {};   // Compact Glock in .40 S&W (Glock 23)
-    class CBA_40SW_Glock_Full {};   // Fullsize Glock in .40 S&W (Glock 22, 24, 35)
-    class CBA_40SW_P226 {};         // SIG P226 .40 S&W
-    class CBA_40SW_P229 {};         // SIG P229 .40 S&W
-    class CBA_40SW_P239 {};         // SIG P239 .40 S&W
+class CBA_40SW_Glock_SubC {};   // Subcompact Glock in .40 S&W (Glock 27)
+class CBA_40SW_Glock_Cpct {};   // Compact Glock in .40 S&W (Glock 23)
+class CBA_40SW_Glock_Full {};   // Fullsize Glock in .40 S&W (Glock 22, 24, 35)
+class CBA_40SW_P226 {};         // SIG P226 .40 S&W
+class CBA_40SW_P229 {};         // SIG P229 .40 S&W
+class CBA_40SW_P239 {};         // SIG P239 .40 S&W

--- a/addons/jam/magwells_40mm.hpp
+++ b/addons/jam/magwells_40mm.hpp
@@ -1,40 +1,40 @@
-    class CBA_40mm_3GL {
-        BI_grenades[] = {
-            "3Rnd_HE_Grenade_shell",
-            "3Rnd_Smoke_Grenade_shell",
-            "3Rnd_SmokeRed_Grenade_shell",
-            "3Rnd_SmokeGreen_Grenade_shell",
-            "3Rnd_SmokeYellow_Grenade_shell",
-            "3Rnd_SmokePurple_Grenade_shell",
-            "3Rnd_SmokeBlue_Grenade_shell",
-            "3Rnd_SmokeOrange_Grenade_shell",
-            "3Rnd_UGL_FlareWhite_F",
-            "3Rnd_UGL_FlareGreen_F",
-            "3Rnd_UGL_FlareRed_F",
-            "3Rnd_UGL_FlareYellow_F",
-            "3Rnd_UGL_FlareCIR_F"
-        };
+class CBA_40mm_3GL {
+    BI_grenades[] = {
+        "3Rnd_HE_Grenade_shell",
+        "3Rnd_Smoke_Grenade_shell",
+        "3Rnd_SmokeRed_Grenade_shell",
+        "3Rnd_SmokeGreen_Grenade_shell",
+        "3Rnd_SmokeYellow_Grenade_shell",
+        "3Rnd_SmokePurple_Grenade_shell",
+        "3Rnd_SmokeBlue_Grenade_shell",
+        "3Rnd_SmokeOrange_Grenade_shell",
+        "3Rnd_UGL_FlareWhite_F",
+        "3Rnd_UGL_FlareGreen_F",
+        "3Rnd_UGL_FlareRed_F",
+        "3Rnd_UGL_FlareYellow_F",
+        "3Rnd_UGL_FlareCIR_F"
     };
+};
 
-    class CBA_40mm_EGLM {};         // for longer grenades that can only fit side breech-loading
-    class CBA_40mm_GP {};           // single grenade for GP-25/GP-30/GP-34
-    class CBA_40mm_GP_6rnds {};     // 6 loose GP type grenades for RG-6/6G30
+class CBA_40mm_EGLM {};         // for longer grenades that can only fit side breech-loading
+class CBA_40mm_GP {};           // single grenade for GP-25/GP-30/GP-34
+class CBA_40mm_GP_6rnds {};     // 6 loose GP type grenades for RG-6/6G30
 
-    class CBA_40mm_M203 {
-        BI_grenades[] = {
-            "1Rnd_HE_Grenade_shell",
-            "1Rnd_Smoke_Grenade_shell",
-            "1Rnd_SmokeRed_Grenade_shell",
-            "1Rnd_SmokeGreen_Grenade_shell",
-            "1Rnd_SmokeYellow_Grenade_shell",
-            "1Rnd_SmokePurple_Grenade_shell",
-            "1Rnd_SmokeBlue_Grenade_shell",
-            "1Rnd_SmokeOrange_Grenade_shell",
-            "UGL_FlareWhite_F",
-            "UGL_FlareGreen_F",
-            "UGL_FlareRed_F",
-            "UGL_FlareYellow_F",
-            "UGL_FlareCIR_F"
-        };
+class CBA_40mm_M203 {
+    BI_grenades[] = {
+        "1Rnd_HE_Grenade_shell",
+        "1Rnd_Smoke_Grenade_shell",
+        "1Rnd_SmokeRed_Grenade_shell",
+        "1Rnd_SmokeGreen_Grenade_shell",
+        "1Rnd_SmokeYellow_Grenade_shell",
+        "1Rnd_SmokePurple_Grenade_shell",
+        "1Rnd_SmokeBlue_Grenade_shell",
+        "1Rnd_SmokeOrange_Grenade_shell",
+        "UGL_FlareWhite_F",
+        "UGL_FlareGreen_F",
+        "UGL_FlareRed_F",
+        "UGL_FlareYellow_F",
+        "UGL_FlareCIR_F"
     };
-    class CBA_40mm_M203_6rnds {};   // 6 loose M203 type grenades for M32 MGL
+};
+class CBA_40mm_M203_6rnds {};   // 6 loose M203 type grenades for M32 MGL

--- a/addons/jam/magwells_455W.hpp
+++ b/addons/jam/magwells_455W.hpp
@@ -1,1 +1,1 @@
-    class CBA_455_Webley {};        // Webley Revolver in .455 Webley
+class CBA_455_Webley {};        // Webley Revolver in .455 Webley

--- a/addons/jam/magwells_45ACP.hpp
+++ b/addons/jam/magwells_45ACP.hpp
@@ -1,10 +1,10 @@
-    class CBA_45ACP_1911 {};            // Colt M1911
-    class CBA_45ACP_C96 {};             // Mauser C-96 in .45 ACP
-    class CBA_45ACP_Delisle {};         // De Lisle Carbine
-    class CBA_45ACP_Glock_Slim {};      // Slimline Glock in .45 ACP (Glock 36)
-    class CBA_45ACP_Glock_Cpct {};      // Compact Glock in .45 ACP (Glock 29)
-    class CBA_45ACP_Glock_Full {};      // Fullsize Glock in .45 ACP (Glock 21, 41)
-    class CBA_45ACP_Grease {};          // Grease Gun
-    class CBA_45ACP_Reising {};         // M50/M55 Reising
-    class CBA_45ACP_Thompson_Stick {};  // Thompson stick magazines
-    class CBA_45ACP_Thompson_Drum {};   // Thompson drum magazines
+class CBA_45ACP_1911 {};            // Colt M1911
+class CBA_45ACP_C96 {};             // Mauser C-96 in .45 ACP
+class CBA_45ACP_Delisle {};         // De Lisle Carbine
+class CBA_45ACP_Glock_Slim {};      // Slimline Glock in .45 ACP (Glock 36)
+class CBA_45ACP_Glock_Cpct {};      // Compact Glock in .45 ACP (Glock 29)
+class CBA_45ACP_Glock_Full {};      // Fullsize Glock in .45 ACP (Glock 21, 41)
+class CBA_45ACP_Grease {};          // Grease Gun
+class CBA_45ACP_Reising {};         // M50/M55 Reising
+class CBA_45ACP_Thompson_Stick {};  // Thompson stick magazines
+class CBA_45ACP_Thompson_Drum {};   // Thompson drum magazines

--- a/addons/jam/magwells_45GAP.hpp
+++ b/addons/jam/magwells_45GAP.hpp
@@ -1,3 +1,3 @@
-    class CBA_45GAP_Glock_SubC {};      // Subcompact Glock in .45 GAP (Glock 39)
-    class CBA_45GAP_Glock_Cpct {};      // Compact Glock in .45 GAP (Glock 38)
-    class CBA_45GAP_Glock_Full {};      // Fullsize Glock in .45 GAP (Glock 37)
+class CBA_45GAP_Glock_SubC {};      // Subcompact Glock in .45 GAP (Glock 39)
+class CBA_45GAP_Glock_Cpct {};      // Compact Glock in .45 GAP (Glock 38)
+class CBA_45GAP_Glock_Full {};      // Fullsize Glock in .45 GAP (Glock 37)

--- a/addons/jam/magwells_46x30.hpp
+++ b/addons/jam/magwells_46x30.hpp
@@ -1,1 +1,1 @@
-    class CBA_46x30_MP7 {};         // H&K MP7
+class CBA_46x30_MP7 {};         // H&K MP7

--- a/addons/jam/magwells_50BMG.hpp
+++ b/addons/jam/magwells_50BMG.hpp
@@ -1,1 +1,1 @@
-    class CBA_50BMG_M107 {};        // M82, M107, G82
+class CBA_50BMG_M107 {};        // M82, M107, G82

--- a/addons/jam/magwells_545x39.hpp
+++ b/addons/jam/magwells_545x39.hpp
@@ -1,10 +1,13 @@
-    class CBA_545x39_AK {       // Standard AK-74 magazines
-        BI_mags[] = {
-            "30Rnd_545x39_Mag_F",
-            "30Rnd_545x39_Mag_Green_F",
-            "30Rnd_545x39_Mag_Tracer_F",
-            "30Rnd_545x39_Mag_Tracer_Green_F"
-        };
+class AK_545x39;
+class CBA_545x39_AK: AK_545x39 {       // Standard AK-74 magazines
+/*
+    BI_mags[] = {
+        "30Rnd_545x39_Mag_F",
+        "30Rnd_545x39_Mag_Green_F",
+        "30Rnd_545x39_Mag_Tracer_F",
+        "30Rnd_545x39_Mag_Tracer_Green_F"
     };
+*/
+};
 
-    class CBA_545x39_RPK {};    // 45rnd RPK-74
+class CBA_545x39_RPK {};    // 45rnd RPK-74

--- a/addons/jam/magwells_556x45.hpp
+++ b/addons/jam/magwells_556x45.hpp
@@ -1,41 +1,51 @@
-    class CBA_556x45_AK {};             // AK mags for 5.56 AK type rifles, AK-101, AK-102, etc.
-    class CBA_556x45_RPK {};            // 45rnd RPK mags for 5.56 RPK-201
-    class CBA_556x45_FAMAS {};          // FAMAS F1
-    class CBA_556x45_G36 {};            // H&K G36
-    class CBA_556x45_HK33 {};           // H&K 33/53/93
+class STANAG_556x45;
+class STANAG_556x45_Large;
+class M249_556x45;
 
-    class CBA_556x45_MINIMI {
-        BI_boxes[] = {
-            "200Rnd_556x45_Box_F",
-            "200Rnd_556x45_Box_Red_F",
-            "200Rnd_556x45_Box_Tracer_F",
-            "200Rnd_556x45_Box_Tracer_Red_F"
-        };
+class CBA_556x45_AK {};             // AK mags for 5.56 AK type rifles, AK-101, AK-102, etc.
+class CBA_556x45_RPK {};            // 45rnd RPK mags for 5.56 RPK-201
+class CBA_556x45_FAMAS {};          // FAMAS F1
+class CBA_556x45_G36 {};            // H&K G36
+class CBA_556x45_HK33 {};           // H&K 33/53/93
+
+class CBA_556x45_MINIMI: M249_556x45 {
+/*
+    BI_boxes[] = {
+        "200Rnd_556x45_Box_F",
+        "200Rnd_556x45_Box_Red_F",
+        "200Rnd_556x45_Box_Tracer_F",
+        "200Rnd_556x45_Box_Tracer_Red_F"
     };
+*/
+};
 
-    class CBA_556x45_TYPE97 {};         // QBZ-97 Stick Mags
-    class CBA_556x45_TYPE97_XL {};      // QBB-97 LSW Drums
-    class CBA_556x45_SG550 {};
+class CBA_556x45_TYPE97 {};         // QBZ-97 Stick Mags
+class CBA_556x45_TYPE97_XL {};      // QBB-97 LSW Drums
+class CBA_556x45_SG550 {};
 
-    class CBA_556x45_STANAG {           // STANAG mags, standard length, including small drums
-        BI_mags[] = {
-            "30Rnd_556x45_Stanag",
-            "30Rnd_556x45_Stanag_green",
-            "30Rnd_556x45_Stanag_red",
-            "30Rnd_556x45_Stanag_Tracer_Red",
-            "30Rnd_556x45_Stanag_Tracer_Green",
-            "30Rnd_556x45_Stanag_Tracer_Yellow"
-        };
+class CBA_556x45_STANAG: STANAG_556x45 {           // STANAG mags, standard length, including small drums
+/*
+    BI_mags[] = {
+        "30Rnd_556x45_Stanag",
+        "30Rnd_556x45_Stanag_green",
+        "30Rnd_556x45_Stanag_red",
+        "30Rnd_556x45_Stanag_Tracer_Red",
+        "30Rnd_556x45_Stanag_Tracer_Green",
+        "30Rnd_556x45_Stanag_Tracer_Yellow"
     };
+*/
+};
 
-    class CBA_556x45_STANAG_L {};       // STANAG mags, long stick or coffin (40/60 rounds, Magpul PMAG 40, Surefire MAG5-60)
-    class CBA_556x45_STANAG_XL {};      // STANAG mags, extra long stick or coffin (80/100 rounds, Surefire MAG5-100)
-    class CBA_556x45_STANAG_2D {};      // STANAG mags, twin drums (100rnd Beta C-MAG)
-    class CBA_556x45_STANAG_2D_XL {     // STANAG mags, extra large twin-drums (150rnd Armatac SAW-MAG)
-        BI_mags[] = {
-            "150Rnd_556x45_Drum_Mag_F",
-            "150Rnd_556x45_Drum_Mag_Tracer_F"
-        };
+class CBA_556x45_STANAG_L {};       // STANAG mags, long stick or coffin (40/60 rounds, Magpul PMAG 40, Surefire MAG5-60)
+class CBA_556x45_STANAG_XL {};      // STANAG mags, extra long stick or coffin (80/100 rounds, Surefire MAG5-100)
+class CBA_556x45_STANAG_2D {};      // STANAG mags, twin drums (100rnd Beta C-MAG)
+class CBA_556x45_STANAG_2D_XL: STANAG_556x45_Large {     // STANAG mags, extra large twin-drums (150rnd Armatac SAW-MAG)
+/*
+    BI_mags[] = {
+        "150Rnd_556x45_Drum_Mag_F",
+        "150Rnd_556x45_Drum_Mag_Tracer_F"
     };
+*/
+};
 
-    class CBA_556x45_STEYR {};          // Steyr AUG
+class CBA_556x45_STEYR {};          // Steyr AUG

--- a/addons/jam/magwells_580x42.hpp
+++ b/addons/jam/magwells_580x42.hpp
@@ -1,13 +1,20 @@
-    class CBA_580x42_TYPE95 {           // QBZ-95 Stick Mags
-        BI_mags[] = {
-            "30Rnd_580x42_Mag_F",
-            "30Rnd_580x42_Mag_Tracer_F"
-        };
-    };
+class CTAR_580x42;
+class CTAR_580x42_Large;
 
-    class CBA_580x42_TYPE95_XL {        // QBB-95 LSW Drums
-        BI_drums[] = {
-            "100Rnd_580x42_Mag_F",
-            "100Rnd_580x42_Mag_Tracer_F"
-        };
+class CBA_580x42_TYPE95: CTAR_580x42 {           // QBZ-95 Stick Mags
+/*
+    BI_mags[] = {
+        "30Rnd_580x42_Mag_F",
+        "30Rnd_580x42_Mag_Tracer_F"
     };
+*/
+};
+
+class CBA_580x42_TYPE95_XL: CTAR_580x42_Large {        // QBB-95 LSW Drums
+/*
+    BI_drums[] = {
+        "100Rnd_580x42_Mag_F",
+        "100Rnd_580x42_Mag_Tracer_F"
+    };
+*/
+};

--- a/addons/jam/magwells_65C.hpp
+++ b/addons/jam/magwells_65C.hpp
@@ -1,1 +1,1 @@
-    class CBA_65C_AR10 {};       // AR-10 in 6.5 Creedmoor standard mag (20 rounds)
+class CBA_65C_AR10 {};       // AR-10 in 6.5 Creedmoor standard mag (20 rounds)

--- a/addons/jam/magwells_65G.hpp
+++ b/addons/jam/magwells_65G.hpp
@@ -1,5 +1,5 @@
-    class CBA_65G_STANAG {};            // 6.5mm Grendel in a normal length STANAG mag, including small drums
-    class CBA_65G_STANAG_L {};          // 6.5mm Grendel in a long STANAG stick or coffin
-    class CBA_65G_STANAG_XL {};         // 6.5mm Grendel in an extra long STANAG stick or coffin mag
-    class CBA_65G_STANAG_2D {};         // 6.5mm Grendel in a twin-drum STANAG mag
-    class CBA_65G_STANAG_2D_XL {};      // 6.5mm Grendel in an extra large twin-drum STANAG mag
+class CBA_65G_STANAG {};            // 6.5mm Grendel in a normal length STANAG mag, including small drums
+class CBA_65G_STANAG_L {};          // 6.5mm Grendel in a long STANAG stick or coffin
+class CBA_65G_STANAG_XL {};         // 6.5mm Grendel in an extra long STANAG stick or coffin mag
+class CBA_65G_STANAG_2D {};         // 6.5mm Grendel in a twin-drum STANAG mag
+class CBA_65G_STANAG_2D_XL {};      // 6.5mm Grendel in an extra large twin-drum STANAG mag

--- a/addons/jam/magwells_65x39.hpp
+++ b/addons/jam/magwells_65x39.hpp
@@ -1,28 +1,38 @@
-    class CBA_65x39_MX {
-        BI_mags[] = {
-            "30Rnd_65x39_caseless_mag",
-            "30Rnd_65x39_caseless_green",
-            "30Rnd_65x39_caseless_mag_Tracer",
-            "30Rnd_65x39_caseless_green_mag_Tracer"
-        };
-    };
-    class CBA_65x39_MX_XL {
-        BI_mags[] = {
-            "100Rnd_65x39_caseless_mag",
-            "100Rnd_65x39_caseless_mag_Tracer"
-        };
-    };
+class MX_65x39;
+class Katiba_65x39;
+class Mk200_65x39;
 
-    class CBA_65x39_Mk200 {
-        BI_mags[] = {
-            "200Rnd_65x39_cased_Box",
-            "200Rnd_65x39_cased_Box_Tracer"
-        };
+class CBA_65x39_MX: MX_65x39 {
+/*
+    BI_mags[] = {
+        "30Rnd_65x39_caseless_mag",
+        "30Rnd_65x39_caseless_green",
+        "30Rnd_65x39_caseless_mag_Tracer",
+        "30Rnd_65x39_caseless_green_mag_Tracer"
     };
+*/
+};
+class CBA_65x39_MX_XL {
+    BI_mags[] = {
+        "100Rnd_65x39_caseless_mag",
+        "100Rnd_65x39_caseless_mag_Tracer"
+    };
+};
 
-    class CBA_65x39_Katiba {
-        BI_mags[] = {
-            "30Rnd_65x39_caseless_green",
-            "30Rnd_65x39_caseless_green_mag_Tracer"
-        };
+class CBA_65x39_Mk200: Mk200_65x39 {
+/*
+    BI_mags[] = {
+        "200Rnd_65x39_cased_Box",
+        "200Rnd_65x39_cased_Box_Tracer"
     };
+*/
+};
+
+class CBA_65x39_Katiba: Katiba_65x39 {
+/*
+    BI_mags[] = {
+        "30Rnd_65x39_caseless_green",
+        "30Rnd_65x39_caseless_green_mag_Tracer"
+    };
+*/
+};

--- a/addons/jam/magwells_68SPC.hpp
+++ b/addons/jam/magwells_68SPC.hpp
@@ -1,8 +1,8 @@
-    class CBA_68SPC_STANAG {};          // 6.8 SPC in a normal length STANAG mag, including small drums
-    class CBA_68SPC_STANAG_L {};        // 6.8 SPC in a long STANAG stick or coffin
-    class CBA_68SPC_STANAG_XL {};       // 6.8 SPC in an extra long STANAG stick or coffin mag
-    class CBA_68SPC_STANAG_2D {};       // 6.8 SPC in a twin-drum STANAG mag
-    class CBA_68SPC_STANAG_2D_XL {};    // 6.8 SPC in an extra large twin-drum STANAG mag
+class CBA_68SPC_STANAG {};          // 6.8 SPC in a normal length STANAG mag, including small drums
+class CBA_68SPC_STANAG_L {};        // 6.8 SPC in a long STANAG stick or coffin
+class CBA_68SPC_STANAG_XL {};       // 6.8 SPC in an extra long STANAG stick or coffin mag
+class CBA_68SPC_STANAG_2D {};       // 6.8 SPC in a twin-drum STANAG mag
+class CBA_68SPC_STANAG_2D_XL {};    // 6.8 SPC in an extra large twin-drum STANAG mag
 
-    //Deprecated classes do not use
-    class CBA_68x43_ACR {};             // DEPRECATED, use CBA_68SPC_STANAG
+//Deprecated classes do not use
+class CBA_68x43_ACR {};             // DEPRECATED, use CBA_68SPC_STANAG

--- a/addons/jam/magwells_75x55.hpp
+++ b/addons/jam/magwells_75x55.hpp
@@ -1,1 +1,1 @@
-    class CBA_75x55_STGW57 {};      // SIG SG 510-1, Stgw. 57
+class CBA_75x55_STGW57 {};      // SIG SG 510-1, Stgw. 57

--- a/addons/jam/magwells_762x25.hpp
+++ b/addons/jam/magwells_762x25.hpp
@@ -1,10 +1,10 @@
-    class CBA_762x25_CZ52 {};       // CZ 52, vz. 52, CZ 482
-    class CBA_762x25_Ots27 {};      // OTs-27 Berdysh
-    class CBA_762x25_PM63 {};       // FB PM-63 RAK
-    class CBA_762x25_PP19 {};       // PP-19 Bizon-2-07
-    class CBA_762x25_PPD_Drum {};   // PPD-40 drum magazines
-    class CBA_762x25_PPD_Stick {};  // PPD-40 stick magazines
-    class CBA_762x25_PPS {};        // PPS-43
-    class CBA_762x25_PPSh_Drum {};  // PPSh-41 drum magazines
-    class CBA_762x25_PPSh_Stick {}; // PPSh-41 stick magazines
-    class CBA_762x25_TT {};         // TT-30, TT-33 Tokarev
+class CBA_762x25_CZ52 {};       // CZ 52, vz. 52, CZ 482
+class CBA_762x25_Ots27 {};      // OTs-27 Berdysh
+class CBA_762x25_PM63 {};       // FB PM-63 RAK
+class CBA_762x25_PP19 {};       // PP-19 Bizon-2-07
+class CBA_762x25_PPD_Drum {};   // PPD-40 drum magazines
+class CBA_762x25_PPD_Stick {};  // PPD-40 stick magazines
+class CBA_762x25_PPS {};        // PPS-43
+class CBA_762x25_PPSh_Drum {};  // PPSh-41 drum magazines
+class CBA_762x25_PPSh_Stick {}; // PPSh-41 stick magazines
+class CBA_762x25_TT {};         // TT-30, TT-33 Tokarev

--- a/addons/jam/magwells_762x38R.hpp
+++ b/addons/jam/magwells_762x38R.hpp
@@ -1,1 +1,1 @@
-    class CBA_762x38R_Nagant {};    // Nagant M1895 Revolver
+class CBA_762x38R_Nagant {};    // Nagant M1895 Revolver

--- a/addons/jam/magwells_762x39.hpp
+++ b/addons/jam/magwells_762x39.hpp
@@ -1,18 +1,21 @@
-    class CBA_762x39_AK {               // Standard AK-47/AKM magazines
-        BI_mags[] = {
-            "30Rnd_762x39_Mag_F",
-            "30Rnd_762x39_Mag_Green_F",
-            "30Rnd_762x39_Mag_Tracer_F",
-            "30Rnd_762x39_Mag_Tracer_Green_F"
-        };
+class AK_762x39;
+class CBA_762x39_AK: AK_762x39 {               // Standard AK-47/AKM magazines
+/*
+    BI_mags[] = {
+        "30Rnd_762x39_Mag_F",
+        "30Rnd_762x39_Mag_Green_F",
+        "30Rnd_762x39_Mag_Tracer_F",
+        "30Rnd_762x39_Mag_Tracer_Green_F"
     };
+*/
+};
 
-    class CBA_762x39_RPK {};            // 40/45/75rnd RPK magazines
+class CBA_762x39_RPK {};            // 40/45/75rnd RPK magazines
 
-    class CBA_762x39_STANAG {};         // 762x39mm in a normal length STANAG mag, including small drums
-    class CBA_762x39_STANAG_L {};       // 762x39mm in a long STANAG stick or coffin
-    class CBA_762x39_STANAG_XL {};      // 762x39mm in an extra long STANAG stick or coffin mag
-    class CBA_762x39_STANAG_2D {};      // 762x39mm in a twin-drum STANAG mag
-    class CBA_762x39_STANAG_2D_XL {};   // 762x39mm in an extra large twin-drum STANAG mag
+class CBA_762x39_STANAG {};         // 762x39mm in a normal length STANAG mag, including small drums
+class CBA_762x39_STANAG_L {};       // 762x39mm in a long STANAG stick or coffin
+class CBA_762x39_STANAG_XL {};      // 762x39mm in an extra long STANAG stick or coffin mag
+class CBA_762x39_STANAG_2D {};      // 762x39mm in a twin-drum STANAG mag
+class CBA_762x39_STANAG_2D_XL {};   // 762x39mm in an extra large twin-drum STANAG mag
 
-    class CBA_762x39_VZ58 {};           // 762x39mm VZ58 magazine, cannot be used in AKs or vice versa
+class CBA_762x39_VZ58 {};           // 762x39mm VZ58 magazine, cannot be used in AKs or vice versa

--- a/addons/jam/magwells_762x51.hpp
+++ b/addons/jam/magwells_762x51.hpp
@@ -1,48 +1,48 @@
-    class CBA_762x51_1rnd {};       // 1 loose round of 7.62x51mm NATO
-    class CBA_762x51_2rnds {};      // 2 loose rounds of 7.62x51mm NATO
-    class CBA_762x51_3rnds {};      // 3 loose rounds of 7.62x51mm NATO
-    class CBA_762x51_4rnds {};      // 4 loose rounds of 7.62x51mm NATO
-    class CBA_762x51_5rnds {};      // 5 loose rounds of 7.62x51mm NATO
+class CBA_762x51_1rnd {};       // 1 loose round of 7.62x51mm NATO
+class CBA_762x51_2rnds {};      // 2 loose rounds of 7.62x51mm NATO
+class CBA_762x51_3rnds {};      // 3 loose rounds of 7.62x51mm NATO
+class CBA_762x51_4rnds {};      // 4 loose rounds of 7.62x51mm NATO
+class CBA_762x51_5rnds {};      // 5 loose rounds of 7.62x51mm NATO
 
-    class CBA_762x51_AICS {};       // AICS short action mag (5/10 rounds)
+class CBA_762x51_AICS {};       // AICS short action mag (5/10 rounds)
 
-    class CBA_762x51_AR10 {};       // AR-10 standard mag (20 rounds)
-    class CBA_762x51_AR10_L {};     // AR-10 long mag (25/30 rounds)
-    class CBA_762x51_AR10_XL {};    // AR-10 drum mag (X-Products 50 round)
+class CBA_762x51_AR10 {};       // AR-10 standard mag (20 rounds)
+class CBA_762x51_AR10_L {};     // AR-10 long mag (25/30 rounds)
+class CBA_762x51_AR10_XL {};    // AR-10 drum mag (X-Products 50 round)
 
-    class CBA_762x51_FAL {};        // FN FAL
-    class CBA_762x51_FAL_L {};      // FN FAL long mag (25/30 rounds)
-    class CBA_762x51_FAL_XL {};     // FN FAL drum mag (X-Products 50 round)
+class CBA_762x51_FAL {};        // FN FAL
+class CBA_762x51_FAL_L {};      // FN FAL long mag (25/30 rounds)
+class CBA_762x51_FAL_XL {};     // FN FAL drum mag (X-Products 50 round)
 
-    class CBA_762x51_G3 {};         // H&K G3
-    class CBA_762x51_G3_L {};       // H&K G3 long mag (25/30 rounds)
-    class CBA_762x51_G3_XL {};      // H&K G3 drum mag (X-Products 50 round)
+class CBA_762x51_G3 {};         // H&K G3
+class CBA_762x51_G3_L {};       // H&K G3 long mag (25/30 rounds)
+class CBA_762x51_G3_XL {};      // H&K G3 drum mag (X-Products 50 round)
 
-    class CBA_762x51_HK417 {};      // H&K 417
-    class CBA_762x51_HK417_L {};    // H&K417 long mag (25/30 rounds)
-    class CBA_762x51_HK417_XL {};   // H&K417 drum mag (50 rounds)
+class CBA_762x51_HK417 {};      // H&K 417
+class CBA_762x51_HK417_L {};    // H&K417 long mag (25/30 rounds)
+class CBA_762x51_HK417_XL {};   // H&K417 drum mag (50 rounds)
 
-    class CBA_762x51_LINKS {        // M13 Links for M60, M240, MG3 (DM6/DM60)
-        BI_belts[] = {
-            "150Rnd_762x51_Box",
-            "150Rnd_762x51_Box_Tracer"
-        };
+class CBA_762x51_LINKS {        // M13 Links for M60, M240, MG3 (DM6/DM60)
+    BI_belts[] = {
+        "150Rnd_762x51_Box",
+        "150Rnd_762x51_Box_Tracer"
     };
+};
 
-    class CBA_762x51_M14 {};        // M14
-    class CBA_762x51_M14_L {};      // M14 long mag (25/30 rounds)
-    class CBA_762x51_M14_XL {};     // M14 drum mag (X-Products 50 round)
+class CBA_762x51_M14 {};        // M14
+class CBA_762x51_M14_L {};      // M14 long mag (25/30 rounds)
+class CBA_762x51_M14_XL {};     // M14 drum mag (X-Products 50 round)
 
-    class CBA_762x51_MG3 {};        // MG3 DM1 link belts
+class CBA_762x51_MG3 {};        // MG3 DM1 link belts
 
-    class CBA_762x51_MkI_EMR {      // Mk-I EMR 7.62 mm magazines
-        BI_mags[] = {
-            "20Rnd_762x51_Mag"
-        };
+class CBA_762x51_MkI_EMR {      // Mk-I EMR 7.62 mm magazines
+    BI_mags[] = {
+        "20Rnd_762x51_Mag"
     };
+};
 
-    class CBA_762x51_SCAR {};       // SCAR-H
-    class CBA_762x51_SIGAMT {};     // SIG 510-4, AMT
+class CBA_762x51_SCAR {};       // SCAR-H
+class CBA_762x51_SIGAMT {};     // SIG 510-4, AMT
 
-    //Deprecated classes do not use
-    class CBA_762x51_SR25 {};       // DEPRECATED, use CBA_762x51_AR10 instead.
+//Deprecated classes do not use
+class CBA_762x51_SR25 {};       // DEPRECATED, use CBA_762x51_AR10 instead.

--- a/addons/jam/magwells_762x54.hpp
+++ b/addons/jam/magwells_762x54.hpp
@@ -1,20 +1,20 @@
-    class CBA_762x54R_DPM {};       // DPM LMG
-    class CBA_762x54R_DT {};        // DT LMG
+class CBA_762x54R_DPM {};       // DPM LMG
+class CBA_762x54R_DT {};        // DT LMG
 
-    class CBA_762x54R_LINKS {       // Links for PK, PKM, and similar
-        BI_belts[] = {
-            "150Rnd_762x54_Box",
-            "150Rnd_762x54_Box_Tracer"
-        };
+class CBA_762x54R_LINKS {       // Links for PK, PKM, and similar
+    BI_belts[] = {
+        "150Rnd_762x54_Box",
+        "150Rnd_762x54_Box_Tracer"
     };
+};
 
-    class CBA_762x54R_Maxim {};     // Maxim gun in 7.62x54R
-    class CBA_762x54R_Mosin {};     // M91/30, M38, M44 Mosin
+class CBA_762x54R_Maxim {};     // Maxim gun in 7.62x54R
+class CBA_762x54R_Mosin {};     // M91/30, M38, M44 Mosin
 
-    class CBA_762x54R_SVD {         // SVD
-        BI_mags[] = {
-            "10Rnd_762x54_Mag"
-        };
+class CBA_762x54R_SVD {         // SVD
+    BI_mags[] = {
+        "10Rnd_762x54_Mag"
     };
+};
 
-    class CBA_762x54R_SVT {};       // SVT
+class CBA_762x54R_SVT {};       // SVT

--- a/addons/jam/magwells_763x25.hpp
+++ b/addons/jam/magwells_763x25.hpp
@@ -1,1 +1,1 @@
-    class CBA_763x25_C96 {};        // Mauser C-96 in 7.63x25mm
+class CBA_763x25_C96 {};        // Mauser C-96 in 7.63x25mm

--- a/addons/jam/magwells_765x21.hpp
+++ b/addons/jam/magwells_765x21.hpp
@@ -1,1 +1,1 @@
-    class CBA_765x21_C96 {};        // Mauser C-96 in 7.65x21mm
+class CBA_765x21_C96 {};        // Mauser C-96 in 7.65x21mm

--- a/addons/jam/magwells_77x58.hpp
+++ b/addons/jam/magwells_77x58.hpp
@@ -1,3 +1,3 @@
-    class CBA_77x58_Arisaka {};     // Japanese Type 99 Arisaka
-    class CBA_77x58_Type92 {};      // Japanese Type 92 HMG
-    class CBA_77x58_Type99 {};      // Japanese Type 99 LMG
+class CBA_77x58_Arisaka {};     // Japanese Type 99 Arisaka
+class CBA_77x58_Type92 {};      // Japanese Type 92 HMG
+class CBA_77x58_Type99 {};      // Japanese Type 99 LMG

--- a/addons/jam/magwells_792x33.hpp
+++ b/addons/jam/magwells_792x33.hpp
@@ -1,1 +1,1 @@
-    class CBA_792x33_StG {};        // StG44
+class CBA_792x33_StG {};        // StG44

--- a/addons/jam/magwells_792x57.hpp
+++ b/addons/jam/magwells_792x57.hpp
@@ -1,6 +1,6 @@
-    class CBA_792x57_FG42 {};       // FG42
-    class CBA_792x57_G43 {};        // G43, G41
-    class CBA_792x57_K98 {};        // K98, G98
-    class CBA_792x57_LINKS {};      // MG42, MG34
-    class CBA_792x57_MG08 {};       // MG08
-    class CBA_792x57_TROMMEL {};    // MG34 Patronentrommel 34
+class CBA_792x57_FG42 {};       // FG42
+class CBA_792x57_G43 {};        // G43, G41
+class CBA_792x57_K98 {};        // K98, G98
+class CBA_792x57_LINKS {};      // MG42, MG34
+class CBA_792x57_MG08 {};       // MG08
+class CBA_792x57_TROMMEL {};    // MG34 Patronentrommel 34

--- a/addons/jam/magwells_8x22.hpp
+++ b/addons/jam/magwells_8x22.hpp
@@ -1,3 +1,3 @@
-    class CBA_8x22_Type100 {};      // Japanese Type 100 SMG
-    class CBA_8x22_Type14 {};       // Japanese Type 14 Nambu
-    class CBA_8x22_TypeB {};        // Japanese Type B Nambu
+class CBA_8x22_Type100 {};      // Japanese Type 100 SMG
+class CBA_8x22_Type14 {};       // Japanese Type 14 Nambu
+class CBA_8x22_TypeB {};        // Japanese Type B Nambu

--- a/addons/jam/magwells_9x18.hpp
+++ b/addons/jam/magwells_9x18.hpp
@@ -1,17 +1,17 @@
-    class CBA_9x18_APS {};      // Stechkin automatic pistol (APS)
-    class CBA_9x18_Fort12 {};   // Fort-12
-    class CBA_9x18_GPP9M {};    // Grand Power K100 P9M
-    class CBA_9x18_Ots01 {};    // OTs-01 Kobalt
-    class CBA_9x18_Ots02 {};    // OTs-01 Kiparis
-    class CBA_9x18_Ots27 {};    // OTs-27 Berdysh
-    class CBA_9x18_Ots33 {};    // OTs-33 Pernach
-    class CBA_9x18_P64 {};      // FB P-64 CZAK
-    class CBA_9x18_P83 {};      // FB P-83 Wanad
-    class CBA_9x18_PA63 {};     // FEG PA-63
-    class CBA_9x18_PM {};       // Makarov PM
-    class CBA_9x18_PM63 {};     // FB PM-63 RAK
-    class CBA_9x18_PM84 {};     // FB PM-84 Glauberyt
-    class CBA_9x18_PMM {};      // Makarov PMM
-    class CBA_9x18_PP19 {};     // PP-19 Bizon-1
-    class CBA_9x18_PP91 {};     // PP-91 KEDR
-    class CBA_9x18_Vz65 {};     // Škorpion (vz. 65)
+class CBA_9x18_APS {};      // Stechkin automatic pistol (APS)
+class CBA_9x18_Fort12 {};   // Fort-12
+class CBA_9x18_GPP9M {};    // Grand Power K100 P9M
+class CBA_9x18_Ots01 {};    // OTs-01 Kobalt
+class CBA_9x18_Ots02 {};    // OTs-01 Kiparis
+class CBA_9x18_Ots27 {};    // OTs-27 Berdysh
+class CBA_9x18_Ots33 {};    // OTs-33 Pernach
+class CBA_9x18_P64 {};      // FB P-64 CZAK
+class CBA_9x18_P83 {};      // FB P-83 Wanad
+class CBA_9x18_PA63 {};     // FEG PA-63
+class CBA_9x18_PM {};       // Makarov PM
+class CBA_9x18_PM63 {};     // FB PM-63 RAK
+class CBA_9x18_PM84 {};     // FB PM-84 Glauberyt
+class CBA_9x18_PMM {};      // Makarov PMM
+class CBA_9x18_PP19 {};     // PP-19 Bizon-1
+class CBA_9x18_PP91 {};     // PP-91 KEDR
+class CBA_9x18_Vz65 {};     // Škorpion (vz. 65)

--- a/addons/jam/magwells_9x19.hpp
+++ b/addons/jam/magwells_9x19.hpp
@@ -1,29 +1,29 @@
-    class CBA_9x19_C96 {};          // Mauser C-96 in 9x19mm
-    class CBA_9x19_CZ82 {};         // CZ 82, Vz. 82, CZ 83
-    class CBA_9x19_GPK199 {};       // Grand Power K100
-    class CBA_9x19_GSh18 {};        // GSh-18
-    class CBA_9x19_Glock_Slim {};   // Slimline Glock in 9x19mm (Glock 43)
-    class CBA_9x19_Glock_SubC {};   // Subcompact Glock in 9x19mm (Glock 26)
-    class CBA_9x19_Glock_Cpct {};   // Compact Glock in 9x19mm (Glock 19, 46)
-    class CBA_9x19_Glock_Full {};   // Fullsize Glock in 9x19mm (Glock 17, 18, 34, 45)
-    class CBA_9x19_HiPower {};      // Browning HiPower
-    class CBA_9x19_MP40 {};         // MP40, MP38
-    class CBA_9x19_MP443 {};        // MP-443 Grach
-    class CBA_9x19_MP5 {};          // H&K MP5
-    class CBA_9x19_Ots27 {};        // OTs-27 Berdysh
-    class CBA_9x19_P08 {};          // Luger P08
-    class CBA_9x19_P226 {};         // SIG P226
-    class CBA_9x19_P228 {};         // SIG P228
-    class CBA_9x19_P239 {};         // SIG P239
-    class CBA_9x19_P38 {};          // Walther P38
-    class CBA_9x19_PM63 {};         // FB PM-63 RAK
-    class CBA_9x19_PM84 {};         // FB PM-84 Glauberyt
-    class CBA_9x19_PP19 {};         // PP-19 Bizon-2-01
-    class CBA_9x19_PP2000 {};       // PP-2000 SMG
-    class CBA_9x19_STEN {};         // STEN
-    class CBA_9x19_STEYR {};        // AUG SMG, MPi, TMP
-    class CBA_9x19_TT {};           // TT-33 Tokarev in 9x19mm (M48, Tokagypt 58, Type 54)
-    class CBA_9x19_Vis {};          // wz. 35 Vis (Radom)
-    class CBA_9x19_Vityaz {};       // Vityaz-SN
-    class CBA_9x19_Vz68 {};         // Škorpion (vz. 68)
-    class CBA_9x19_Welrod {};       // Welrod pistol in 9x19mm
+class CBA_9x19_C96 {};          // Mauser C-96 in 9x19mm
+class CBA_9x19_CZ82 {};         // CZ 82, Vz. 82, CZ 83
+class CBA_9x19_GPK199 {};       // Grand Power K100
+class CBA_9x19_GSh18 {};        // GSh-18
+class CBA_9x19_Glock_Slim {};   // Slimline Glock in 9x19mm (Glock 43)
+class CBA_9x19_Glock_SubC {};   // Subcompact Glock in 9x19mm (Glock 26)
+class CBA_9x19_Glock_Cpct {};   // Compact Glock in 9x19mm (Glock 19, 46)
+class CBA_9x19_Glock_Full {};   // Fullsize Glock in 9x19mm (Glock 17, 18, 34, 45)
+class CBA_9x19_HiPower {};      // Browning HiPower
+class CBA_9x19_MP40 {};         // MP40, MP38
+class CBA_9x19_MP443 {};        // MP-443 Grach
+class CBA_9x19_MP5 {};          // H&K MP5
+class CBA_9x19_Ots27 {};        // OTs-27 Berdysh
+class CBA_9x19_P08 {};          // Luger P08
+class CBA_9x19_P226 {};         // SIG P226
+class CBA_9x19_P228 {};         // SIG P228
+class CBA_9x19_P239 {};         // SIG P239
+class CBA_9x19_P38 {};          // Walther P38
+class CBA_9x19_PM63 {};         // FB PM-63 RAK
+class CBA_9x19_PM84 {};         // FB PM-84 Glauberyt
+class CBA_9x19_PP19 {};         // PP-19 Bizon-2-01
+class CBA_9x19_PP2000 {};       // PP-2000 SMG
+class CBA_9x19_STEN {};         // STEN
+class CBA_9x19_STEYR {};        // AUG SMG, MPi, TMP
+class CBA_9x19_TT {};           // TT-33 Tokarev in 9x19mm (M48, Tokagypt 58, Type 54)
+class CBA_9x19_Vis {};          // wz. 35 Vis (Radom)
+class CBA_9x19_Vityaz {};       // Vityaz-SN
+class CBA_9x19_Vz68 {};         // Škorpion (vz. 68)
+class CBA_9x19_Welrod {};       // Welrod pistol in 9x19mm

--- a/addons/jam/magwells_9x21.hpp
+++ b/addons/jam/magwells_9x21.hpp
@@ -1,1 +1,1 @@
-    class CBA_9x21_SR1M {};       // 6P53/SR1M pistol
+class CBA_9x21_SR1M {};       // 6P53/SR1M pistol

--- a/addons/jam/magwells_9x39.hpp
+++ b/addons/jam/magwells_9x39.hpp
@@ -1,1 +1,1 @@
-    class CBA_9x39_VSS {};          // Vintorez, Val
+class CBA_9x39_VSS {};          // Vintorez, Val


### PR DESCRIPTION
Updates instead of overriding vanilla magwells.
Inherit from existing vanilla magwells.
Remove leading spaces.