### PR TITLE
fix admin macros

### DIFF
--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -1752,7 +1752,8 @@ Example:
 Author:
     commy2
 ------------------------------------------- */
-#define IS_ADMIN serverCommandAvailable '#kick'
+#define IS_ADMIN_SYS(x) x##kick
+#define IS_ADMIN serverCommandAvailable 'IS_ADMIN_SYS(#)'
 
 /* -------------------------------------------
 Macro: IS_ADMIN_LOGGED
@@ -1772,7 +1773,8 @@ Example:
 Author:
     commy2
 ------------------------------------------- */
-#define IS_ADMIN_LOGGED serverCommandAvailable '#shutdown'
+#define IS_ADMIN_LOGGED_SYS(x) x##shutdown
+#define IS_ADMIN_LOGGED serverCommandAvailable 'IS_ADMIN_LOGGED_SYS(#)'
 
 /* -------------------------------------------
 Macro: FILE_EXISTS


### PR DESCRIPTION
**When merged this pull request will:**
- currently (3.10 RC 1), the IS_ADMIN(_LOGGED) macros are broken
- bug introduced in https://github.com/CBATeam/CBA_A3/pull/1048/files
- features a crafty way to use # in single quote strings
