### PR TITLE
fix stock mission filter on dedicated server

### DIFF
--- a/addons/ui/fnc_initDisplayRemoteMissions.sqf
+++ b/addons/ui/fnc_initDisplayRemoteMissions.sqf
@@ -125,8 +125,9 @@ _display setVariable [QFUNC(filter), {
 
     {
         _x params ["_name", "_value", "_data", "_color"];
+        private _classname = _data splitString "." select 0;
 
-        if (toLower _name find _filter != -1 && {_showStockMissions || {!(_data in _stockMissions)}}) then {
+        if (toLower _name find _filter != -1 && {_showStockMissions || {!(_classname in _stockMissions)}}) then {
             private _index = _ctrlMissions lbAdd _name;
             _ctrlMissions lbSetValue [_index, _value];
             _ctrlMissions lbSetData [_index, _data];


### PR DESCRIPTION
**When merged this pull request will:**
- Stock mission filter does not work as admin on dedicated server.
- This is because the list box data value is not "MissionName" like as local host, but "MissionName.Map" for whatever reason. Example: "TestMission.Altis" (dedi) vs. "TestMission" (local host)
- This PR fixes the issue.
