### PR TITLE
More magwells

### DIFF
--- a/addons/jam/CfgMagazineWells.hpp
+++ b/addons/jam/CfgMagazineWells.hpp
@@ -32,7 +32,7 @@ class CfgMagazineWells {
 
     // Pistol calibre magwells, ordered lexicographically in metric and imperial groups
     #include "magwells_10mmAuto.hpp"    // 10mm Auto | 10mm Automatic | 10x25mm
-    #include "magwells_570x28.hpp"      // 5.70x28mm
+    #include "magwells_57x28.hpp"       // 5.7x28mm
     #include "magwells_762x25.hpp"      // 7.62x25mm Tokarev
     #include "magwells_762x38R.hpp"     // 7.62x38mmR | 7.62 mm Nagant
     #include "magwells_763x25.hpp"      // 7.63x25mm Mauser | .30 Mauser Automatic

--- a/addons/jam/CfgWeapons.hpp
+++ b/addons/jam/CfgWeapons.hpp
@@ -76,7 +76,6 @@ class CfgWeapons {
     class arifle_AKS_base_F: Rifle_Base_F {
         magazineWell[] = {"CBA_545x39_AK", "CBA_545x39_RPK"};
     };
-
     class LMG_03_base_F: Rifle_Long_Base_F {
         magazineWell[] = {"CBA_556x45_MINIMI"};
     };
@@ -101,7 +100,20 @@ class CfgWeapons {
         magazineWell[] = {"CBA_338NM_LINKS"};
     };
 
-    class SMG_03_TR_BASE: Rifle_Base_F {
-        magazineWell[] = {"CBA_570x28_P90"};
+    class SMG_01_Base : Rifle_Short_Base_F {
+        magazineWell[] = {"CBA_45ACP_Glock_Full"};
     };
+
+    class SMG_02_base_F : Rifle_Short_Base_F {
+        magazineWell[] = {"CBA_9x19_ScorpionEvo3"};
+    };
+
+    class SMG_03_TR_BASE : Rifle_Base_F {
+        magazineWell[] = {"CBA_57x28_FNP90"};
+    };
+
+    class SMG_05_base_F : Rifle_Short_Base_F {
+        magazineWell[] = {"CBA_9x19_MP5"};
+    };
+
 };

--- a/addons/jam/CfgWeapons.hpp
+++ b/addons/jam/CfgWeapons.hpp
@@ -101,19 +101,19 @@ class CfgWeapons {
         magazineWell[] = {"CBA_338NM_LINKS"};
     };
 
-    class SMG_01_Base : Rifle_Short_Base_F {
+    class SMG_01_Base: Rifle_Short_Base_F {
         magazineWell[] = {"CBA_45ACP_Glock_Full"};
     };
 
-    class SMG_02_base_F : Rifle_Short_Base_F {
+    class SMG_02_base_F: Rifle_Short_Base_F {
         magazineWell[] = {"CBA_9x19_ScorpionEvo3"};
     };
 
-    class SMG_03_TR_BASE : Rifle_Base_F {
+    class SMG_03_TR_BASE: Rifle_Base_F {
         magazineWell[] = {"CBA_57x28_FNP90"};
     };
 
-    class SMG_05_base_F : Rifle_Short_Base_F {
+    class SMG_05_base_F: Rifle_Short_Base_F {
         magazineWell[] = {"CBA_9x19_MP5"};
     };
 

--- a/addons/jam/CfgWeapons.hpp
+++ b/addons/jam/CfgWeapons.hpp
@@ -76,6 +76,7 @@ class CfgWeapons {
     class arifle_AKS_base_F: Rifle_Base_F {
         magazineWell[] = {"CBA_545x39_AK", "CBA_545x39_RPK"};
     };
+
     class LMG_03_base_F: Rifle_Long_Base_F {
         magazineWell[] = {"CBA_556x45_MINIMI"};
     };

--- a/addons/jam/magwells_22LR.hpp
+++ b/addons/jam/magwells_22LR.hpp
@@ -1,2 +1,3 @@
+    class CBA_9x19_CZP09Kadet {};   // CZ P-09 Kadet in .22LR
     class CBA_22LR_PP {};           // Walther PP in .22LR
     class CBA_22LR_PPK {};          // Walther PPK in .22LR

--- a/addons/jam/magwells_40SW.hpp
+++ b/addons/jam/magwells_40SW.hpp
@@ -1,3 +1,10 @@
+
+    class CBA_40SW_CZ2075 {};       // Subcompact CZ 2075 in .40 S&W
+    class CBA_40SW_CZ75_Cpct {};    // Compact CZ 75, CZ 85 in .40 S&W
+    class CBA_40SW_CZ75_Full {};    // Fullsize CZ 75, CZ 85 in .40 S&W
+    class CBA_40SW_CZP06 {};        // CZ P-06 in .40 S&W
+    class CBA_40SW_CZP07 {};        // CZ P-07 in .40 S&W
+    class CBA_40SW_CZP09 {};        // CZ P-09 in .40 S&W (also should fit in .40 S&W CZ P-07)
     class CBA_40SW_Glock_SubC {};   // Subcompact Glock in .40 S&W (Glock 27)
     class CBA_40SW_Glock_Cpct {};   // Compact Glock in .40 S&W (Glock 23)
     class CBA_40SW_Glock_Full {};   // Fullsize Glock in .40 S&W (Glock 22, 24, 35)

--- a/addons/jam/magwells_45ACP.hpp
+++ b/addons/jam/magwells_45ACP.hpp
@@ -1,9 +1,17 @@
     class CBA_45ACP_1911 {};            // Colt M1911
     class CBA_45ACP_C96 {};             // Mauser C-96 in .45 ACP
+    class CBA_9x19_CZ97 {};             // CZ 97 in .45 ACP
     class CBA_45ACP_Delisle {};         // De Lisle Carbine
     class CBA_45ACP_Glock_Slim {};      // Slimline Glock in .45 ACP (Glock 36)
     class CBA_45ACP_Glock_Cpct {};      // Compact Glock in .45 ACP (Glock 29)
-    class CBA_45ACP_Glock_Full {};      // Fullsize Glock in .45 ACP (Glock 21, 41)
+    class CBA_45ACP_Glock_Full {        // Fullsize Glock in .45 ACP (Glock 21, 41)
+        BI_mags[] = {
+            "30Rnd_45ACP_Mag_SMG_01",
+            "30Rnd_45ACP_Mag_SMG_01_tracer_green",
+            "30Rnd_45ACP_Mag_SMG_01_Tracer_Red",
+            "30Rnd_45ACP_Mag_SMG_01_Tracer_Yellow"
+        };
+    };
     class CBA_45ACP_Grease {};          // Grease Gun
     class CBA_45ACP_Reising {};         // M50/M55 Reising
     class CBA_45ACP_Thompson_Stick {};  // Thompson stick magazines

--- a/addons/jam/magwells_570x28.hpp
+++ b/addons/jam/magwells_570x28.hpp
@@ -1,6 +1,0 @@
-    class CBA_570x28_FN57 {};        // FN Five-Seven  
-    class CBA_570x28_P90 {           // FN P90
-        BI_mags[] = {
-            "50Rnd_570x28_SMG_03"
-        };
-    };

--- a/addons/jam/magwells_57x28.hpp
+++ b/addons/jam/magwells_57x28.hpp
@@ -1,0 +1,6 @@
+    class CBA_57x28_FN57 {};        // FN Five-Seven  
+    class CBA_57x28_P90 {           // FN P90, also 5.7x28 AR-57
+        BI_mags[] = {
+            "50Rnd_570x28_SMG_03"
+        };
+    };

--- a/addons/jam/magwells_9x19.hpp
+++ b/addons/jam/magwells_9x19.hpp
@@ -1,4 +1,10 @@
     class CBA_9x19_C96 {};          // Mauser C-96 in 9x19mm
+    class CBA_9x19_CZ2075 {};       // Subcompact CZ 2075 in 9x19mm
+    class CBA_9x19_CZ75_Cpct {};    // Compact CZ 75, CZ 85 in 9x19mm
+    class CBA_9x19_CZ75_Full {};    // Fullsize CZ 75, CZ 85 in 9x19mm
+    class CBA_9x19_CZP01 {};        // CZ P-01 in 9x19mm
+    class CBA_9x19_CZP07 {};        // CZ P-07 in 9x19mm
+    class CBA_9x19_CZP09 {};        // CZ P-09 in 9x19mm (also should fit in  9x19mm CZ P-07)
     class CBA_9x19_CZ82 {};         // CZ 82, Vz. 82, CZ 83
     class CBA_9x19_GPK199 {};       // Grand Power K100
     class CBA_9x19_GSh18 {};        // GSh-18
@@ -10,7 +16,14 @@
     class CBA_9x19_M9 {};           // Beretta M9
     class CBA_9x19_MP40 {};         // MP40, MP38
     class CBA_9x19_MP443 {};        // MP-443 Grach
-    class CBA_9x19_MP5 {};          // H&K MP5
+    class CBA_9x19_MP5 {            // H&K MP5
+        BI_mags[] = {
+            "30Rnd_9x21_Mag_SMG_02",
+            "30Rnd_9x21_Mag_SMG_02_Tracer_Red",
+            "30Rnd_9x21_Mag_SMG_02_Tracer_Yellow",
+            "30Rnd_9x21_Mag_SMG_02_Tracer_Green"
+        };
+    };
     class CBA_9x19_Ots27 {};        // OTs-27 Berdysh
     class CBA_9x19_P08 {};          // Luger P08
     class CBA_9x19_P226 {};         // SIG P226
@@ -21,6 +34,18 @@
     class CBA_9x19_PM84 {};         // FB PM-84 Glauberyt
     class CBA_9x19_PP19 {};         // PP-19 Bizon-2-01
     class CBA_9x19_PP2000 {};       // PP-2000 SMG
+    class CBA_9x19_ScorpionEvo3 {   // CZ Scorpion Evo 3
+        BI_mags[] = {
+            "30Rnd_9x21_Mag_SMG_02",
+            "30Rnd_9x21_Mag_SMG_02_Tracer_Red",
+            "30Rnd_9x21_Mag_SMG_02_Tracer_Yellow",
+            "30Rnd_9x21_Mag_SMG_02_Tracer_Green",
+            "30Rnd_9x21_Mag",
+            "30Rnd_9x21_Red_Mag",
+            "30Rnd_9x21_Yellow_Mag",
+            "30Rnd_9x21_Green_Mag"
+        };
+    };
     class CBA_9x19_STEN {};         // STEN
     class CBA_9x19_STEYR {};        // AUG SMG, MPi, TMP
     class CBA_9x19_TT {};           // TT-33 Tokarev in 9x19mm (M48, Tokagypt 58, Type 54)


### PR DESCRIPTION
**When merged this pull request will:**
- Change 570x28 to 57x28, since the cartridge is always called the 5.7x28mm
This is more correct and keeps the naming convention of other magwells that do not add trailing zeros.
- Add magwels for the CZ 75, 85, 97, 2075, P-01, P-06, P-07, P-09 for Urban.
- Add .45 ACP fullsize Glock magwell to SMG_01 (Vermin SMG/KRISS Vector)
- Add 9x19mm Scorpion Evo 3 magwell for SMG_02 (Sting 9mm/CZ Skorpion Evo)
- Add 9x19mm MP5 magwell to SMG_05 (Protector 9 mm/MP5K)
* I'm not 100% happy with having these vanilla two vanilla SMGs as 9x19mm since in vanilla they use 9x21mm and because they should not be able to interchange magazines with each other IRL.
However I think it would be confusing for players if weapons that appear to be able to interchange magazines with mod weapons aren't able to (for example the vanilla MP5K and the NIA or CUP MP5's).
