### PR TITLE
Cache incompatibleClasses at preStart

### DIFF
--- a/addons/xeh/fnc_preInit.sqf
+++ b/addons/xeh/fnc_preInit.sqf
@@ -75,14 +75,14 @@ GVAR(EventsLowercase) = [];
 GVAR(incompatible) = [] call CBA_fnc_createNamespace;
 
 {
-    private _class = configFile >> "CfgVehicles" >> _x;
+    private _class = _x;
 
     while {isClass _class && {!ISINCOMP(configName _class)}} do {
         SETINCOMP(configName _class);
 
         _class = inheritsFrom _class;
     };
-} forEach ([false, true] call CBA_fnc_supportMonitor);
+} forEach (uiNamespace getVariable [QGVAR(incompatibleClasses), []]);
 
 // always recompile extended event handlers
 #ifdef DEBUG_MODE_FULL

--- a/addons/xeh/fnc_preInit.sqf
+++ b/addons/xeh/fnc_preInit.sqf
@@ -73,16 +73,16 @@ GVAR(EventsLowercase) = [];
 
 // generate list of incompatible classes
 GVAR(incompatible) = [] call CBA_fnc_createNamespace;
-
+private _cfgVehicles = configFile >> "CfgVehicles";
 {
-    private _class = _x;
+    private _class = _cfgVehicles >> _x;
 
     while {isClass _class && {!ISINCOMP(configName _class)}} do {
         SETINCOMP(configName _class);
 
         _class = inheritsFrom _class;
     };
-} forEach (uiNamespace getVariable [QGVAR(incompatibleClasses), []]);
+} forEach call (uiNamespace getVariable [QGVAR(incompatibleClasses), {[]}]);
 
 // always recompile extended event handlers
 #ifdef DEBUG_MODE_FULL

--- a/addons/xeh/fnc_preStart.sqf
+++ b/addons/xeh/fnc_preStart.sqf
@@ -65,4 +65,8 @@ with uiNamespace do {
             diag_log text format ["[XEH]: %1 does not support Extended Event Handlers! Addon: %2", _classname, _addon];
         };
     } forEach (true call CBA_fnc_supportMonitor);
+
+    // cache incompatible classes that are needed in preInit
+    private _cfgVehicles = configFile >> "CfgVehicles"; //We need classes in preInit anyway
+    GVAR(incompatibleClasses) = ([false, true] call CBA_fnc_supportMonitor) apply {_cfgVehicles >> _x};
 };

--- a/addons/xeh/fnc_preStart.sqf
+++ b/addons/xeh/fnc_preStart.sqf
@@ -67,6 +67,5 @@ with uiNamespace do {
     } forEach (true call CBA_fnc_supportMonitor);
 
     // cache incompatible classes that are needed in preInit
-    private _cfgVehicles = configFile >> "CfgVehicles"; //We need classes in preInit anyway
-    GVAR(incompatibleClasses) = ([false, true] call CBA_fnc_supportMonitor) apply {_cfgVehicles >> _x};
+    GVAR(incompatibleClasses) = compileFinal str ([false, true] call CBA_fnc_supportMonitor);
 };


### PR DESCRIPTION
configFile cannot change, so we might aswell collect that stuff at preStart.

![](https://s.sqf.ovh/Tracy_2019-02-07_20-54-49.png)