### PR TITLE
ref #1082 - leave states on delete

### DIFF
--- a/addons/statemachine/fnc_clockwork.sqf
+++ b/addons/statemachine/fnc_clockwork.sqf
@@ -59,7 +59,7 @@ SCRIPT(clockwork);
         private _thisState = _current getVariable (QGVAR(state) + str _id);
 
         if (isNil "_thisState") then {
-            // Item is new and gets set to the intial state, onStateEntered
+            // Item is new and gets set to the initial state, onStateEntered
             // function of initial state gets executed as well.
             _thisState = _stateMachine getVariable QGVAR(initialState);
             _current setVariable [QGVAR(state) + str _id, _thisState];

--- a/addons/statemachine/fnc_delete.sqf
+++ b/addons/statemachine/fnc_delete.sqf
@@ -26,6 +26,22 @@ if (isNil QGVAR(stateMachines)) exitWith {};
 
 private _index = GVAR(stateMachines) find _stateMachine;
 if (_index != -1) then {
+
+    // all items exit their states before the machine gets deleted
+
+    private _skipNull = _stateMachine getVariable QGVAR(skipNull);
+    private _list = _stateMachine getVariable [QGVAR(list), []];
+
+    if (_skipNull) then {
+        _list = _list select {!isNull _x};
+    };
+
+    {
+        _currentState = [_x, _stateMachine] call CBA_statemachine_fnc_getCurrentState;
+        _x call (_stateMachine getVariable ONSTATELEAVING(_currentState));
+        false
+    } count _list;
+
     GVAR(stateMachines) deleteAt _index;
     [_stateMachine] call CBA_fnc_deleteNamespace;
 };

--- a/addons/statemachine/fnc_delete.sqf
+++ b/addons/statemachine/fnc_delete.sqf
@@ -37,7 +37,7 @@ if (_index != -1) then {
     };
 
     {
-        _currentState = [_x, _stateMachine] call CBA_statemachine_fnc_getCurrentState;
+        _thisState = [_x, _stateMachine] call CBA_statemachine_fnc_getCurrentState;
         _x call (_stateMachine getVariable ONSTATELEAVING(_currentState));
         false
     } count _list;

--- a/addons/statemachine/fnc_getCurrentState.sqf
+++ b/addons/statemachine/fnc_getCurrentState.sqf
@@ -3,7 +3,7 @@
 Function: CBA_statemachine_fnc_getCurrentState
 
 Description:
-    Manually triggers a transition.
+    Returns an item's current state
 
 Parameters:
     _listItem       - item to get the state of <any namespace type>


### PR DESCRIPTION
**When merged this pull request will:**

Let a state machine's items leave their states when the machine gets deleted by executing their onStateLeave handler.
This mirrors the behavior when creating a state machine, where the initial state's onStateEntered handler is called without a transition.

*(edit: correction, not necessary for #1082 )*

**TODO**
- [ ] test
- [ ] squash