### PR TITLE
Preload 3DEN and Zeus item lists

### DIFF
--- a/addons/ui/CfgEventHandlers.hpp
+++ b/addons/ui/CfgEventHandlers.hpp
@@ -29,4 +29,10 @@ class Extended_DisplayLoad_EventHandlers {
     class RscDisplayRemoteMissions {
         ADDON = QUOTE(_this call (uiNamespace getVariable 'FUNC(initDisplayRemoteMissions)'));
     };
+    class Display3DEN {
+        ADDON = QUOTE(_this call (uiNamespace getVariable 'FUNC(initDisplay3DEN)'));
+    };
+    class RscDisplayCurator {
+        ADDON = QUOTE(_this call (uiNamespace getVariable 'FUNC(initDisplayCurator)'));
+    };
 };

--- a/addons/ui/XEH_preInit.sqf
+++ b/addons/ui/XEH_preInit.sqf
@@ -29,4 +29,6 @@ if (hasInterface) then {
             QGVAR(ProgressBar) cutRsc [QGVAR(ProgressBar), "PLAIN"];
         };
     }];
+
+    RscAttrbuteInventory_weaponAddons = uiNamespace getVariable QGVAR(curatorItemCache); // spelling is "Attrbute"
 };

--- a/addons/ui/XEH_preInit.sqf
+++ b/addons/ui/XEH_preInit.sqf
@@ -29,6 +29,4 @@ if (hasInterface) then {
             QGVAR(ProgressBar) cutRsc [QGVAR(ProgressBar), "PLAIN"];
         };
     }];
-
-    RscAttrbuteInventory_weaponAddons = uiNamespace getVariable QGVAR(curatorItemCache); // spelling is "Attrbute"
 };

--- a/addons/ui/XEH_preStart.sqf
+++ b/addons/ui/XEH_preStart.sqf
@@ -1,21 +1,21 @@
 #include "script_component.hpp"
 
-if (hasInterface) then {
-    PREP(initDisplayInterrupt);
-    PREP(initDisplayMultiplayerSetup);
-    PREP(initDisplayOptionsLayout);
-    PREP(initDisplayPassword);
-    PREP(initDisplayRemoteMissions);
+if (!hasInterface) exitWith {};
 
-    // preload 3den and curator item lists
-    PREP(preload3DEN);
-    PREP(preloadCurator);
+PREP(initDisplayInterrupt);
+PREP(initDisplayMultiplayerSetup);
+PREP(initDisplayOptionsLayout);
+PREP(initDisplayPassword);
+PREP(initDisplayRemoteMissions);
 
-    private _timeStart = diag_tickTime;
-    call FUNC(preload3DEN);
-    INFO_1("3DEN item list preloaded. Time: %1 ms",round ((diag_tickTime - _timeStart) * 1000));
+// preload 3den and curator item lists
+PREP(preload3DEN);
+PREP(preloadCurator);
 
-    _timeStart = diag_tickTime;
-    call FUNC(preloadCurator);
-    INFO_1("Curator item list preloaded. Time: %1 ms",round ((diag_tickTime - _timeStart) * 1000));
-};
+private _timeStart = diag_tickTime;
+call FUNC(preload3DEN);
+INFO_1("3DEN item list preloaded. Time: %1 ms",round ((diag_tickTime - _timeStart) * 1000));
+
+_timeStart = diag_tickTime;
+call FUNC(preloadCurator);
+INFO_1("Curator item list preloaded. Time: %1 ms",round ((diag_tickTime - _timeStart) * 1000));

--- a/addons/ui/XEH_preStart.sqf
+++ b/addons/ui/XEH_preStart.sqf
@@ -1,12 +1,12 @@
 #include "script_component.hpp"
 
-PREP(initDisplayInterrupt);
-PREP(initDisplayMultiplayerSetup);
-PREP(initDisplayOptionsLayout);
-PREP(initDisplayPassword);
-PREP(initDisplayRemoteMissions);
-
 if (hasInterface) then {
+    PREP(initDisplayInterrupt);
+    PREP(initDisplayMultiplayerSetup);
+    PREP(initDisplayOptionsLayout);
+    PREP(initDisplayPassword);
+    PREP(initDisplayRemoteMissions);
+
     // preload 3den and curator item lists
     PREP(preload3DEN);
     PREP(preloadCurator);

--- a/addons/ui/XEH_preStart.sqf
+++ b/addons/ui/XEH_preStart.sqf
@@ -6,14 +6,16 @@ PREP(initDisplayOptionsLayout);
 PREP(initDisplayPassword);
 PREP(initDisplayRemoteMissions);
 
-// preload 3den and curator item lists
-PREP(preload3DEN);
-PREP(preloadCurator);
+if (hasInterface) then {
+    // preload 3den and curator item lists
+    PREP(preload3DEN);
+    PREP(preloadCurator);
 
-private _timeStart = diag_tickTime;
-call FUNC(preload3DEN);
-INFO_1("3DEN item list preloaded. Time: %1 ms",(diag_tickTime - _timeStart) * 1000);
+    _timeStart = diag_tickTime;
+    call FUNC(preload3DEN);
+    INFO_1("3DEN item list preloaded. Time: %1 ms",(diag_tickTime - _timeStart) * 1000);
 
-_timeStart = diag_tickTime;
-call FUNC(preloadCurator);
-INFO_1("Curator item list preloaded. Time: %1 ms",(diag_tickTime - _timeStart) * 1000);
+    private _timeStart = diag_tickTime;
+    call FUNC(preloadCurator);
+    INFO_1("Curator item list preloaded. Time: %1 ms",(diag_tickTime - _timeStart) * 1000);
+};

--- a/addons/ui/XEH_preStart.sqf
+++ b/addons/ui/XEH_preStart.sqf
@@ -11,11 +11,11 @@ if (hasInterface) then {
     PREP(preload3DEN);
     PREP(preloadCurator);
 
-    _timeStart = diag_tickTime;
+    private _timeStart = diag_tickTime;
     call FUNC(preload3DEN);
     INFO_1("3DEN item list preloaded. Time: %1 ms",round ((diag_tickTime - _timeStart) * 1000));
 
-    private _timeStart = diag_tickTime;
+    _timeStart = diag_tickTime;
     call FUNC(preloadCurator);
     INFO_1("Curator item list preloaded. Time: %1 ms",round ((diag_tickTime - _timeStart) * 1000));
 };

--- a/addons/ui/XEH_preStart.sqf
+++ b/addons/ui/XEH_preStart.sqf
@@ -13,9 +13,9 @@ if (hasInterface) then {
 
     _timeStart = diag_tickTime;
     call FUNC(preload3DEN);
-    INFO_1("3DEN item list preloaded. Time: %1 ms",(diag_tickTime - _timeStart) * 1000);
+    INFO_1("3DEN item list preloaded. Time: %1 ms",round ((diag_tickTime - _timeStart) * 1000));
 
     private _timeStart = diag_tickTime;
     call FUNC(preloadCurator);
-    INFO_1("Curator item list preloaded. Time: %1 ms",(diag_tickTime - _timeStart) * 1000);
+    INFO_1("Curator item list preloaded. Time: %1 ms",round ((diag_tickTime - _timeStart) * 1000));
 };

--- a/addons/ui/XEH_preStart.sqf
+++ b/addons/ui/XEH_preStart.sqf
@@ -7,15 +7,8 @@ PREP(initDisplayMultiplayerSetup);
 PREP(initDisplayOptionsLayout);
 PREP(initDisplayPassword);
 PREP(initDisplayRemoteMissions);
+PREP(initDisplay3DEN);
+PREP(initDisplayCurator);
 
-// preload 3den and curator item lists
 PREP(preload3DEN);
 PREP(preloadCurator);
-
-private _timeStart = diag_tickTime;
-call FUNC(preload3DEN);
-INFO_1("3DEN item list preloaded. Time: %1 ms",round ((diag_tickTime - _timeStart) * 1000));
-
-_timeStart = diag_tickTime;
-call FUNC(preloadCurator);
-INFO_1("Curator item list preloaded. Time: %1 ms",round ((diag_tickTime - _timeStart) * 1000));

--- a/addons/ui/XEH_preStart.sqf
+++ b/addons/ui/XEH_preStart.sqf
@@ -5,3 +5,10 @@ PREP(initDisplayMultiplayerSetup);
 PREP(initDisplayOptionsLayout);
 PREP(initDisplayPassword);
 PREP(initDisplayRemoteMissions);
+
+// preload 3den item list
+PREP(preload3DEN);
+
+private _timeStart = diag_tickTime;
+call FUNC(preload3DEN);
+INFO_1("3DEN item list preloaded. Time: %1 ms",(diag_tickTime - _timeStart) * 1000);

--- a/addons/ui/XEH_preStart.sqf
+++ b/addons/ui/XEH_preStart.sqf
@@ -6,9 +6,14 @@ PREP(initDisplayOptionsLayout);
 PREP(initDisplayPassword);
 PREP(initDisplayRemoteMissions);
 
-// preload 3den item list
+// preload 3den and curator item lists
 PREP(preload3DEN);
+PREP(preloadCurator);
 
 private _timeStart = diag_tickTime;
 call FUNC(preload3DEN);
 INFO_1("3DEN item list preloaded. Time: %1 ms",(diag_tickTime - _timeStart) * 1000);
+
+_timeStart = diag_tickTime;
+call FUNC(preloadCurator);
+INFO_1("Curator item list preloaded. Time: %1 ms",(diag_tickTime - _timeStart) * 1000);

--- a/addons/ui/fnc_initDisplay3DEN.sqf
+++ b/addons/ui/fnc_initDisplay3DEN.sqf
@@ -1,0 +1,9 @@
+#include "script_component.hpp"
+
+params ["_display"];
+
+with uiNamespace do {
+    private _timeStart = diag_tickTime;
+    call FUNC(preload3DEN);
+    INFO_1("3DEN item list preloaded. Time: %1 ms",round ((diag_tickTime - _timeStart) * 1000));
+};

--- a/addons/ui/fnc_initDisplay3DEN.sqf
+++ b/addons/ui/fnc_initDisplay3DEN.sqf
@@ -4,6 +4,7 @@ params ["_display"];
 
 with uiNamespace do {
     private _timeStart = diag_tickTime;
-    call FUNC(preload3DEN);
-    INFO_1("3DEN item list preloaded. Time: %1 ms",round ((diag_tickTime - _timeStart) * 1000));
+    if (call FUNC(preload3DEN)) then {
+        INFO_1("3DEN item list preloaded. Time: %1 ms",round ((diag_tickTime - _timeStart) * 1000));
+    };
 };

--- a/addons/ui/fnc_initDisplayCurator.sqf
+++ b/addons/ui/fnc_initDisplayCurator.sqf
@@ -1,0 +1,11 @@
+#include "script_component.hpp"
+
+params ["_display"];
+
+with uiNamespace do {
+    private _timeStart = diag_tickTime;
+    call FUNC(preloadCurator);
+    INFO_1("Curator item list preloaded. Time: %1 ms",round ((diag_tickTime - _timeStart) * 1000));
+};
+
+RscAttrbuteInventory_weaponAddons = uiNamespace getVariable QGVAR(curatorItemCache); // spelling is "Attrbute"

--- a/addons/ui/fnc_initDisplayCurator.sqf
+++ b/addons/ui/fnc_initDisplayCurator.sqf
@@ -4,8 +4,9 @@ params ["_display"];
 
 with uiNamespace do {
     private _timeStart = diag_tickTime;
-    call FUNC(preloadCurator);
-    INFO_1("Curator item list preloaded. Time: %1 ms",round ((diag_tickTime - _timeStart) * 1000));
+    if (call FUNC(preloadCurator)) then {
+        INFO_1("Curator item list preloaded. Time: %1 ms",round ((diag_tickTime - _timeStart) * 1000));
+    };
 };
 
 RscAttrbuteInventory_weaponAddons = uiNamespace getVariable QGVAR(curatorItemCache); // spelling is "Attrbute"

--- a/addons/ui/fnc_preload3DEN.sqf
+++ b/addons/ui/fnc_preload3DEN.sqf
@@ -145,7 +145,7 @@ private _magazinesLists = [];
 #ifdef DEBUG_MODE_FULL
     if (getNumber (_x >> "scope") == 2) then {
 #else
-    if (getNumber (_x >> "isBackpack") == 1 && {getNumber (_x >> "scope") == 2}) then {
+    if (getNumber (_x >> "isBackpack") == 1 && {getNumber (_x >> "scope") == 2}) then { //}
 #endif
         private _item = toLower configName _x;
         private _itemType = _item call BIS_fnc_itemType select 1;

--- a/addons/ui/fnc_preload3DEN.sqf
+++ b/addons/ui/fnc_preload3DEN.sqf
@@ -183,4 +183,6 @@ private _listHeadgear = _list select 10;
     _x sort true;
 } forEach _list;
 
+_itemTypes call CBA_fnc_deleteNamespace;
+
 true

--- a/addons/ui/fnc_preload3DEN.sqf
+++ b/addons/ui/fnc_preload3DEN.sqf
@@ -143,10 +143,11 @@ private _magazinesLists = [];
 // use the same classname in CfgVehicles and CfgWeapons this isBackpack
 // optimization prevents the item from added by twice.
 #ifdef DEBUG_MODE_FULL
-    if (getNumber (_x >> "scope") == 2) then {
+    if (getNumber (_x >> "scope") == 2)
 #else
-    if (getNumber (_x >> "isBackpack") == 1 && {getNumber (_x >> "scope") == 2}) then { //}
+    if (getNumber (_x >> "isBackpack") == 1 && {getNumber (_x >> "scope") == 2})
 #endif
+    then {
         private _item = toLower configName _x;
         private _itemType = _item call BIS_fnc_itemType select 1;
 

--- a/addons/ui/fnc_preload3DEN.sqf
+++ b/addons/ui/fnc_preload3DEN.sqf
@@ -1,0 +1,167 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Internal Function: cba_ui_fnc_preload3DEN
+
+Description:
+    Preload 3den editor ammo box item list.
+
+Parameters:
+    None
+
+Returns:
+    true: preloaded successfully, false: already preloaded <BOOL>
+
+Examples:
+    (begin example)
+        call cba_ui_fnc_preload3DEN
+    (end)
+
+Author:
+    commy2
+---------------------------------------------------------------------------- */
+
+if (!isNil {uiNamespace getVariable "AmmoBox_list"}) exitWith {
+    INFO("3DEN item list already preloaded.");
+    false
+};
+
+private _list = [[],[],[],[],[],[],[],[],[],[],[],[]];
+uiNamespace setVariable ["AmmoBox_list", _list];
+
+private _types = [
+    ["AssaultRifle","Shotgun","Rifle","SubmachineGun"],
+    ["MachineGun"],
+    ["SniperRifle"],
+    ["Launcher","MissileLauncher","RocketLauncher"],
+    ["Handgun"],
+    ["UnknownWeapon"],
+    ["AccessoryMuzzle","AccessoryPointer","AccessorySights","AccessoryBipod"],
+    ["Uniform"],
+    ["Vest"],
+    ["Backpack"],
+    ["Headgear","Glasses"],
+    ["Binocular","Compass","FirstAidKit","GPS","LaserDesignator","Map","Medikit","MineDetector","NVGoggles","Radio","Toolkit","Watch","UAVTerminal"]
+];
+
+//--- Weapons, Magazines and Items
+private _cfgWeapons = configFile >> "CfgWeapons";
+private _cfgMagazines = configFile >> "CfgMagazines";
+
+private _magazines = [];
+
+{
+    private _item = toLower configName _x;
+    (_item call BIS_fnc_itemType) params ["_itemCategory", "_itemType"];
+
+    private _index = -1;
+    {
+        if (_itemType in _x) exitWith {
+            _index = _forEachIndex;
+        };
+    } forEach _types;
+
+    if (_index >= 0 && {_itemCategory != "VehicleWeapon"}) then {
+        private _isPublic = getNumber (_x >> "scope") == 2;
+        private _listItem = _list select _index;
+
+        if (_isPublic) then {
+            _displayName = getText (_x >> "displayName");
+
+            // append display name with attachment names
+            {
+                _displayName = format [
+                    "%1 + %2",
+                    _displayName,
+                    getText (_cfgWeapons >> getText (_x >> "item") >> "displayName")
+                ];
+            } forEach ("true" configClasses (_x >> "linkeditems")); //configProperties [_x >> "linkeditems", "isClass _x"];
+
+            _listItem pushBack [
+                _displayName,
+                _item,
+                getText (_x >> "picture"),
+                parseNumber (getNumber (_x >> "type") in [4096, 131072]),
+                false
+            ];
+        };
+
+        //--- Magazines
+        if (_isPublic || {_item in ["throw","put"]}) then {
+            private _weaponConfig = _x;
+
+            {
+                private _muzzleConfig = _weaponConfig;
+
+                if (_x != "this") then {
+                    _muzzleConfig = _weaponConfig >> _x;
+                };
+
+                {
+                    private _item = tolower _x;
+
+                    if ({_x select 1 == _item} count _listItem == 0) then {
+                        private _magazineConfig = _cfgMagazines >> _item;
+
+                        if (getNumber (_magazineConfig >> "scope") == 2) then {
+                            _listItem pushBack [
+                                getText (_magazineConfig >> "displayName"),
+                                _item,
+                                getText (_magazineConfig >> "picture"),
+                                2,
+                                _item in _magazines
+                            ];
+
+                            _magazines pushBack _item;
+                        };
+                    };
+                } forEach getArray (_muzzleConfig >> "magazines");
+            } forEach getArray (_weaponConfig >> "muzzles");
+        };
+    };
+} forEach ("true" configClasses _cfgWeapons);
+
+//--- Backpacks
+{
+    if (getNumber (_x >> "isBackpack") == 1 && {getNumber (_x >> "scope") == 2}) then {
+        private _item = toLower configName _x;
+        private _itemType = _item call BIS_fnc_itemType select 1;
+
+        private _index = -1;
+        {
+            if (_itemType in _x) exitWith {
+                _index = _forEachIndex;
+            };
+        } forEach _types;
+
+        if (_index >= 0) then {
+            (_list select _index) pushBack [
+                getText (_x >> "displayName"),
+                _item,
+                getText (_x >> "picture"),
+                3,
+                false
+            ];
+        };
+    };
+} forEach ("true" configClasses (configFile >> "CfgVehicles"));
+
+//--- Glasses
+private _listHeadgear = _list select 10;
+
+{
+    if (getNumber (_x >> "scope") == 2) then {
+        _listHeadgear pushBack [
+            getText (_x >> "displayName"),
+            toLower configName _x,
+            getText (_x >> "picture"),
+            3,
+            false
+        ];
+    };
+} forEach ("true" configClasses (configFile >> "CfgGlasses"));
+
+{
+    _x sort true;
+} forEach _list;
+
+true

--- a/addons/ui/fnc_preload3DEN.sqf
+++ b/addons/ui/fnc_preload3DEN.sqf
@@ -31,19 +31,34 @@ if (!isNil {uiNamespace getVariable "AmmoBox_list"}) exitWith {
 private _list = [[],[],[],[],[],[],[],[],[],[],[],[]];
 uiNamespace setVariable ["AmmoBox_list", _list];
 
+private _itemTypes = [
+    "AssaultRifle","Shotgun","Rifle","SubmachineGun",
+    "MachineGun",
+    "SniperRifle",
+    "Launcher","MissileLauncher","RocketLauncher",
+    "Handgun",
+    "UnknownWeapon",
+    "AccessoryMuzzle","AccessoryPointer","AccessorySights","AccessoryBipod",
+    "Uniform",
+    "Vest",
+    "Backpack",
+    "Headgear","Glasses",
+    "Binocular","Compass","FirstAidKit","GPS","LaserDesignator","Map","Medikit","MineDetector","NVGoggles","Radio","Toolkit","Watch","UAVTerminal"
+];
+
 private _types = [
-    ["AssaultRifle","Shotgun","Rifle","SubmachineGun"],
-    ["MachineGun"],
-    ["SniperRifle"],
-    ["Launcher","MissileLauncher","RocketLauncher"],
-    ["Handgun"],
-    ["UnknownWeapon"],
-    ["AccessoryMuzzle","AccessoryPointer","AccessorySights","AccessoryBipod"],
-    ["Uniform"],
-    ["Vest"],
-    ["Backpack"],
-    ["Headgear","Glasses"],
-    ["Binocular","Compass","FirstAidKit","GPS","LaserDesignator","Map","Medikit","MineDetector","NVGoggles","Radio","Toolkit","Watch","UAVTerminal"]
+    0,0,0,0,
+    1,
+    2,
+    3,3,3,
+    4,
+    5,
+    6,6,6,6,
+    7,
+    8,
+    9,
+    10,10,
+    11,11,11,11,11,11,11,11,11,11,11,11,11
 ];
 
 //--- Weapons, Magazines and Items
@@ -56,13 +71,7 @@ private _magazines = [];
     private _item = toLower configName _x;
     (_item call BIS_fnc_itemType) params ["_itemCategory", "_itemType"];
 
-    private _index = -1;
-    {
-        if (_itemType in _x) exitWith {
-            _index = _forEachIndex;
-        };
-    } forEach _types;
-
+    private _index = _types param [_itemTypes find _itemType, -1];
     if (_index >= 0 && {_itemCategory != "VehicleWeapon"}) then {
         private _weaponConfig = _x;
         private _isPublic = getNumber (_weaponConfig >> "scope") == 2;
@@ -128,13 +137,7 @@ private _magazines = [];
         private _item = toLower configName _x;
         private _itemType = _item call BIS_fnc_itemType select 1;
 
-        private _index = -1;
-        {
-            if (_itemType in _x) exitWith {
-                _index = _forEachIndex;
-            };
-        } forEach _types;
-
+        private _index = _types param [_itemTypes find _itemType, -1];
         if (_index >= 0) then {
             (_list select _index) pushBack [
                 getText (_x >> "displayName"),

--- a/addons/ui/fnc_preload3DEN.sqf
+++ b/addons/ui/fnc_preload3DEN.sqf
@@ -31,35 +31,40 @@ if (!isNil {uiNamespace getVariable "AmmoBox_list"}) exitWith {
 private _list = [[],[],[],[],[],[],[],[],[],[],[],[]];
 uiNamespace setVariable ["AmmoBox_list", _list];
 
-private _itemTypes = [
-    "AssaultRifle","Shotgun","Rifle","SubmachineGun",
-    "MachineGun",
-    "SniperRifle",
-    "Launcher","MissileLauncher","RocketLauncher",
-    "Handgun",
-    "UnknownWeapon",
-    "AccessoryMuzzle","AccessoryPointer","AccessorySights","AccessoryBipod",
-    "Uniform",
-    "Vest",
-    "Backpack",
-    "Headgear","Glasses",
-    "Binocular","Compass","FirstAidKit","GPS","LaserDesignator","Map","Medikit","MineDetector","NVGoggles","Radio","Toolkit","Watch","UAVTerminal"
-];
-
-private _types = [
-    0,0,0,0,
-    1,
-    2,
-    3,3,3,
-    4,
-    5,
-    6,6,6,6,
-    7,
-    8,
-    9,
-    10,10,
-    11,11,11,11,11,11,11,11,11,11,11,11,11
-];
+private _itemTypes = call CBA_fnc_createNamespace;
+_itemTypes setVariable ["AssaultRifle", 0];
+_itemTypes setVariable ["Shotgun", 0];
+_itemTypes setVariable ["Rifle", 0];
+_itemTypes setVariable ["SubmachineGun", 0];
+_itemTypes setVariable ["MachineGun", 1];
+_itemTypes setVariable ["SniperRifle", 2];
+_itemTypes setVariable ["Launcher", 3];
+_itemTypes setVariable ["MissileLauncher", 3];
+_itemTypes setVariable ["RocketLauncher", 3];
+_itemTypes setVariable ["Handgun", 4];
+_itemTypes setVariable ["UnknownWeapon", 5];
+_itemTypes setVariable ["AccessoryMuzzle", 6];
+_itemTypes setVariable ["AccessoryPointer", 6];
+_itemTypes setVariable ["AccessorySights", 6];
+_itemTypes setVariable ["AccessoryBipod", 6];
+_itemTypes setVariable ["Uniform", 7];
+_itemTypes setVariable ["Vest", 8];
+_itemTypes setVariable ["Backpack", 9];
+_itemTypes setVariable ["Headgear", 10];
+_itemTypes setVariable ["Glasses", 10];
+_itemTypes setVariable ["Binocular", 11];
+_itemTypes setVariable ["Compass", 11];
+_itemTypes setVariable ["FirstAidKit", 11];
+_itemTypes setVariable ["GPS", 11];
+_itemTypes setVariable ["LaserDesignator", 11];
+_itemTypes setVariable ["Map", 11];
+_itemTypes setVariable ["Medikit", 11];
+_itemTypes setVariable ["MineDetector", 11];
+_itemTypes setVariable ["NVGoggles", 11];
+_itemTypes setVariable ["Radio", 11];
+_itemTypes setVariable ["Toolkit", 11];
+_itemTypes setVariable ["Watch", 11];
+_itemTypes setVariable ["UAVTerminal", 11];
 
 //--- Weapons, Magazines and Items
 private _cfgWeapons = configFile >> "CfgWeapons";
@@ -71,7 +76,7 @@ private _magazines = [];
     private _item = toLower configName _x;
     (_item call BIS_fnc_itemType) params ["_itemCategory", "_itemType"];
 
-    private _index = _types param [_itemTypes find _itemType, -1];
+    private _index = _itemTypes getVariable [_itemType, -1];
     if (_index >= 0 && {_itemCategory != "VehicleWeapon"}) then {
         private _weaponConfig = _x;
         private _isPublic = getNumber (_weaponConfig >> "scope") == 2;
@@ -137,7 +142,7 @@ private _magazines = [];
         private _item = toLower configName _x;
         private _itemType = _item call BIS_fnc_itemType select 1;
 
-        private _index = _types param [_itemTypes find _itemType, -1];
+        private _index = _itemTypes getVariable [_itemType, -1];
         if (_index >= 0) then {
             (_list select _index) pushBack [
                 getText (_x >> "displayName"),

--- a/addons/ui/fnc_preload3DEN.sqf
+++ b/addons/ui/fnc_preload3DEN.sqf
@@ -99,7 +99,7 @@ private _magazines = [];
                 };
 
                 {
-                    private _item = tolower _x;
+                    private _item = toLower _x;
 
                     if ({_x select 1 == _item} count _listItem == 0) then {
                         private _magazineConfig = _cfgMagazines >> _item;

--- a/addons/ui/fnc_preload3DEN.sqf
+++ b/addons/ui/fnc_preload3DEN.sqf
@@ -71,6 +71,7 @@ private _cfgWeapons = configFile >> "CfgWeapons";
 private _cfgMagazines = configFile >> "CfgMagazines";
 
 private _magazines = [];
+private _magazinesLists = [];
 
 {
     private _item = toLower configName _x;
@@ -115,7 +116,7 @@ private _magazines = [];
                 {
                     private _item = toLower _x;
 
-                    if ({_x select 1 == _item} count _listItem == 0) then {
+                    if (_magazinesLists pushBackUnique [_item, _listItem] != -1) then {
                         private _magazineConfig = _cfgMagazines >> _item;
 
                         if (getNumber (_magazineConfig >> "scope") == 2) then {
@@ -138,7 +139,14 @@ private _magazines = [];
 
 //--- Backpacks
 {
+// In case you are executing the unit test with addons loaded, should an addon
+// use the same classname in CfgVehicles and CfgWeapons this isBackpack
+// optimization prevents the item from added by twice.
+#ifdef DEBUG_MODE_FULL
+    if (getNumber (_x >> "scope") == 2) then {
+#else
     if (getNumber (_x >> "isBackpack") == 1 && {getNumber (_x >> "scope") == 2}) then {
+#endif
         private _item = toLower configName _x;
         private _itemType = _item call BIS_fnc_itemType select 1;
 

--- a/addons/ui/fnc_preload3DEN.sqf
+++ b/addons/ui/fnc_preload3DEN.sqf
@@ -64,11 +64,12 @@ private _magazines = [];
     } forEach _types;
 
     if (_index >= 0 && {_itemCategory != "VehicleWeapon"}) then {
-        private _isPublic = getNumber (_x >> "scope") == 2;
+        private _weaponConfig = _x;
+        private _isPublic = getNumber (_weaponConfig >> "scope") == 2;
         private _listItem = _list select _index;
 
         if (_isPublic) then {
-            _displayName = getText (_x >> "displayName");
+            _displayName = getText (_weaponConfig >> "displayName");
 
             // append display name with attachment names
             {
@@ -77,21 +78,19 @@ private _magazines = [];
                     _displayName,
                     getText (_cfgWeapons >> getText (_x >> "item") >> "displayName")
                 ];
-            } forEach ("true" configClasses (_x >> "linkeditems")); //configProperties [_x >> "linkeditems", "isClass _x"];
+            } forEach ("true" configClasses (_weaponConfig >> "linkeditems")); //configProperties [_weaponConfig >> "linkeditems", "isClass _x"];
 
             _listItem pushBack [
                 _displayName,
                 _item,
-                getText (_x >> "picture"),
-                parseNumber (getNumber (_x >> "type") in [4096, 131072]),
+                getText (_weaponConfig >> "picture"),
+                parseNumber (getNumber (_weaponConfig >> "type") in [4096, 131072]),
                 false
             ];
         };
 
         //--- Magazines
         if (_isPublic || {_item in ["throw","put"]}) then {
-            private _weaponConfig = _x;
-
             {
                 private _muzzleConfig = _weaponConfig;
 

--- a/addons/ui/fnc_preload3DEN.sqf
+++ b/addons/ui/fnc_preload3DEN.sqf
@@ -16,6 +16,9 @@ Examples:
         call cba_ui_fnc_preload3DEN
     (end)
 
+Notes:
+    To disable cache use: uiNamespace setVariable ["AmmoBox_list", nil];
+
 Author:
     commy2
 ---------------------------------------------------------------------------- */

--- a/addons/ui/fnc_preloadCurator.sqf
+++ b/addons/ui/fnc_preloadCurator.sqf
@@ -73,6 +73,7 @@ private _cfgWeapons = configFile >> "CfgWeapons";
 private _cfgMagazines = configFile >> "CfgMagazines";
 
 private _magazines = [];
+private _magazinesLists = [];
 
 {
     private _patchConfig = _cfgPatches >> _x;
@@ -132,7 +133,7 @@ private _magazines = [];
                     {
                         private _item = toLower _x;
 
-                        if ({_x select 0 == _item} count _listItem == 0) then {
+                        if (_magazinesLists pushBackUnique [_item, _listItem] != -1) then {
                             private _magazineConfig = _cfgMagazines >> _item;
 
                             if (getNumber (_magazineConfig >> "scope") == 2) then {
@@ -160,7 +161,14 @@ private _magazines = [];
         private _item = toLower _x;
         private _weaponConfig = _cfgVehicles >> _item;
 
+// In case you are executing the unit test with addons loaded, should an addon
+// use the same classname in CfgVehicles and CfgWeapons this isBackpack
+// optimization prevents the item from added by twice.
+#ifdef DEBUG_MODE_FULL
+        if (getNumber (_weaponConfig >> "scope") == 2) then {
+#else
         if (getNumber (_weaponConfig >> "isBackpack") == 1 && {getNumber (_weaponConfig >> "scope") == 2}) then {
+#endif
             private _itemType = _item call BIS_fnc_itemType select 1;
 
             private _index = _itemTypes getVariable [_itemType, -1];

--- a/addons/ui/fnc_preloadCurator.sqf
+++ b/addons/ui/fnc_preloadCurator.sqf
@@ -31,19 +31,34 @@ if (!isNil {uiNamespace getVariable QGVAR(curatorItemCache)}) exitWith {
 private _list = [];
 uiNamespace setVariable [QGVAR(curatorItemCache), _list];
 
+private _itemTypes = [
+    "AssaultRifle","Shotgun","Rifle","SubmachineGun",
+    "MachineGun",
+    "SniperRifle",
+    "Launcher","MissileLauncher","RocketLauncher",
+    "Handgun",
+    "UnknownWeapon",
+    "AccessoryMuzzle","AccessoryPointer","AccessorySights","AccessoryBipod",
+    "Uniform",
+    "Vest",
+    "Backpack",
+    "Headgear","Glasses",
+    "Binocular","Compass","FirstAidKit","GPS","LaserDesignator","Map","Medikit","MineDetector","NVGoggles","Radio","Toolkit","Watch","UAVTerminal"
+];
+
 private _types = [
-    ["AssaultRifle","Shotgun","Rifle","SubmachineGun"],
-    ["MachineGun"],
-    ["SniperRifle"],
-    ["Launcher","MissileLauncher","RocketLauncher"],
-    ["Handgun"],
-    ["UnknownWeapon"],
-    ["AccessoryMuzzle","AccessoryPointer","AccessorySights","AccessoryBipod"],
-    ["Uniform"],
-    ["Vest"],
-    ["Backpack"],
-    ["Headgear","Glasses"],
-    ["Binocular","Compass","FirstAidKit","GPS","LaserDesignator","Map","Medikit","MineDetector","NVGoggles","Radio","Toolkit","Watch","UAVTerminal"]
+    0,0,0,0,
+    1,
+    2,
+    3,3,3,
+    4,
+    5,
+    6,6,6,6,
+    7,
+    8,
+    9,
+    10,10,
+    11,11,11,11,11,11,11,11,11,11,11,11,11
 ];
 
 //--- Weapons, Magazines and Items
@@ -64,13 +79,7 @@ private _magazines = [];
         private _item = toLower _x;
         (_item call BIS_fnc_itemType) params ["_itemCategory", "_itemType"];
 
-        private _index = -1;
-        {
-            if (_itemType in _x) exitWith {
-                _index = _forEachIndex;
-            };
-        } forEach _types;
-
+        private _index = _types param [_itemTypes find _itemType, -1];
         if (_index >= 0 && {_itemCategory != "VehicleWeapon"}) then {
             private _weaponConfig = _cfgWeapons >> _item;
             private _isPublic = getNumber (_weaponConfig >> "scope") == 2;
@@ -149,13 +158,7 @@ private _magazines = [];
         if (getNumber (_weaponConfig >> "isBackpack") == 1 && {getNumber (_weaponConfig >> "scope") == 2}) then {
             private _itemType = _item call BIS_fnc_itemType select 1;
 
-            private _index = -1;
-            {
-                if (_itemType in _x) exitWith {
-                    _index = _forEachIndex;
-                };
-            } forEach _types;
-
+            private _index = _types param [_itemTypes find _itemType, -1];
             if (_index >= 0) then {
                 private _displayName = getText (_weaponConfig >> "displayName");
 

--- a/addons/ui/fnc_preloadCurator.sqf
+++ b/addons/ui/fnc_preloadCurator.sqf
@@ -191,4 +191,6 @@ private _magazinesLists = [];
     _list append [_addon, _addonList];
 } forEach call (uiNamespace getVariable QEGVAR(common,addons));
 
+_itemTypes call CBA_fnc_deleteNamespace;
+
 true

--- a/addons/ui/fnc_preloadCurator.sqf
+++ b/addons/ui/fnc_preloadCurator.sqf
@@ -56,12 +56,12 @@ private _magazines = [];
 
 {
     private _patchConfig = _cfgPatches >> _x;
-    _addon = tolower _x;
+    _addon = toLower _x;
 
     private _addonList = [[],[],[],[],[],[],[],[],[],[],[],[]];
 
     {
-        private _item = tolower _x;
+        private _item = toLower _x;
         (_item call BIS_fnc_itemType) params ["_itemCategory", "_itemType"];
 
         private _index = -1;
@@ -116,7 +116,7 @@ private _magazines = [];
                     };
 
                     {
-                        private _item = tolower _x;
+                        private _item = toLower _x;
 
                         if ({_x select 0 == _item} count _listItem == 0) then {
                             private _magazineConfig = _cfgMagazines >> _item;

--- a/addons/ui/fnc_preloadCurator.sqf
+++ b/addons/ui/fnc_preloadCurator.sqf
@@ -1,0 +1,141 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Internal Function: cba_ui_fnc_preloadCurator
+
+Description:
+    Preload Zeus ammo box item list.
+
+Parameters:
+    None
+
+Returns:
+    true: preloaded successfully, false: already preloaded <BOOL>
+
+Examples:
+    (begin example)
+        call cba_ui_fnc_preloadCurator
+    (end)
+
+Notes:
+    - curator needs a similar function
+    - function can be run without adjustments to the ui init script (opposed to curator)
+    - BIS_fnc_itemType caching
+    //"\a3\ui_f_curator\UI\RscCommon\RscAttributeInventory.sqf"
+
+Author:
+    commy2
+---------------------------------------------------------------------------- */
+
+
+
+
+
+
+//--- Get weapons and magazines from curator addons
+_curator = getassignedcuratorlogic player;
+_weaponAddons = missionnamespace getvariable ["RscAttrbuteInventory_weaponAddons",[]];
+_types = [
+    ["AssaultRifle","Shotgun","Rifle","SubmachineGun"],
+    ["MachineGun"],
+    ["SniperRifle"],
+    ["Launcher","MissileLauncher","RocketLauncher"],
+    ["Handgun"],
+    ["UnknownWeapon"],
+    ["AccessoryMuzzle","AccessoryPointer","AccessorySights","AccessoryBipod"],
+    ["Uniform"],
+    ["Vest"],
+    ["Backpack"],
+    ["Headgear","Glasses"],
+    ["Binocular","Compass","FirstAidKit","GPS","LaserDesignator","Map","Medikit","MineDetector","NVGoggles","Radio","Toolkit","Watch","UAVTerminal"]
+];
+_typeMagazine = _types find "Magazine";
+_list = [[],[],[],[],[],[],[],[],[],[],[],[]];
+_magazines = []; //--- Store magazines in an array and mark duplicates, so nthey don't appear in the list of all items
+{
+    _addon = tolower _x;
+    _addonList = [[],[],[],[],[],[],[],[],[],[],[],[]];
+    _addonID = _weaponAddons find _addon;
+    if (_addonID < 0) then {
+        {
+            _weapon = tolower _x;
+            _weaponType = (_weapon call bis_fnc_itemType);
+            _weaponTypeCategory = _weaponType select 0;
+            _weaponTypeSpecific = _weaponType select 1;
+            _weaponTypeID = -1;
+            {
+                if (_weaponTypeSpecific in _x) exitwith {_weaponTypeID = _foreachindex;};
+            } foreach _types;
+            //_weaponTypeID = _types find (_weaponType select 0);
+            if (_weaponTypeCategory != "VehicleWeapon" && _weaponTypeID >= 0) then {
+                _weaponCfg = configfile >> "cfgweapons" >> _weapon;
+                _weaponPublic = getnumber (_weaponCfg >> "scope") == 2;
+                _addonListType = _addonList select _weaponTypeID;
+                if (_weaponPublic) then {
+                    _displayName = gettext (_weaponCfg >> "displayName");
+                    _picture = gettext (_weaponCfg >> "picture");
+                    {
+                        _item = gettext (_x >> "item");
+                        _itemName = gettext (configfile >> "cfgweapons" >> _item >> "displayName");
+                        _displayName = _displayName + " + " + _itemName;
+                    } foreach ((_weaponCfg >> "linkeditems") call bis_fnc_returnchildren);
+                    _displayNameShort = _displayName;
+                    _displayNameShortArray = toarray _displayNameShort;
+                    if (count _displayNameShortArray > 41) then { //--- Cut when the name is too long (41 chars is approximate)
+                        _displayNameShortArray resize 41;
+                        _displayNameShort = tostring _displayNameShortArray + "...";
+                    };
+                    _type = if (getnumber (configfile >> "cfgweapons" >> _weapon >> "type") in [4096,131072]) then {1} else {0};
+                    _addonListType pushback [_weapon,_displayName,_displayNameShort,_picture,_type,false];
+                };
+                //--- Add magazines compatible with the weapon
+                if (_weaponPublic || _weapon in ["throw","put"]) then {
+                    //_addonListType = _addonList select _typeMagazine;
+                    {
+                        _muzzle = if (_x == "this") then {_weaponCfg} else {_weaponCfg >> _x};
+                        {
+                            _mag = tolower _x;
+                            if ({(_x select 0) == _mag} count _addonListType == 0) then {
+                                _magCfg = configfile >> "cfgmagazines" >> _mag;
+                                if (getnumber (_magCfg >> "scope") == 2) then {
+                                    _displayName = gettext (_magCfg >> "displayName");
+                                    _picture = gettext (_magCfg >> "picture");
+                                    _addonListType pushback [_mag,_displayName,_displayName,_picture,2,_mag in _magazines];
+                                    _magazines pushback _mag;
+                                };
+                            };
+                        } foreach getarray (_muzzle >> "magazines");
+                    } foreach getarray (_weaponCfg >> "muzzles");
+                };
+            };
+        } foreach getarray (configfile >> "cfgpatches" >> _x >> "weapons");
+        {
+            _weapon = tolower _x;
+            _weaponType = _weapon call bis_fnc_itemType;
+            _weaponTypeSpecific = _weaponType select 1;
+            _weaponTypeID = -1;
+            {
+                if (_weaponTypeSpecific in _x) exitwith {_weaponTypeID = _foreachindex;};
+            } foreach _types;
+            //_weaponTypeID = _types find (_weaponType select 0);
+            if (_weaponTypeID >= 0) then {
+                _weaponCfg = configfile >> "cfgvehicles" >> _weapon;
+                if (getnumber (_weaponCfg >> "scope") == 2) then {
+                    _displayName = gettext (_weaponCfg >> "displayName");
+                    _picture = gettext (_weaponCfg >> "picture");
+                    _addonListType = _addonList select _weaponTypeID;
+                    _addonListType pushback [_weapon,_displayName,_displayName,_picture,3,false];
+                };
+            };
+        } foreach getarray (configfile >> "cfgpatches" >> _x >> "units");
+        _weaponAddons set [count _weaponAddons,_addon];
+        _weaponAddons set [count _weaponAddons,_addonList];
+    } else {
+        _addonList = _weaponAddons select (_addonID + 1);
+    };
+    {
+        _current = _list select _foreachindex;
+        _list set [_foreachindex,_current + (_x - _current)];
+    } foreach _addonList;
+} foreach (curatoraddons _curator);
+missionnamespace setvariable ["RscAttrbuteInventory_weaponAddons",_weaponAddons];
+RscAttributeInventory_list = _list;

--- a/addons/ui/fnc_preloadCurator.sqf
+++ b/addons/ui/fnc_preloadCurator.sqf
@@ -31,35 +31,40 @@ if (!isNil {uiNamespace getVariable QGVAR(curatorItemCache)}) exitWith {
 private _list = [];
 uiNamespace setVariable [QGVAR(curatorItemCache), _list];
 
-private _itemTypes = [
-    "AssaultRifle","Shotgun","Rifle","SubmachineGun",
-    "MachineGun",
-    "SniperRifle",
-    "Launcher","MissileLauncher","RocketLauncher",
-    "Handgun",
-    "UnknownWeapon",
-    "AccessoryMuzzle","AccessoryPointer","AccessorySights","AccessoryBipod",
-    "Uniform",
-    "Vest",
-    "Backpack",
-    "Headgear","Glasses",
-    "Binocular","Compass","FirstAidKit","GPS","LaserDesignator","Map","Medikit","MineDetector","NVGoggles","Radio","Toolkit","Watch","UAVTerminal"
-];
-
-private _types = [
-    0,0,0,0,
-    1,
-    2,
-    3,3,3,
-    4,
-    5,
-    6,6,6,6,
-    7,
-    8,
-    9,
-    10,10,
-    11,11,11,11,11,11,11,11,11,11,11,11,11
-];
+private _itemTypes = call CBA_fnc_createNamespace;
+_itemTypes setVariable ["AssaultRifle", 0];
+_itemTypes setVariable ["Shotgun", 0];
+_itemTypes setVariable ["Rifle", 0];
+_itemTypes setVariable ["SubmachineGun", 0];
+_itemTypes setVariable ["MachineGun", 1];
+_itemTypes setVariable ["SniperRifle", 2];
+_itemTypes setVariable ["Launcher", 3];
+_itemTypes setVariable ["MissileLauncher", 3];
+_itemTypes setVariable ["RocketLauncher", 3];
+_itemTypes setVariable ["Handgun", 4];
+_itemTypes setVariable ["UnknownWeapon", 5];
+_itemTypes setVariable ["AccessoryMuzzle", 6];
+_itemTypes setVariable ["AccessoryPointer", 6];
+_itemTypes setVariable ["AccessorySights", 6];
+_itemTypes setVariable ["AccessoryBipod", 6];
+_itemTypes setVariable ["Uniform", 7];
+_itemTypes setVariable ["Vest", 8];
+_itemTypes setVariable ["Backpack", 9];
+_itemTypes setVariable ["Headgear", 10];
+_itemTypes setVariable ["Glasses", 10];
+_itemTypes setVariable ["Binocular", 11];
+_itemTypes setVariable ["Compass", 11];
+_itemTypes setVariable ["FirstAidKit", 11];
+_itemTypes setVariable ["GPS", 11];
+_itemTypes setVariable ["LaserDesignator", 11];
+_itemTypes setVariable ["Map", 11];
+_itemTypes setVariable ["Medikit", 11];
+_itemTypes setVariable ["MineDetector", 11];
+_itemTypes setVariable ["NVGoggles", 11];
+_itemTypes setVariable ["Radio", 11];
+_itemTypes setVariable ["Toolkit", 11];
+_itemTypes setVariable ["Watch", 11];
+_itemTypes setVariable ["UAVTerminal", 11];
 
 //--- Weapons, Magazines and Items
 private _cfgPatches = configFile >> "CfgPatches";
@@ -79,7 +84,7 @@ private _magazines = [];
         private _item = toLower _x;
         (_item call BIS_fnc_itemType) params ["_itemCategory", "_itemType"];
 
-        private _index = _types param [_itemTypes find _itemType, -1];
+        private _index = _itemTypes getVariable [_itemType, -1];
         if (_index >= 0 && {_itemCategory != "VehicleWeapon"}) then {
             private _weaponConfig = _cfgWeapons >> _item;
             private _isPublic = getNumber (_weaponConfig >> "scope") == 2;
@@ -158,7 +163,7 @@ private _magazines = [];
         if (getNumber (_weaponConfig >> "isBackpack") == 1 && {getNumber (_weaponConfig >> "scope") == 2}) then {
             private _itemType = _item call BIS_fnc_itemType select 1;
 
-            private _index = _types param [_itemTypes find _itemType, -1];
+            private _index = _itemTypes getVariable [_itemType, -1];
             if (_index >= 0) then {
                 private _displayName = getText (_weaponConfig >> "displayName");
 

--- a/addons/ui/fnc_preloadCurator.sqf
+++ b/addons/ui/fnc_preloadCurator.sqf
@@ -144,19 +144,19 @@ private _magazines = [];
 
     {
         private _item = toLower _x;
-        private _itemType = _item call BIS_fnc_itemType select 1;
+        private _weaponConfig = _cfgVehicles >> _item;
 
-        private _index = -1;
-        {
-            if (_itemType in _x) exitWith {
-                _index = _forEachIndex;
-            };
-        } forEach _types;
+        if (getNumber (_weaponConfig >> "isBackpack") == 1 && {getNumber (_weaponConfig >> "scope") == 2}) then {
+            private _itemType = _item call BIS_fnc_itemType select 1;
 
-        if (_index >= 0) then {
-            private _weaponConfig = _cfgVehicles >> _item;
+            private _index = -1;
+            {
+                if (_itemType in _x) exitWith {
+                    _index = _forEachIndex;
+                };
+            } forEach _types;
 
-            if (getNumber (_weaponConfig >> "scope") == 2) then {
+            if (_index >= 0) then {
                 private _displayName = getText (_weaponConfig >> "displayName");
 
                 (_addonList select _index) pushBack [

--- a/addons/ui/fnc_preloadCurator.sqf
+++ b/addons/ui/fnc_preloadCurator.sqf
@@ -165,10 +165,11 @@ private _magazinesLists = [];
 // use the same classname in CfgVehicles and CfgWeapons this isBackpack
 // optimization prevents the item from added by twice.
 #ifdef DEBUG_MODE_FULL
-        if (getNumber (_weaponConfig >> "scope") == 2) then {
+        if (getNumber (_weaponConfig >> "scope") == 2)
 #else
-        if (getNumber (_weaponConfig >> "isBackpack") == 1 && {getNumber (_weaponConfig >> "scope") == 2}) then { //}
+        if (getNumber (_weaponConfig >> "isBackpack") == 1 && {getNumber (_weaponConfig >> "scope") == 2})
 #endif
+        then {
             private _itemType = _item call BIS_fnc_itemType select 1;
 
             private _index = _itemTypes getVariable [_itemType, -1];

--- a/addons/ui/fnc_preloadCurator.sqf
+++ b/addons/ui/fnc_preloadCurator.sqf
@@ -17,23 +17,22 @@ Examples:
     (end)
 
 Notes:
-    - curator needs a similar function
-    - function can be run without adjustments to the ui init script (opposed to curator)
-    - BIS_fnc_itemType caching
-    //"\a3\ui_f_curator\UI\RscCommon\RscAttributeInventory.sqf"
+    To disable cache use in init.sqf: RscAttrbuteInventory_weaponAddons = nil;
 
 Author:
     commy2
 ---------------------------------------------------------------------------- */
 
+if (!isNil {uiNamespace getVariable QGVAR(curatorItemCache)}) exitWith {
+    INFO("Curator item list already preloaded.");
+    false
+};
 
-
-
-
+private _weaponAddons = [];
+uiNamespace setVariable [QGVAR(curatorItemCache), _weaponAddons];
 
 //--- Get weapons and magazines from curator addons
 _curator = getassignedcuratorlogic player;
-_weaponAddons = missionnamespace getvariable ["RscAttrbuteInventory_weaponAddons",[]];
 _types = [
     ["AssaultRifle","Shotgun","Rifle","SubmachineGun"],
     ["MachineGun"],
@@ -49,7 +48,7 @@ _types = [
     ["Binocular","Compass","FirstAidKit","GPS","LaserDesignator","Map","Medikit","MineDetector","NVGoggles","Radio","Toolkit","Watch","UAVTerminal"]
 ];
 _typeMagazine = _types find "Magazine";
-_list = [[],[],[],[],[],[],[],[],[],[],[],[]];
+
 _magazines = []; //--- Store magazines in an array and mark duplicates, so nthey don't appear in the list of all items
 {
     _addon = tolower _x;
@@ -132,10 +131,6 @@ _magazines = []; //--- Store magazines in an array and mark duplicates, so nthey
     } else {
         _addonList = _weaponAddons select (_addonID + 1);
     };
-    {
-        _current = _list select _foreachindex;
-        _list set [_foreachindex,_current + (_x - _current)];
-    } foreach _addonList;
-} foreach (curatoraddons _curator);
-missionnamespace setvariable ["RscAttrbuteInventory_weaponAddons",_weaponAddons];
-RscAttributeInventory_list = _list;
+} forEach call EGVAR(common,addons);
+
+true

--- a/addons/ui/fnc_preloadCurator.sqf
+++ b/addons/ui/fnc_preloadCurator.sqf
@@ -167,7 +167,7 @@ private _magazinesLists = [];
 #ifdef DEBUG_MODE_FULL
         if (getNumber (_weaponConfig >> "scope") == 2) then {
 #else
-        if (getNumber (_weaponConfig >> "isBackpack") == 1 && {getNumber (_weaponConfig >> "scope") == 2}) then {
+        if (getNumber (_weaponConfig >> "isBackpack") == 1 && {getNumber (_weaponConfig >> "scope") == 2}) then { //}
 #endif
             private _itemType = _item call BIS_fnc_itemType select 1;
 

--- a/addons/ui/script_component.hpp
+++ b/addons/ui/script_component.hpp
@@ -13,6 +13,7 @@
     #define DEBUG_SETTINGS DEBUG_SETTINGS_UI
 #endif
 
+#define DEBUG_SYNCHRONOUS
 #include "\x\cba\addons\main\script_macros.hpp"
 
 #include "\a3\ui_f\hpp\defineCommonGrids.inc"

--- a/addons/ui/test_preload.sqf
+++ b/addons/ui/test_preload.sqf
@@ -18,5 +18,33 @@ isNil {
 
         // Curator
         TEST_DEFINED(QFUNC(preloadCurator),"");
+
+        private _unit = player;
+        private _curator = getAssignedCuratorLogic _unit;
+
+        if (isNull _curator) then {
+            _curator = createGroup sideLogic createUnit ["ModuleCurator_F", [0,0,0], [], 0, "NONE"];
+            _curator spawn {
+                private _group = group _this;
+                deleteVehicle _this;
+                deleteGroup _group;
+            };
+
+            _unit assignCurator _curator;
+            _curator removeCuratorAddons call EGVAR(common,addons);
+            _curator addCuratorAddons call EGVAR(common,addons);
+        };
+
+        missionNamespace setVariable ["RscAttrbuteInventory_weaponAddons", nil];
+        ["onLoad", [displayNull], objNull] call compile preprocessFile "\a3\ui_f_curator\UI\RscCommon\RscAttributeInventory.sqf";
+        _vanilla = RscAttributeInventory_list;
+
+        GVAR(curatorItemCache) = nil;
+        call FUNC(preloadCurator);
+        missionNamespace setVariable ["RscAttrbuteInventory_weaponAddons", GVAR(curatorItemCache)];
+        ["onLoad", [displayNull], objNull] call compile preprocessFile "\a3\ui_f_curator\UI\RscCommon\RscAttributeInventory.sqf";
+        _cba = RscAttributeInventory_list;
+
+        TEST_TRUE(_vanilla isEqualTo _cba,QFUNC(preloadCurator));
     };
 };

--- a/addons/ui/test_preload.sqf
+++ b/addons/ui/test_preload.sqf
@@ -3,6 +3,7 @@
 
 isNil {
     with uiNamespace do {
+        // 3DEN
         TEST_DEFINED(QFUNC(preload3DEN),"");
 
         AmmoBox_list = nil;
@@ -14,5 +15,8 @@ isNil {
         private _cba = AmmoBox_list;
 
         TEST_TRUE(_vanilla isEqualTo _cba,QFUNC(preload3DEN));
+
+        // Curator
+        TEST_DEFINED(QFUNC(preloadCurator),"");
     };
 };

--- a/addons/ui/test_preload.sqf
+++ b/addons/ui/test_preload.sqf
@@ -24,16 +24,11 @@ isNil {
 
         if (isNull _curator) then {
             _curator = createGroup sideLogic createUnit ["ModuleCurator_F", [0,0,0], [], 0, "NONE"];
-            _curator spawn {
-                private _group = group _this;
-                deleteVehicle _this;
-                deleteGroup _group;
-            };
-
             _unit assignCurator _curator;
-            _curator removeCuratorAddons call EGVAR(common,addons);
-            _curator addCuratorAddons call EGVAR(common,addons);
         };
+
+        _curator removeCuratorAddons call EGVAR(common,addons);
+        _curator addCuratorAddons call EGVAR(common,addons);
 
         missionNamespace setVariable ["RscAttrbuteInventory_weaponAddons", nil];
         ["onLoad", [displayNull], objNull] call compile preprocessFile "\a3\ui_f_curator\UI\RscCommon\RscAttributeInventory.sqf";

--- a/addons/ui/test_preload.sqf
+++ b/addons/ui/test_preload.sqf
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+// execVM "\x\cba\addons\ui\test_preload.sqf";
+
+isNil {
+    with uiNamespace do {
+        TEST_DEFINED(QFUNC(preload3DEN),"");
+
+        AmmoBox_list = nil;
+        ["onLoad", [controlNull]] call compile preprocessFile "\a3\3den\UI\Attributes\AmmoBox.sqf";
+        private _vanilla = AmmoBox_list;
+
+        AmmoBox_list = nil;
+        call FUNC(preload3DEN);
+        private _cba = AmmoBox_list;
+
+        TEST_TRUE(_vanilla isEqualTo _cba,QFUNC(preload3DEN));
+    };
+};


### PR DESCRIPTION
**When merged this pull request will:**
- Adds `cba_ui_fnc_preload3den` to generate the item list used as mission attribute in the editor.
- Adds `cba_ui_fnc_preloadCurator` to generate the complete item list for the `RscAttributeInventory` display used on weapon crates in Zeus.
- Adds `test_preload.sqf";` unit test to check validity of the preloaded item lists (compares them to the lists you get with vanilla or w/e other modset)

Note that the test requires a previewed mission in 3den for the curator part.

The functions to generate these lists are taken from vanilla, but optimized / ace-ified.