### PR TITLE
addPlayerEh - Skip checking turretPath in not in vehicle

### DIFF
--- a/addons/events/fnc_addPlayerEventHandler.sqf
+++ b/addons/events/fnc_addPlayerEventHandler.sqf
@@ -124,6 +124,7 @@ if (_id != -1) then {
         GVAR(oldLoadout) = [];
         GVAR(oldLoadoutNoAmmo) = [];
         GVAR(oldVehicle) = objNull;
+        GVAR(inVehicle) = false;
         GVAR(oldTurret) = [];
         GVAR(oldVisionMode) = -1;
         GVAR(oldCameraView) = "";
@@ -184,12 +185,21 @@ if (_id != -1) then {
             if !(_data isEqualTo GVAR(oldVehicle)) then {
                 GVAR(oldVehicle) = _data;
                 [QGVAR(vehicleEvent), [_player, _data]] call CBA_fnc_localEvent;
+                GVAR(inVehicle) = _data != _player;
+                if (!GVAR(inVehicle)) then {
+                    _data = _player call CBA_fnc_turretPath;
+                    if !(_data isEqualTo GVAR(oldTurret)) then {
+                        GVAR(oldTurret) = _data;
+                        [QGVAR(turretEvent), [_player, _data]] call CBA_fnc_localEvent;
+                    };
+                };
             };
-
-            _data = _player call CBA_fnc_turretPath;
-            if !(_data isEqualTo GVAR(oldTurret)) then {
-                GVAR(oldTurret) = _data;
-                [QGVAR(turretEvent), [_player, _data]] call CBA_fnc_localEvent;
+            if (GVAR(inVehicle)) then {
+                _data = _player call CBA_fnc_turretPath;
+                if !(_data isEqualTo GVAR(oldTurret)) then {
+                    GVAR(oldTurret) = _data;
+                    [QGVAR(turretEvent), [_player, _data]] call CBA_fnc_localEvent;
+                };
             };
 
             // handle controlling UAV, UAV entity needed for visionMode


### PR DESCRIPTION
Skips call to `CBA_fnc_turretPath` when not in vehicle
There is an extra `if` check when in a vehicle, 
but it's very small compared to the performance gains when unmounted.