### PR TITLE
fix undefined flexi menu functions

### DIFF
--- a/addons/ui/CfgFunctions.hpp
+++ b/addons/ui/CfgFunctions.hpp
@@ -19,9 +19,6 @@ class CfgFunctions {
             class flexiMenu_keyUp {
                 file = QUOTE(PATHTOF(flexiMenu\fnc_keyUp.sqf));
             };
-            class menu {
-                file = QUOTE(PATHTOF(flexiMenu\fnc_menu.sqf));
-            };
             class flexiMenu_menu {
                 file = QUOTE(PATHTOF(flexiMenu\fnc_menu.sqf));
             };

--- a/addons/ui/RscDisplayOptionsLayout.hpp
+++ b/addons/ui/RscDisplayOptionsLayout.hpp
@@ -4,12 +4,12 @@ class RscDisplayOptionsLayout {
         class Element021;
         class Element022: Element021 {
             idc = 12022;
-            onMouseEnter = "with uinamespace do {['mouseEnter',_this,''] call RscDisplayOptionsLayout_script;};";
-            onMouseExit = "with uinamespace do {['mouseExit',_this,''] call RscDisplayOptionsLayout_script;};";
-            onMouseHolding = "with uinamespace do {['mouseMoving',_this,''] call RscDisplayOptionsLayout_script;};";
-            onMouseMoving = "with uinamespace do {['mouseMoving',_this,''] call RscDisplayOptionsLayout_script;};";
-            onMouseButtonDown = "with uinamespace do {['mouseButtonDown',_this,''] call RscDisplayOptionsLayout_script;};";
-            onMouseButtonUp = "with uinamespace do {['mouseButtonUp',_this,''] call RscDisplayOptionsLayout_script;};";
+            onMouseEnter = "with uiNamespace do {['mouseEnter',_this,''] call RscDisplayOptionsLayout_script;};";
+            onMouseExit = "with uiNamespace do {['mouseExit',_this,''] call RscDisplayOptionsLayout_script;};";
+            onMouseHolding = "with uiNamespace do {['mouseMoving',_this,''] call RscDisplayOptionsLayout_script;};";
+            onMouseMoving = "with uiNamespace do {['mouseMoving',_this,''] call RscDisplayOptionsLayout_script;};";
+            onMouseButtonDown = "with uiNamespace do {['mouseButtonDown',_this,''] call RscDisplayOptionsLayout_script;};";
+            onMouseButtonUp = "with uiNamespace do {['mouseButtonUp',_this,''] call RscDisplayOptionsLayout_script;};";
         };
         #define ADD_ELEMENT(var1) class Element##var1: Element022 {\
             idc = __EVAL(12000 + var1);\

--- a/addons/ui/XEH_preInit.sqf
+++ b/addons/ui/XEH_preInit.sqf
@@ -30,3 +30,19 @@ if (hasInterface) then {
         };
     }];
 };
+
+// legacy function names
+FUNC(Add) = CBA_fnc_flexiMenu_Add;
+FUNC(Remove) = CBA_fnc_flexiMenu_Remove;
+FUNC(setObjectMenuSource) = CBA_fnc_flexiMenu_setObjectMenuSource;
+FUNC(openMenuByDef) = CBA_fnc_flexiMenu_openMenuByDef;
+FUNC(keyDown) = CBA_fnc_flexiMenu_keyDown;
+FUNC(keyUp) = CBA_fnc_flexiMenu_keyUp;
+FUNC(menu) = CBA_fnc_flexiMenu_menu;
+FUNC(list) = CBA_fnc_flexiMenu_list;
+FUNC(getMenuDef) = CBA_fnc_flexiMenu_getMenuDef;
+FUNC(getMenuOption) = CBA_fnc_flexiMenu_getMenuOption;
+FUNC(menuShortcut) = CBA_fnc_flexiMenu_menuShortcut;
+FUNC(mouseButtonDown) = CBA_fnc_flexiMenu_mouseButtonDown;
+FUNC(highlightCaretKey) = CBA_fnc_flexiMenu_highlightCaretKey;
+FUNC(execute) = CBA_fnc_flexiMenu_execute;


### PR DESCRIPTION
**When merged this pull request will:**
- Restore the old variable names before the flexi menu was moved to  CfgFunctions
- some optimization
- some formatting

This is needed for the TFAR radio menus, because they, for whatever reason, are actually based on the flexi menu of all things.