### PR TITLE
settings, fix set for out of bounds priority

### DIFF
--- a/addons/settings/script_component.hpp
+++ b/addons/settings/script_component.hpp
@@ -163,7 +163,10 @@
 #define IS_LOCAL_SETTING(setting)  (GVAR(default) getVariable [setting, []] param [7, 0] == 2)
 
 #define SANITIZE_PRIORITY(setting,priority,source) (call {\
-    private _priority = [0,1,2] select priority;\
+    private _priority = priority;\
+    if (_priority isEqualType false) then {\
+        _priority = parseNumber _priority;\
+    };\
     if (IS_GLOBAL_SETTING(setting) && {source != "mission"}) exitWith {_priority max 1};\
     if (IS_LOCAL_SETTING(setting)) exitWith {_priority min 0};\
     _priority\


### PR DESCRIPTION
**When merged this pull request will:**
- fix a freeze for invalid priority used in FUNC(set).

```sqf
["banana", "CHECKBOX", "Banana", "Banana", true] call CBA_settings_fnc_init;
["banana", true, 3] call CBA_settings_fnc_set;
```
Before PR: game freeze, after PR: undefined behavior.
