### PR TITLE
remove 100Rnd mags magwell from non MX-SW MX variants

### DIFF
--- a/addons/jam/CfgWeapons.hpp
+++ b/addons/jam/CfgWeapons.hpp
@@ -13,20 +13,20 @@ class CfgWeapons {
     class Tavor_base_F: Rifle_Base_F {
         magazineWell[] = {"CBA_556x45_STANAG", "CBA_556x45_STANAG_L", "CBA_556x45_STANAG_XL", "CBA_556x45_STANAG_2D"};
     };
-    class arifle_SPAR_01_base_F : Rifle_Base_F {
+    class arifle_SPAR_01_base_F: Rifle_Base_F {
         magazineWell[] = {"CBA_556x45_STANAG", "CBA_556x45_STANAG_L", "CBA_556x45_STANAG_XL", "CBA_556x45_STANAG_2D", "CBA_556x45_STANAG_2D_XL"};
     };
-    class arifle_SPAR_02_base_F : Rifle_Base_F {
+    class arifle_SPAR_02_base_F: Rifle_Base_F {
         magazineWell[] = {"CBA_556x45_STANAG", "CBA_556x45_STANAG_L", "CBA_556x45_STANAG_XL", "CBA_556x45_STANAG_2D", "CBA_556x45_STANAG_2D_XL"};
     };
 
-    class UGL_F : GrenadeLauncher {
+    class UGL_F: GrenadeLauncher {
         magazineWell[] = {"CBA_40mm_M203", "CBA_40mm_EGLM"};
     };
 
-    class arifle_MX_Base_F : Rifle_Base_F {
+    class arifle_MX_Base_F: Rifle_Base_F {
         magazineWell[] = {"CBA_65x39_MX"};
-        class GL_3GL_F : UGL_F {
+        class GL_3GL_F: UGL_F {
             magazineWell[] = {"CBA_40mm_3GL", "CBA_40mm_M203", "CBA_40mm_EGLM"};
         };
     };
@@ -34,11 +34,11 @@ class CfgWeapons {
         magazineWell[] = {"CBA_65x39_MX", "CBA_65x39_MX_XL"};
     };
 
-    class arifle_Katiba_Base_F : Rifle_Base_F {
+    class arifle_Katiba_Base_F: Rifle_Base_F {
         magazineWell[] = {"CBA_65x39_Katiba"};
     };
 
-    class arifle_ARX_base_F : Rifle_Base_F {
+    class arifle_ARX_base_F: Rifle_Base_F {
         magazineWell[] = {"CBA_65x39_Katiba"};
     };
 
@@ -51,53 +51,53 @@ class CfgWeapons {
     class DMR_06_base_F: Rifle_Long_Base_F {
         magazineWell[] = {"CBA_762x51_M14"};
     };
-    class arifle_SPAR_03_base_F : Rifle_Base_F {
+    class arifle_SPAR_03_base_F: Rifle_Base_F {
         magazineWell[] = {"CBA_762x51_HK417", "CBA_762x51_HK417_L", "CBA_762x51_HK417_XL"};
     };
 
-    class DMR_01_base_F : Rifle_Long_Base_F {
+    class DMR_01_base_F: Rifle_Long_Base_F {
         magazineWell[] = {"CBA_762x54R_SVD"};
     };
 
-    class arifle_CTAR_base_F : Rifle_Base_F {
+    class arifle_CTAR_base_F: Rifle_Base_F {
         magazineWell[] = {"CBA_580x42_TYPE95", "CBA_580x42_TYPE95_XL"};
     };
-    class arifle_CTARS_base_F : Rifle_Base_F {
+    class arifle_CTARS_base_F: Rifle_Base_F {
         magazineWell[] = {"CBA_580x42_TYPE95", "CBA_580x42_TYPE95_XL"};
     };
 
-    class arifle_AK12_base_F : Rifle_Base_F {
+    class arifle_AK12_base_F: Rifle_Base_F {
         magazineWell[] = {"CBA_762x39_AK", "CBA_762x39_RPK"};
     };
-    class arifle_AKM_base_F : Rifle_Base_F {
+    class arifle_AKM_base_F: Rifle_Base_F {
         magazineWell[] = {"CBA_762x39_AK", "CBA_762x39_RPK"};
     };
 
-    class arifle_AKS_base_F : Rifle_Base_F {
+    class arifle_AKS_base_F: Rifle_Base_F {
         magazineWell[] = {"CBA_545x39_AK", "CBA_545x39_RPK"};
     };
 
-    class LMG_03_base_F : Rifle_Long_Base_F {
+    class LMG_03_base_F: Rifle_Long_Base_F {
         magazineWell[] = {"CBA_556x45_MINIMI"};
     };
 
-    class LMG_Mk200_F : Rifle_Long_Base_F {
+    class LMG_Mk200_F: Rifle_Long_Base_F {
         magazineWell[] = {"CBA_65x39_Mk200"};
     };
 
-    class LMG_Zafir_F : Rifle_Long_Base_F {
+    class LMG_Zafir_F: Rifle_Long_Base_F {
         magazineWell[] = {"CBA_762x54R_LINKS"};
     };
 
-    class launch_RPG7_F : Launcher_Base_F {
+    class launch_RPG7_F: Launcher_Base_F {
         magazineWell[] = {"CBA_RPG7"};
     };
 
-    class MMG_01_base_F : Rifle_Long_Base_F {
+    class MMG_01_base_F: Rifle_Long_Base_F {
         magazineWell[] = {"CBA_93x64_LINKS"};
     };
 
-    class MMG_02_base_F : Rifle_Long_Base_F {
+    class MMG_02_base_F: Rifle_Long_Base_F {
         magazineWell[] = {"CBA_338NM_LINKS"};
     };
 };

--- a/addons/jam/CfgWeapons.hpp
+++ b/addons/jam/CfgWeapons.hpp
@@ -25,10 +25,13 @@ class CfgWeapons {
     };
 
     class arifle_MX_Base_F : Rifle_Base_F {
-        magazineWell[] = {"CBA_65x39_MX", "CBA_65x39_MX_XL"};
+        magazineWell[] = {"CBA_65x39_MX"};
         class GL_3GL_F : UGL_F {
             magazineWell[] = {"CBA_40mm_3GL", "CBA_40mm_M203", "CBA_40mm_EGLM"};
         };
+    };
+    class arifle_MX_SW_F: arifle_MX_Base_F {
+        magazineWell[] = {"CBA_65x39_MX", "CBA_65x39_MX_XL"};
     };
 
     class arifle_Katiba_Base_F : Rifle_Base_F {


### PR DESCRIPTION
**When merged this pull request will:**
- remove the 100Rnd 6.5mm MX magwell from all MX variants, except from the MX SW
- this makes it so that the MX SW variant is the only variant to support 100Rnd mags when using CBA - the same behavior as in the base game
- close #1050

Reasons can be found here: https://github.com/CBATeam/CBA_A3/issues/1050
Don't fret, below is linked a PR for ACE that re-introduces the big magazines for all other MX variants.


