### PR TITLE
fix admin macros for usage in strings and config

### DIFF
--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -1740,7 +1740,7 @@ Example:
 Author:
     commy2
 ------------------------------------------- */
-#define IS_ADMIN serverCommandAvailable "#kick"
+#define IS_ADMIN serverCommandAvailable '#kick'
 
 /* -------------------------------------------
 Macro: IS_ADMIN_LOGGED
@@ -1760,7 +1760,7 @@ Example:
 Author:
     commy2
 ------------------------------------------- */
-#define IS_ADMIN_LOGGED serverCommandAvailable "#shutdown"
+#define IS_ADMIN_LOGGED serverCommandAvailable '#shutdown'
 
 /* -------------------------------------------
 Macro: FILE_EXISTS


### PR DESCRIPTION
**When merged this pull request will:**
- currently these cannot be used inside config, because the quote marks are not escaped.
- after this PR they will escape from strings with single quotes, but I doubt anyone uses them this way
