### PR TITLE
add event for confirming changes in Layout Editor

### DIFF
--- a/addons/ui/fnc_initDisplayOptionsLayout.sqf
+++ b/addons/ui/fnc_initDisplayOptionsLayout.sqf
@@ -4,6 +4,12 @@
 
 params ["_display"];
 
+private _ok = _display displayCtrl IDC_OK;
+
+_ok ctrlAddEventHandler ["ButtonClick", {
+    ["CBA_layoutEditorSaved", []] call CBA_fnc_localEvent;
+}];
+
 for "_idc" from IDCBASE to (IDCBASE + 99) do {
     private _control = _display displayCtrl _idc;
 


### PR DESCRIPTION
**When merged this pull request will:**
- title
- close #1070

Example:
```sqf
["CBA_layoutEditorSaved", {
    systemChat str [diag_tickTime, _this];
}] call CBA_fnc_addEventHandler;
```

Note: Add in XEH_preInit to ensure this working in the main menu and 3den. Adding the event in preInit might or might not require to put cba_events in requiredAddons of the component of the XEH preInit event.