### PR TITLE
Fix sqf_validator to work with # command

### DIFF
--- a/tools/sqf_validator.py
+++ b/tools/sqf_validator.py
@@ -119,6 +119,9 @@ def check_sqf_syntax(filepath):
                             print("ERROR: Tab detected at {0} Line number: {1}".format(filepath,lineNumber))
                             bad_count_file += 1
 
+                        if (c not in [' ', '\t', '\n']):
+                            onlyWhitespace = False
+
                         if (checkForSemiColon):
                             if (c not in [' ', '\t', '\n', '/']): # keep reading until no white space or comments
                                 checkForSemiColon = False

--- a/tools/sqf_validator.py
+++ b/tools/sqf_validator.py
@@ -51,7 +51,8 @@ def check_sqf_syntax(filepath):
         inStringType = '';
 
         lastIsCurlyBrace = False
-        checkForSemiColumn = False
+        checkForSemiColon = False
+        onlyWhitespace = True
 
         # Extra information so we know what line we find errors at
         lineNumber = 1
@@ -61,9 +62,10 @@ def check_sqf_syntax(filepath):
         for c in content:
             if (lastIsCurlyBrace):
                 lastIsCurlyBrace = False
-                checkForSemiColumn = True
+                checkForSemiColon = True
 
             if c == '\n': # Keeping track of our line numbers
+                onlyWhitespace = True # reset so we can see if # is for a preprocessor command
                 lineNumber += 1 # so we can print accurate line number information when we detect a possible error
             if (isInString): # while we are in a string, we can ignore everything else, except the end of the string
                 if (c == inStringType):
@@ -87,7 +89,7 @@ def check_sqf_syntax(filepath):
                         if (c == '"' or c == "'"):
                             isInString = True
                             inStringType = c
-                        elif (c == '#'):
+                        elif (c == '#' and onlyWhitespace):
                             ignoreTillEndOfLine = True
                         elif (c == '/'):
                             checkIfInComment = True
@@ -117,11 +119,11 @@ def check_sqf_syntax(filepath):
                             print("ERROR: Tab detected at {0} Line number: {1}".format(filepath,lineNumber))
                             bad_count_file += 1
 
-                        if (checkForSemiColumn):
+                        if (checkForSemiColon):
                             if (c not in [' ', '\t', '\n', '/']): # keep reading until no white space or comments
-                                checkForSemiColumn = False
+                                checkForSemiColon = False
                                 if (c not in [']', ')', '}', ';', ',', '&', '!', '|', '='] and not validKeyWordAfterCode(content, indexOfCharacter)): # , 'f', 'd', 'c', 'e', 'a', 'n', 'i']):
-                                    print("ERROR: Possible missing semi-column ';' detected at {0} Line number: {1}".format(filepath,lineNumber))
+                                    print("ERROR: Possible missing semicolon ';' detected at {0} Line number: {1}".format(filepath,lineNumber))
                                     bad_count_file += 1
 
             else: # Look for the end of our comment block


### PR DESCRIPTION
**When merged this pull request will:**
- Rename semiColumn to correct spelling semiColon
- Fix the # command to check if there is only whitespace before it, to differentiate between preprocessor command and select command.
