### PR TITLE
add default value for serializedNamespace

### DIFF
--- a/addons/hashes/fnc_serializeNamespace.sqf
+++ b/addons/hashes/fnc_serializeNamespace.sqf
@@ -7,6 +7,7 @@ Description:
 
 Parameters:
     _namespace - a namespace <LOCATION, OBJECT>
+    _defaultValue - Default value. Used when key doesn't exist. A key is also removed from the hash if the value is set to this default [Any, defaults to nil]
 
 Returns:
     _hash - a hash <ARRAY>
@@ -22,9 +23,9 @@ Author:
 ---------------------------------------------------------------------------- */
 SCRIPT(serializeNamespace);
 
-params [["_namespace", locationNull, [locationNull, objNull]]];
+params [["_namespace", locationNull, [locationNull, objNull]], "_defaultValue"];
 
-private _hash = [] call CBA_fnc_hashCreate;
+private _hash = [[], _defaultValue] call CBA_fnc_hashCreate;
 
 {
     [_hash, _x, _namespace getVariable _x] call CBA_fnc_hashSet;


### PR DESCRIPTION
**When merged this pull request will:**
- Will add a default value parameter for `fnc_serializeVariable`

I needed this for my mod project since I use this function but was missing the defaultValue I was used to when using `fnc_hashCreate`

