### PR TITLE
Resolve XEH redirect handlers

### DIFF
--- a/addons/xeh/fnc_compileEventHandlers.sqf
+++ b/addons/xeh/fnc_compileEventHandlers.sqf
@@ -69,6 +69,28 @@ private _resultNames = [];
         };
 
         if !(_eventFunc isEqualTo "") then {
+		
+			//Optimize "QUOTE(call COMPILE_FILE(XEH_preInit));" down to just the content of the EH script
+			if (!(["compile"] call CBA_fnc_isRecompileEnabled) && //Users might expect their preInit script to be reloaded everytime when debugging
+				{
+					(toLower (_eventFunc select [0,40])) isEqualTo "call compile preprocessfilelinenumbers '"
+					&& 
+					{
+							(_eventFunc select [count _eventFunc -2]) isEqualTo "';"
+					}
+				}
+			) then {
+				private _funcPath = _eventFunc select [40, count _eventFunc - 42];
+				//If there is a quote mark in the path, then something went wrong and we got multiple paths, just skip optimization
+				//Example cause: "call COMPILE_FILE(XEH_preInit);call COMPILE_FILE(XEH_preClientInit)"
+				if (_funcPath find "'" == -1) then {
+					_eventFunc = preprocessFileLineNumbers _funcPath;
+					
+					TRACE_2("eventfunction redirected",_customName,_funcPath);
+				};
+			};	
+		
+		
             _eventFunc = compile _eventFunc;
             TRACE_2("does something",_customName,_eventName);
         } else {

--- a/addons/xeh/fnc_compileEventHandlers.sqf
+++ b/addons/xeh/fnc_compileEventHandlers.sqf
@@ -71,15 +71,10 @@ private _resultNames = [];
         if !(_eventFunc isEqualTo "") then {
 
             //Optimize "QUOTE(call COMPILE_FILE(XEH_preInit));" down to just the content of the EH script
-            if (!(["compile"] call CBA_fnc_isRecompileEnabled) && //Users might expect their preInit script to be reloaded everytime when debugging
-                {
-                    (toLower (_eventFunc select [0,40])) isEqualTo "call compile preprocessfilelinenumbers '"
-                    &&
-                    {
-                            (_eventFunc select [count _eventFunc -2]) isEqualTo "';"
-                    }
-                }
-            ) then {
+            if (!(["compile"] call CBA_fnc_isRecompileEnabled) && { //Users might expect their preInit script to be reloaded everytime when debugging
+                    (toLower (_eventFunc select [0,40])) isEqualTo "call compile preprocessfilelinenumbers '" && {
+					(_eventFunc select [count _eventFunc -2]) isEqualTo "';"
+			}}) then {
                 private _funcPath = _eventFunc select [40, count _eventFunc - 42];
                 //If there is a quote mark in the path, then something went wrong and we got multiple paths, just skip optimization
                 //Example cause: "call COMPILE_FILE(XEH_preInit);call COMPILE_FILE(XEH_preClientInit)"

--- a/addons/xeh/fnc_compileEventHandlers.sqf
+++ b/addons/xeh/fnc_compileEventHandlers.sqf
@@ -73,8 +73,8 @@ private _resultNames = [];
             //Optimize "QUOTE(call COMPILE_FILE(XEH_preInit));" down to just the content of the EH script
             if (!(["compile"] call CBA_fnc_isRecompileEnabled) && { //Users might expect their preInit script to be reloaded everytime when debugging
                     (toLower (_eventFunc select [0,40])) isEqualTo "call compile preprocessfilelinenumbers '" && {
-					(_eventFunc select [count _eventFunc -2]) isEqualTo "';"
-			}}) then {
+                    (_eventFunc select [count _eventFunc -2]) isEqualTo "';"
+            }}) then {
                 private _funcPath = _eventFunc select [40, count _eventFunc - 42];
                 //If there is a quote mark in the path, then something went wrong and we got multiple paths, just skip optimization
                 //Example cause: "call COMPILE_FILE(XEH_preInit);call COMPILE_FILE(XEH_preClientInit)"

--- a/addons/xeh/fnc_compileEventHandlers.sqf
+++ b/addons/xeh/fnc_compileEventHandlers.sqf
@@ -69,28 +69,27 @@ private _resultNames = [];
         };
 
         if !(_eventFunc isEqualTo "") then {
-		
-			//Optimize "QUOTE(call COMPILE_FILE(XEH_preInit));" down to just the content of the EH script
-			if (!(["compile"] call CBA_fnc_isRecompileEnabled) && //Users might expect their preInit script to be reloaded everytime when debugging
-				{
-					(toLower (_eventFunc select [0,40])) isEqualTo "call compile preprocessfilelinenumbers '"
-					&& 
-					{
-							(_eventFunc select [count _eventFunc -2]) isEqualTo "';"
-					}
-				}
-			) then {
-				private _funcPath = _eventFunc select [40, count _eventFunc - 42];
-				//If there is a quote mark in the path, then something went wrong and we got multiple paths, just skip optimization
-				//Example cause: "call COMPILE_FILE(XEH_preInit);call COMPILE_FILE(XEH_preClientInit)"
-				if (_funcPath find "'" == -1) then {
-					_eventFunc = preprocessFileLineNumbers _funcPath;
-					
-					TRACE_2("eventfunction redirected",_customName,_funcPath);
-				};
-			};	
-		
-		
+
+            //Optimize "QUOTE(call COMPILE_FILE(XEH_preInit));" down to just the content of the EH script
+            if (!(["compile"] call CBA_fnc_isRecompileEnabled) && //Users might expect their preInit script to be reloaded everytime when debugging
+                {
+                    (toLower (_eventFunc select [0,40])) isEqualTo "call compile preprocessfilelinenumbers '"
+                    &&
+                    {
+                            (_eventFunc select [count _eventFunc -2]) isEqualTo "';"
+                    }
+                }
+            ) then {
+                private _funcPath = _eventFunc select [40, count _eventFunc - 42];
+                //If there is a quote mark in the path, then something went wrong and we got multiple paths, just skip optimization
+                //Example cause: "call COMPILE_FILE(XEH_preInit);call COMPILE_FILE(XEH_preClientInit)"
+                if (_funcPath find "'" == -1) then {
+                    _eventFunc = preprocessFileLineNumbers _funcPath;
+
+                    TRACE_2("eventfunction redirected",_customName,_funcPath);
+                };
+            };
+
             _eventFunc = compile _eventFunc;
             TRACE_2("does something",_customName,_eventName);
         } else {


### PR DESCRIPTION
Resolve handlers that just point to a file.
Instead of executing `call compile preprocessFileLineNumbers...` every time before the EH is executed. Detect that pattern and resolve it at compile time and directly compile the target file.
Get's rid of (number of preInit scripts in ACE and CBA) calls to preprocessFile and compile at preInit
Get's rid of (number of postInit scripts in ACE and CBA) calls to preprocessFile and compile at postInit

After all the recent PR's to speed up pre/postInit this should give a nice additional boost.



Q: Should I implement that for Object handlers too? I guess yes because everything that uses the call preproc pattern will benefit, which I assume is done for objects too.