### PR TITLE
Add return value to cba_fnc_preStart

### DIFF
--- a/addons/xeh/fnc_preStart.sqf
+++ b/addons/xeh/fnc_preStart.sqf
@@ -68,4 +68,5 @@ with uiNamespace do {
 
     // cache incompatible classes that are needed in preInit
     GVAR(incompatibleClasses) = compileFinal str ([false, true] call CBA_fnc_supportMonitor);
+    nil // needs return value [a3\functions_f\initfunctions.sqf Line 499]
 };


### PR DESCRIPTION
Fix
```
 [0,9.635,0,"XEH: PreStart finished."]
 Error in expression <",_x] call bis_fnc_logFormat;
_function = [] call (uinamespace getvariable _x);
>
   Error position: <= [] call (uinamespace getvariable _x);
>
   Error Generic error in expression
 File A3\functions_f\initFunctions.sqf, line 499
```

a3 does
```
			_function = [] call (uinamespace getvariable _x);
			uinamespace setvariable [_x + "_preStart",_function];
```
and `c = call {a=b}` throws error