### PR TITLE
Add macros to skip adding headers to cfgFunctions

### DIFF
--- a/addons/common/script_component.hpp
+++ b/addons/common/script_component.hpp
@@ -1,9 +1,6 @@
 #define COMPONENT common
 #include "\x\cba\addons\main\script_mod.hpp"
 
-#define SKIP_FUNCTION_HEADER
-#define SKIP_SCRIPT_NAME
-
 #ifdef DEBUG_ENABLED_COMMON
     #define DEBUG_MODE_FULL
 #endif

--- a/addons/common/script_component.hpp
+++ b/addons/common/script_component.hpp
@@ -1,6 +1,8 @@
 #define COMPONENT common
 #include "\x\cba\addons\main\script_mod.hpp"
 
+#define SKIP_FUNCTION_HEADER
+#define SKIP_SCRIPT_NAME
 
 #ifdef DEBUG_ENABLED_COMMON
     #define DEBUG_MODE_FULL

--- a/addons/common/script_component.hpp
+++ b/addons/common/script_component.hpp
@@ -1,6 +1,7 @@
 #define COMPONENT common
 #include "\x\cba\addons\main\script_mod.hpp"
 
+
 #ifdef DEBUG_ENABLED_COMMON
     #define DEBUG_MODE_FULL
 #endif

--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -942,6 +942,7 @@ Description:
     Full file path in addons:
         '\MAINPREFIX\PREFIX\SUBPREFIX\COMPONENT\fnc_<FNC>.sqf'
     Define 'RECOMPILE' to enable recompiling.
+    Define 'SKIP_FUNCTION_HEADER' to skip adding function header.
 
 Parameters:
     FUNCTION NAME - Name of the function, unquoted <STRING>
@@ -968,9 +969,16 @@ Author:
 #else
     #define RECOMPILE recompile = 0
 #endif
+// Set function header type: -1 - no header; 0 - default header; 1 - system header.
+#ifdef SKIP_FUNCTION_HEADER
+    #define CFGFUNCTION_HEADER headerType = -1
+#else
+    #define CFGFUNCTION_HEADER headerType = 0
+#endif
 
 #define PATHTO_FNC(func) class func {\
     file = QPATHTOF(DOUBLES(fnc,func).sqf);\
+    CFGFUNCTION_HEADER;\
     RECOMPILE;\
 }
 
@@ -1119,6 +1127,7 @@ Author:
 /* -------------------------------------------
 Macro: SCRIPT()
     Sets name of script (relies on PREFIX and COMPONENT values being #defined).
+    Define 'SKIP_SCRIPT_NAME' to skip adding scriptName.
 
 Parameters:
     NAME - Name of script [Indentifier]
@@ -1131,8 +1140,11 @@ Example:
 Author:
     Spooner
 ------------------------------------------- */
-#define SCRIPT(NAME) \
-    scriptName 'PREFIX\COMPONENT\NAME'
+#ifndef SKIP_SCRIPT_NAME
+    #define SCRIPT(NAME) scriptName 'PREFIX\COMPONENT\NAME'
+#else
+    #define SCRIPT(NAME) /* nope */
+#endif
 
 /* -------------------------------------------
 Macros: EXPLODE_n()

--- a/addons/main/script_mod.hpp
+++ b/addons/main/script_mod.hpp
@@ -29,3 +29,7 @@
     #define DEBUG_ENABLED_STRINGS
     #define DEBUG_ENABLED_VERSIONING
 */
+
+// Remove CfgFunction adding headers and disable SCRIPT macro (comment out to enable for debugging)
+#define SKIP_FUNCTION_HEADER
+#define SKIP_SCRIPT_NAME

--- a/addons/vectors/fnc_polar2vect.sqf
+++ b/addons/vectors/fnc_polar2vect.sqf
@@ -21,7 +21,6 @@ Examples:
 Author:
     Vigilante, courtesy by -=ACE=- of Simcentric
 ---------------------------------------------------------------------------- */
-scriptName "fnc_polar2vect.sqf";
 
 SCRIPT(polar2vect);
 

--- a/addons/vectors/fnc_scaleVect.sqf
+++ b/addons/vectors/fnc_scaleVect.sqf
@@ -20,7 +20,6 @@ Examples:
 Author:
     Vigilante, courtesy by -=ACE=- of Simcentric
 ---------------------------------------------------------------------------- */
-scriptName "fnc_scaleVect.sqf";
 
 SCRIPT(scaleVect);
 

--- a/addons/vectors/fnc_scaleVectTo.sqf
+++ b/addons/vectors/fnc_scaleVectTo.sqf
@@ -22,7 +22,6 @@ Examples:
 Author:
     Vigilante, courtesy by -=ACE=- of Simcentric
 ---------------------------------------------------------------------------- */
-scriptName "fnc_scaleVectTo.sqf";
 
 SCRIPT(scaleVectTo);
 

--- a/addons/vectors/fnc_vect2polar.sqf
+++ b/addons/vectors/fnc_vect2polar.sqf
@@ -20,7 +20,6 @@ Examples:
 Author:
     Vigilante, courtesy by -=ACE=- of Simcentric
 ---------------------------------------------------------------------------- */
-scriptName "fnc_vect2Polar.sqf";
 
 SCRIPT(vect2Polar);
 

--- a/addons/vectors/fnc_vectCross2D.sqf
+++ b/addons/vectors/fnc_vectCross2D.sqf
@@ -23,7 +23,6 @@ Examples:
 Author:
     Vigilante, courtesy by -=ACE=- of Simcentric
 ---------------------------------------------------------------------------- */
-scriptName "fnc_vectCross2D.sqf";
 
 SCRIPT(vectCross2D);
 

--- a/addons/vectors/fnc_vectDir.sqf
+++ b/addons/vectors/fnc_vectDir.sqf
@@ -19,7 +19,6 @@ Examples:
 Author:
     Vigilante, courtesy by -=ACE=- of Simcentric
 ---------------------------------------------------------------------------- */
-scriptName "fnc_vectDir.sqf";
 
 SCRIPT(vectDir);
 

--- a/addons/vectors/fnc_vectElev.sqf
+++ b/addons/vectors/fnc_vectElev.sqf
@@ -19,7 +19,6 @@ Examples:
 Author:
     Vigilante, courtesy by -=ACE=- of Simcentric
 ---------------------------------------------------------------------------- */
-scriptName "fnc_vectElev.sqf";
 
 SCRIPT(vectElev);
 

--- a/addons/vectors/fnc_vectMagn.sqf
+++ b/addons/vectors/fnc_vectMagn.sqf
@@ -19,7 +19,6 @@ Examples:
 Author:
     Vigilante, courtesy by -=ACE=- of Simcentric
 ---------------------------------------------------------------------------- */
-scriptName "fnc_vectMagn.sqf";
 
 SCRIPT(vectMagn);
 

--- a/addons/vectors/fnc_vectMagn2D.sqf
+++ b/addons/vectors/fnc_vectMagn2D.sqf
@@ -19,7 +19,6 @@ Examples:
 Author:
     Vigilante, courtesy by -=ACE=- of Simcentric
 ---------------------------------------------------------------------------- */
-scriptName "fnc_vectMagn2D.sqf";
 
 SCRIPT(vectMagn2D);
 

--- a/addons/vectors/fnc_vectSubtract.sqf
+++ b/addons/vectors/fnc_vectSubtract.sqf
@@ -20,7 +20,6 @@ Examples:
 Author:
     Vigilante, courtesy by -=ACE=- of Simcentric
 ---------------------------------------------------------------------------- */
-scriptName "fnc_vectSubtract.sqf";
 
 SCRIPT(vectSubtract);
 


### PR DESCRIPTION
Adds optional macros to remove both
- CfgFunction headers (which add code for `_fnc_scriptNameParent / _fnc_scriptName`)
- CBA Macro SCRIPT (which adds `scriptName 'PREFIX\COMPONENT\NAME'`)

e.g. `CBA_fnc_currentUnit` is a single line of code, but becomes
```
CBA_fnc_currentUnit = {
    private _fnc_scriptNameParent = if (isNil '_fnc_scriptName') then {'CBA_fnc_currentUnit'} else {_fnc_scriptName};
    private _fnc_scriptName = 'CBA_fnc_currentUnit';
    scriptName _fnc_scriptName;
    scriptName 'cba\common\currentUnit';
    missionNamespace getVariable ["bis_fnc_moduleRemoteControl_unit", player]
```
Changing execution time from 0.0022 ms to 0.0045 ms.

There should be no change to anyone else using CBA macros unless they add these defines.
For CBA both are set in main/script_mod.hpp