### PR TITLE
sort maps alphabetically

### DIFF
--- a/addons/ui/fnc_initDisplayRemoteMissions.sqf
+++ b/addons/ui/fnc_initDisplayRemoteMissions.sqf
@@ -5,6 +5,7 @@ params ["_display"];
 private _ctrlMaps = _display displayCtrl IDC_SERVER_ISLAND;
 private _ctrlMissions = _display displayCtrl IDC_SERVER_MISSION;
 
+lbSort _ctrlMaps;
 ctrlPosition _ctrlMissions params ["_left", "_top", "_width", "_height"];
 
 private _ctrlSearch = _display ctrlCreate ["RscEdit", IDC_SEARCH];


### PR DESCRIPTION
**When merged this pull request will:**
- This makes it so the maps are sorted alphabetically on the mission creation screen.
- The missions are already sorted this way, so the maps currently being sorted by config order is weird.

