### PR TITLE
keep Editor in local hosted mission browser while hiding stock missions

### DIFF
--- a/addons/ui/fnc_initDisplayRemoteMissions.sqf
+++ b/addons/ui/fnc_initDisplayRemoteMissions.sqf
@@ -128,7 +128,7 @@ _display setVariable [QFUNC(filter), {
 
     {
         _x params ["_name", "_value", "_data", "_color"];
-        private _classname = _data splitString "." select 0;
+        private _classname = _data splitString "." param [0, ""];
 
         if (toLower _name find _filter != -1 && {_showStockMissions || {!(_classname in _stockMissions)}}) then {
             private _index = _ctrlMissions lbAdd _name;


### PR DESCRIPTION
**When merged this pull request will:**
- Currently, in local hosted MP only, you can select a special editor "mission" to open MP 3den. In MP 3den when using the preview the lobby opens and connected clients can pick slots. Very helpful for debugging btw.
- With the addition of the stock mission filter when filtering stock missions this entry will be hidden from the list, despite not being a stock mission technically.
- Since a way to open the editor is pretty much the opposite of using a stock mission, I want to keep this entry even when the filter is active.
- The reason it becomes hidden is because the list box entry has value "" instead of "missionName.mapName". `"" splitString "."` is the empty array. `[] select 0` is nil, no error. `ARRAY find nil` is nil and thus the if executes neither the then nor the else block. Basically something that errors in scheduled environment.
- switching to `param` with default value makes my script recognize the mission name of the editor "mission" as "" instead of undefined, and thus it is correctly recognized as not a stock mission.
