### PR TITLE
Activate all addons

### DIFF
--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -47,8 +47,8 @@ call COMPILE_FILE(init_perFrameHandler);
 call COMPILE_FILE(init_delayLess);
 
 // Due to activateAddons being overwritten by eachother (only the last executed command will be active), we apply this bandaid
-activateAddons call (uiNamespace getVariable [QGVAR(unitAddons), {[]}]);
 GVAR(addons) = call (uiNamespace getVariable [QGVAR(addons), {[]}]);
+activateAddons GVAR(addons);
 
 // BWC
 #include "backwards_comp.sqf"

--- a/addons/common/XEH_preStart.sqf
+++ b/addons/common/XEH_preStart.sqf
@@ -3,21 +3,4 @@
 //See usage in XEH_preInit
 private _cfgPatches = configFile >> "CfgPatches";
 private _allComponents = "true" configClasses _cfgPatches apply {configName _x};
-
-//Filter out addons that don't have any units defined as we don't need to activate these
-private _unitAddons = _allComponents select {
-    !(getArray (_cfgPatches >> _x >> "units") isEqualTo [])
-};
-
-//Filter out addons defined in CfgAddons as they are always activated
-private _allAddons = "true" configClasses (configFile >> "CfgAddons");
-private _preloadedAddons = [];
-
-{
-    _preloadedAddons append (getArray (_x >> "list") apply {configName (_cfgPatches >> _x)});
-} forEach _allAddons;
-
-_unitAddons = _unitAddons - _preloadedAddons;
-
 uiNamespace setVariable [QGVAR(addons), compileFinal str _allComponents];
-uiNamespace setVariable [QGVAR(unitAddons), compileFinal str _unitAddons];


### PR DESCRIPTION
On current master an old mission fails to load on a dedicated server with error:
```
 Warning Message: You cannot play/edit this mission; it is dependent on downloadable content that has been deleted.
ace_javelin
```
On a different mission, it seems like ace_javelin is not in activated addons
![image](https://user-images.githubusercontent.com/9376747/53396200-8196be00-3969-11e9-8535-7e0574d8af07.png)

This partially reverts changes in #1051