### PR TITLE
fix error popup in Arsenal Garage

### DIFF
--- a/addons/ai/CfgVehicles.hpp
+++ b/addons/ai/CfgVehicles.hpp
@@ -2,6 +2,7 @@ class CfgVehicles {
     class B_TargetSoldier;
     class CBA_B_InvisibleTarget: B_TargetSoldier {
         scope = 2;
+        scopeArsenal = 0;
         model = QPATHTOF(InvisibleTarget.p3d);
         icon = "CBA_iconInvisibleTarget";
 
@@ -11,6 +12,7 @@ class CfgVehicles {
     class O_TargetSoldier;
     class CBA_O_InvisibleTarget: O_TargetSoldier {
         scope = 2;
+        scopeArsenal = 0;
         model = QPATHTOF(InvisibleTarget.p3d);
         icon = "CBA_iconInvisibleTarget";
 
@@ -20,6 +22,7 @@ class CfgVehicles {
     class I_TargetSoldier;
     class CBA_I_InvisibleTarget: I_TargetSoldier {
         scope = 2;
+        scopeArsenal = 0;
         model = QPATHTOF(InvisibleTarget.p3d);
         icon = "CBA_iconInvisibleTarget";
 

--- a/addons/main_a3/CfgMods.hpp
+++ b/addons/main_a3/CfgMods.hpp
@@ -2,7 +2,7 @@ class CfgMods {
     class PREFIX {
         author = "$STR_CBA_Author";
         dir = "@CBA_A3";
-        name = "Community Base Addons";
+        name = "Community Base Addons v0.0.0";
         picture = "x\cba\addons\main\logo_cba_ca.paa";
         hidePicture = 1;
         hideName = 1;

--- a/addons/main_a3/CfgMods.hpp
+++ b/addons/main_a3/CfgMods.hpp
@@ -2,15 +2,13 @@ class CfgMods {
     class PREFIX {
         author = "$STR_CBA_Author";
         dir = "@CBA_A3";
-        name = "Community Base Addons v3.9.1";
+        name = "Community Base Addons";
         picture = "x\cba\addons\main\logo_cba_ca.paa";
         hidePicture = 1;
         hideName = 1;
         actionName = "Website";
         action = "$STR_CBA_URL";
         description = "Bugtracker: https://github.com/CBATeam/CBA_A3/issues<br/>Documentation: https://github.com/CBATeam/CBA_A3/wiki";
-        logo = "logo_cba_ca.paa";
-        logoOver = "logo_cba_ca.paa";
         tooltip = "Community Base Addons";
         tooltipOwned = "Community Base Addons Owned";
         overview = "What does the name Community Base Addons mean? It is a system that offers a range of features for addon-makers and mission designers. This includes a collection of community-built functions, an integrated keybinding system, and extend event-handler support for compatibility with other 3rd-party addons; and much much more.";

--- a/tools/make.py
+++ b/tools/make.py
@@ -74,7 +74,7 @@ prefix = "cba"
 pbo_name_prefix = "cba_"
 signature_blacklist = []
 importantFiles = ["mod.cpp", "meta.cpp", "README.md", "LICENSE.md", "logo_cba_ca.paa"]
-versionFiles = ["mod.cpp"]
+versionFiles = ["mod.cpp","addons\main_a3\CfgMods.hpp"]
 
 ciBuild = False # Used for CI builds
 


### PR DESCRIPTION
**When merged this pull request will:**
- fixes error popup `Picture logo_cba_ca.paa not found` when opening the Virtual Garage
- remove a version number from a place that will not get updated
- attempt to hide the invisible target from the Arsenal using `scopeArsenal = 0;`

Predictably `scopeArsenal = 0;` doesn't work. It never works. I just leave it here as a reminder for everyone else that `scopeArsenal` indeed does not work.

![https://i.imgur.com/C40ewkv.png](https://i.imgur.com/C40ewkv.png)