### PR TITLE
More WW2 era magwells

### DIFF
--- a/addons/jam/CfgMagazineWells.hpp
+++ b/addons/jam/CfgMagazineWells.hpp
@@ -1,64 +1,71 @@
 class CfgMagazineWells {
 
     // Rifle calibre magwells, ordered lexicographically in metric and imperial groups
-    #include "magwells_11x59R.hpp"      // 11x59mmR Gras | 11mm Vickers
-    #include "magwells_145x114.hpp"     // 14.5x114mm
-    #include "magwells_46x30.hpp"       // 4.6x30mm
-    #include "magwells_545x39.hpp"      // 5.45x39mm
-    #include "magwells_556x45.hpp"      // 5.56x45mm | .223
-    #include "magwells_580x42.hpp"      // 5.8x42mm
-    #include "magwells_65C.hpp"         // 6.5mm Creedmoor | 6.5 Creedmoor | 6,5 Creedmoor | 6.5 CM | 6.5 CRDMR
-    #include "magwells_65G.hpp"         // 6.5mm Grendel | 6.5x39mm Grendel
-    #include "magwells_65x39.hpp"       // 6.5x39mm Caseless
-    #include "magwells_68SPC.hpp"       // 6.8mm Remington SPC | 6.8 SPC | 6.8x43mm
-    #include "magwells_75x55.hpp"       // 7.5x55mm Swiss | 7.5x55mm Schmidt–Rubin
-    #include "magwells_762x39.hpp"      // 7.62x39mm | 7.62 Soviet | .30 Russian Short
-    #include "magwells_762x51.hpp"      // 7.62x51mm | .308
-    #include "magwells_762x54.hpp"      // 7.62x54mmR
-    #include "magwells_77x58.hpp"       // 7.7x58mm Arisaka | Type 99 rimless 7.7 mm | 7.7mm Japanese
-    #include "magwells_792x33.hpp"      // 7.92x33mm Kurz | 7.92 x 33 kurz | 7.9mm Kurz | 7.9 Kurz | 7.9mmK | 8x33 Polte
-    #include "magwells_792x57.hpp"      // 7.92x57mm Mauser | 8mm Mauser | 8x57mm | 8 x 57 IS
-    #include "magwells_9x39.hpp"        // 9x39mm
-    #include "magwells_93x64.hpp"       // 9.3x64mm
+    #include "magwells_11x59R.hpp"                  // 11x59mmR Gras | 11mm Vickers
+    #include "magwells_145x114.hpp"                 // 14.5x114mm
+    #include "magwells_46x30.hpp"                   // 4.6x30mm
+    #include "magwells_545x39.hpp"                  // 5.45x39mm
+    #include "magwells_556x45.hpp"                  // 5.56x45mm | .223
+    #include "magwells_580x42.hpp"                  // 5.8x42mm
+    #include "magwells_65C.hpp"                     // 6.5mm Creedmoor | 6.5 Creedmoor | 6,5 Creedmoor | 6.5 CM | 6.5 CRDMR
+    #include "magwells_65G.hpp"                     // 6.5mm Grendel | 6.5x39mm Grendel
+    #include "magwells_65x39.hpp"                   // 6.5x39mm Caseless
+    #include "magwells_68SPC.hpp"                   // 6.8mm Remington SPC | 6.8 SPC | 6.8x43mm
+    #include "magwells_75x54mmFrench.hpp"           // 7.5x54mm French | 7.5 French | 7,5 x 54 MAS
+    #include "magwells_75x55.hpp"                   // 7.5x55mm Swiss | 7.5x55mm Schmidt–Rubin
+    #include "magwells_762x39.hpp"                  // 7.62x39mm | 7.62 Soviet | .30 Russian Short
+    #include "magwells_762x51.hpp"                  // 7.62x51mm | .308
+    #include "magwells_762x54.hpp"                  // 7.62x54mmR
+    #include "magwells_77x58.hpp"                   // 7.7x58mm Arisaka | Type 99 rimless 7.7 mm | 7.7mm Japanese
+    #include "magwells_792x107mmDS.hpp"             // 7.92x107mm DS
+    #include "magwells_792x33.hpp"                  // 7.92x33mm Kurz | 7.92 x 33 kurz | 7.9mm Kurz | 7.9 Kurz | 7.9mmK | 8x33 Polte
+    #include "magwells_792x57.hpp"                  // 7.92x57mm Mauser | 8mm Mauser | 8x57mm | 8 x 57 IS
+    #include "magwells_8x50mmR_Mannlicher.hpp"      // 8x50mmR Mannlicher | 8x50mmR M93
+    #include "magwells_8x56mmR.hpp"                 // 8x56mmR | 8x56mmR M30S | 8x56mmR Steyr | 8x56mmR Hungarian
+    #include "magwells_9x39.hpp"                    // 9x39mm
+    #include "magwells_93x64.hpp"                   // 9.3x64mm
 
-    #include "magwells_3006.hpp"        // .30-06 Springfield | 7.62x63mm
-    #include "magwells_300BLK.hpp"      // .300 AAC Blackout | 300 BLK | .300 Blackout | 7.62x35mm
-    #include "magwells_300WM.hpp"       // .300 Winchester Magnum | .300 Win Mag | 300WM
-    #include "magwells_303B.hpp"        // .303 British | 7.7x56mmR
-    #include "magwells_338LM.hpp"       // .338 Lapua Magnum
-    #include "magwells_338NM.hpp"       // .338 Norma Magnum
-    #include "magwells_408CT.hpp"       // .408 Cheyenne Tactical | 408 Chey Tac | 10.36x77mm
-    #include "magwells_50BMG.hpp"       // .50 BMG | .50 Browning Machine Gun | 12.7x99mm NATO
+    #include "magwells_3006.hpp"                    // .30-06 Springfield | 7.62x63mm
+    #include "magwells_300BLK.hpp"                  // .300 AAC Blackout | 300 BLK | .300 Blackout | 7.62x35mm
+    #include "magwells_300WM.hpp"                   // .300 Winchester Magnum | .300 Win Mag | 300WM
+    #include "magwells_303B.hpp"                    // .303 British | 7.7x56mmR
+    #include "magwells_338LM.hpp"                   // .338 Lapua Magnum
+    #include "magwells_338NM.hpp"                   // .338 Norma Magnum
+    #include "magwells_30Carbine.hpp"               // .30 Carbine | 7.62x33mm
+    #include "magwells_408CT.hpp"                   // .408 Cheyenne Tactical | 408 Chey Tac | 10.36x77mm
+    #include "magwells_50BMG.hpp"                   // .50 BMG | .50 Browning Machine Gun | 12.7x99mm NATO
 
     // Pistol calibre magwells, ordered lexicographically in metric and imperial groups
-    #include "magwells_10mmAuto.hpp"    // 10mm Auto | 10mm Automatic | 10x25mm
-    #include "magwells_57x28.hpp"       // 5.7x28mm
-    #include "magwells_762x25.hpp"      // 7.62x25mm Tokarev
-    #include "magwells_762x38R.hpp"     // 7.62x38mmR | 7.62 mm Nagant
-    #include "magwells_763x25.hpp"      // 7.63x25mm Mauser | .30 Mauser Automatic
-    #include "magwells_765x21.hpp"      // 7.65x21mm Parabellum | 7,65 Parabellum | 7.65mm Luger | .30 Luger
-    #include "magwells_8x22.hpp"        // 8x22mm Nambu
-    #include "magwells_9x18.hpp"        // 9x18mm Makarov | 9mm Makarov | 9x18mm PM
-    #include "magwells_9x19.hpp"        // 9x19mm Parabellum | 9mm Luger
-    #include "magwells_9x21.hpp"        // 9x21mm IMI | 9x21mm Gyurza
+    #include "magwells_10mmAuto.hpp"                // 10mm Auto | 10mm Automatic | 10x25mm
+    #include "magwells_57x28.hpp"                   // 5.7x28mm
+    #include "magwells_762x25.hpp"                  // 7.62x25mm Tokarev
+    #include "magwells_762x38R.hpp"                 // 7.62x38mmR | 7.62 mm Nagant
+    #include "magwells_763x25.hpp"                  // 7.63x25mm Mauser | .30 Mauser Automatic
+    #include "magwells_765x20Longue.hpp"            // 7.65x20mm Longue | 7.65mm French Longue | 7.65 mm Long | 7.65mm MAS | 7.65x20mm | 7.65L | .30-18 Auto
+    #include "magwells_765x21.hpp"                  // 7.65x21mm Parabellum | 7,65 Parabellum | 7.65mm Luger | .30 Luger
+    #include "magwells_8x22.hpp"                    // 8x22mm Nambu
+    #include "magwells_9x18.hpp"                    // 9x18mm Makarov | 9mm Makarov | 9x18mm PM
+    #include "magwells_9x19.hpp"                    // 9x19mm Parabellum | 9mm Luger
+    #include "magwells_9x21.hpp"                    // 9x21mm IMI | 9x21mm Gyurza
 
-    #include "magwells_22LR.hpp"        // .22 LR | .22 Long Rifle | 5.6x15mmR
-    #include "magwells_32ACP.hpp"       // .32 ACP | .32 Automatic | 7.65x17mmSR Browning | 7.65 mm Browning Short
-    #include "magwells_357Mag.hpp"      // .375 Magnum | .357 S&W Magnum | 9x33mmR
-    #include "magwells_357SIG.hpp"      // .357 SIG
-    #include "magwells_380ACP.hpp"      // .380 ACP | .380 Auto | 9mm Browning | 9mm Corto | 9mm Kurz | 9mm Short | 9x17mm | 9 mm Browning Court
-    #include "magwells_38Spec.hpp"      // .38 Smith & Wesson Special | .38 Special | .38 Spl | .38 Spc | 9x29.5mmR | 9.1x29mmR
-    #include "magwells_38_200.hpp"      // .38/200 | 9x20mmR
-    #include "magwells_40SW.hpp"        // .40 S&W
-    #include "magwells_455W.hpp"        // .455 Webley | .455 Eley | .455 Colt
-    #include "magwells_45ACP.hpp"       // .45 ACP | .45 Automatic Colt Pistol | .45 Auto | 11.43x23mm
-    #include "magwells_45GAP.hpp"       // .45 GAP | .45 "GAP" | .45 Glock Auto Pistol
+    #include "magwells_22LR.hpp"                    // .22 LR | .22 Long Rifle | 5.6x15mmR
+    #include "magwells_25ACP.hpp"                   // .25 ACP | 6.35x16mmSR
+    #include "magwells_32ACP.hpp"                   // .32 ACP | .32 Automatic | 7.65x17mmSR Browning | 7.65 mm Browning Short
+    #include "magwells_357Mag.hpp"                  // .375 Magnum | .357 S&W Magnum | 9x33mmR
+    #include "magwells_357SIG.hpp"                  // .357 SIG
+    #include "magwells_380ACP.hpp"                  // .380 ACP | .380 Auto | 9mm Browning | 9mm Corto | 9mm Kurz | 9mm Short | 9x17mm | 9 mm Browning Court
+    #include "magwells_38Spec.hpp"                  // .38 Smith & Wesson Special | .38 Special | .38 Spl | .38 Spc | 9x29.5mmR | 9.1x29mmR
+    #include "magwells_38_200.hpp"                  // .38/200 | 9x20mmR
+    #include "magwells_40SW.hpp"                    // .40 S&W
+    #include "magwells_455W.hpp"                    // .455 Webley | .455 Eley | .455 Colt
+    #include "magwells_45ACP.hpp"                   // .45 ACP | .45 Automatic Colt Pistol | .45 Auto | 11.43x23mm
+    #include "magwells_45GAP.hpp"                   // .45 GAP | .45 "GAP" | .45 Glock Auto Pistol
 
     // Shotgun calibre magwells, ordered lexicographically
-    #include "magwells_10gauge.hpp"     // 10 Gauge
-    #include "magwells_12gauge.hpp"     // 12 Gauge
-    #include "magwells_16gauge.hpp"     // 16 Gauge
-    #include "magwells_20gauge.hpp"     // 20 Gauge
+    #include "magwells_10gauge.hpp"                 // 10 Gauge
+    #include "magwells_12gauge.hpp"                 // 12 Gauge
+    #include "magwells_16gauge.hpp"                 // 16 Gauge
+    #include "magwells_20gauge.hpp"                 // 20 Gauge
 
 
     // Grenade/Flare Launchers, ordered lexicographically
@@ -67,13 +74,13 @@ class CfgMagazineWells {
 
     // AT and AA Launchers, ordered lexicographically
 
-    class CBA_Bazooka {};               // M1, M1A1 Bazooka
-    class CBA_Panzerschreck {};         // Panzerschreck RPzB 54
-    class CBA_PIAT {};                  // PIAT
-    class CBA_SMAW {};                  // Mk 153 Shoulder-Launched Multipurpose Assault Weapon
-    class CBA_SMAW_Spotting_Rifle {};   // Mk 153 Shoulder-Launched Multipurpose Assault Weapon - Spotting Rifle
+    class CBA_Bazooka {};                           // M1, M1A1 Bazooka
+    class CBA_Panzerschreck {};                     // Panzerschreck RPzB 54
+    class CBA_PIAT {};                              // PIAT
+    class CBA_SMAW {};                              // Mk 153 Shoulder-Launched Multipurpose Assault Weapon
+    class CBA_SMAW_Spotting_Rifle {};               // Mk 153 Shoulder-Launched Multipurpose Assault Weapon - Spotting Rifle
 
-    class CBA_Carl_Gustaf {             // MAAWS, RAWS
+    class CBA_Carl_Gustaf {                         // MAAWS, RAWS
         BI_rounds[] = {
             "MRAWS_HEAT_F",
             "MRAWS_HE_F"

--- a/addons/jam/magwells_25ACP.hpp
+++ b/addons/jam/magwells_25ACP.hpp
@@ -1,0 +1,1 @@
+    class CBA_25ACP_vz36 {};          // vz. 36

--- a/addons/jam/magwells_30Carbine.hpp
+++ b/addons/jam/magwells_30Carbine.hpp
@@ -1,0 +1,1 @@
+    class CBA_30Carbine_M1Carbine {};        // M1 Carbine, M2 Carbine

--- a/addons/jam/magwells_32ACP.hpp
+++ b/addons/jam/magwells_32ACP.hpp
@@ -1,8 +1,9 @@
-    class CBA_32ACP_CZ82 {};        // CZ 83
+    class CBA_32ACP_CZ82 {};        // CZ 82, CZ 83
     class CBA_32ACP_P83 {};         // FB P-83 Wanad
     class CBA_32ACP_PA63 {};        // FEG PA-63
     class CBA_32ACP_PM63 {};        // FB PM-63 RAK
     class CBA_32ACP_PP {};          // Walther PP in .32 ACP (7.65x17mm Browning)
     class CBA_32ACP_PPK {};         // Walther PPK in .32 ACP (7.65x17mm Browning)
+    class CBA_32ACP_Vz27 {};        // vz. 27
     class CBA_32ACP_Vz61 {};        // Škorpion (vz. 61), M84
-    class CBA_32ACP_Welrod {};      // Welrod pistol in .32 ACP (7.65x17mm Browning)
+    class CBA_32ACP_Welrod {};      // Welrod MkII in .32 ACP (7.65x17mm Browning)

--- a/addons/jam/magwells_380ACP.hpp
+++ b/addons/jam/magwells_380ACP.hpp
@@ -1,4 +1,4 @@
-    class CBA_380ACP_CZ82 {};           // CZ 83
+    class CBA_380ACP_CZ82 {};           // CZ 82, CZ-83
     class CBA_380ACP_Fort12 {};         // Fort-12
     class CBA_380ACP_Glock_Slim {};     // Slimline Glock in .380 ACP (Glock 42)
     class CBA_380ACP_Glock_SubC {};     // Subcompact Glock in .380 ACP (Glock 28)
@@ -12,4 +12,7 @@
     class CBA_380ACP_PP {};             // Walther PP in .380 ACP
     class CBA_380ACP_PP19 {};           // PP-19 Bizon-2-02
     class CBA_380ACP_PPK {};            // Walther PPK in .380 ACP
+    class CBA_380ACP_Vz22Pistol {};     // vz. 22, vz. 24 pistols
+    class CBA_380ACP_Vz38Pistol {};     // vz. 38 pistol
+    class CBA_380ACP_Vz38SMG {};        // vz. 38 SMG
     class CBA_380ACP_Vz64 {};           // Škorpion (vz. 64, vz. 83)

--- a/addons/jam/magwells_75x54mmFrench.hpp
+++ b/addons/jam/magwells_75x54mmFrench.hpp
@@ -1,0 +1,1 @@
+    class CBA_75x54mmFrench_MAS36 {};          // MAS 36

--- a/addons/jam/magwells_762x54.hpp
+++ b/addons/jam/magwells_762x54.hpp
@@ -1,5 +1,5 @@
-    class CBA_762x54R_DPM {};       // DPM LMG
-    class CBA_762x54R_DT {};        // DT LMG
+    class CBA_762x54R_DPM {};       // DP-27, DP-28, DPM, Degtyaryov LMG
+    class CBA_762x54R_DT {};        // DT, DTM LMG
 
     class CBA_762x54R_LINKS {       // Links for PK, PKM, and similar
         BI_belts[] = {
@@ -10,6 +10,8 @@
 
     class CBA_762x54R_Maxim {};     // Maxim gun in 7.62x54R
     class CBA_762x54R_Mosin {};     // M91/30, M38, M44 Mosin
+    
+    class CBA_762x54R_RP46 {};      // RP-46
 
     class CBA_762x54R_SVD {         // SVD
         BI_mags[] = {
@@ -17,4 +19,4 @@
         };
     };
 
-    class CBA_762x54R_SVT {};       // SVT
+    class CBA_762x54R_SVT {};       // SVT-38, SVT-40

--- a/addons/jam/magwells_763x25.hpp
+++ b/addons/jam/magwells_763x25.hpp
@@ -1,1 +1,4 @@
-    class CBA_763x25_C96 {};        // Mauser C-96 in 7.63x25mm
+    class CBA_763x25_C96 {};            // Mauser C-96 in 7.63x25mm
+    class CBA_763x25_C96_Compact {};    // Compact Mauser C-96 in 7.63x25mm (6 rounds)
+    class CBA_763x25_C96_Extended {};   // Extended Mauser C-96 in 7.63x25mm (20 rounds)
+    class CBA_763x25_M712 {};           // Mauser M712 Schnellfeuer in 7.63x25mm

--- a/addons/jam/magwells_765x20Longue.hpp
+++ b/addons/jam/magwells_765x20Longue.hpp
@@ -1,0 +1,1 @@
+    class CBA_765x20mmLongue_MAS38 {};          // MAS 38

--- a/addons/jam/magwells_792x107mmDS.hpp
+++ b/addons/jam/magwells_792x107mmDS.hpp
@@ -1,0 +1,1 @@
+    class CBA_792x107mmDS_wz35 {};      // wz.35

--- a/addons/jam/magwells_792x57.hpp
+++ b/addons/jam/magwells_792x57.hpp
@@ -1,7 +1,15 @@
     class CBA_792x57_FG42 {};       // FG42
-    class CBA_792x57_G43 {};        // G43, G41
-    class CBA_792x57_K98 {};        // K98, G98
+    class CBA_792x57_G41 {};        // G41
+    class CBA_792x57_G43 {};        // G43
+    class CBA_792x57_K98 {};        // K98, G98, G33/40, other Mauser type rifles
+    class CBA_792x57_K98_Trench {}; // K98, G98 with trench magazine
     class CBA_792x57_LINKS {};      // MG42, MG34
     class CBA_792x57_M76 {};        // Zastava M76
     class CBA_792x57_MG08 {};       // MG08
+    class CBA_792x57_MG30 {};       // MG30
     class CBA_792x57_TROMMEL {};    // MG34 Patronentrommel 34
+    class CBA_792x57_vz7_24 {};     // Schwarzlose-Janeček vz.7/24
+    class CBA_792x57_wz28 {};       // wz.28
+    class CBA_792x57_wz38M {};      // wz.38M
+    class CBA_792x57_ZB26 {};       // ZB-26, vz.26
+    class CBA_792x57_ZB53 {};       // ZB-53, vz.37

--- a/addons/jam/magwells_8x50mmR_Mannlicher.hpp
+++ b/addons/jam/magwells_8x50mmR_Mannlicher.hpp
@@ -1,0 +1,1 @@
+    class CBA_8x50mmR_Mannlicher_M1895 {};          // Mannlicher M1895

--- a/addons/jam/magwells_8x56mmR.hpp
+++ b/addons/jam/magwells_8x56mmR.hpp
@@ -1,0 +1,1 @@
+    class CBA_8x56mmR_Solothurn_31M {};       // Solothurn 31.M Golyoszoro

--- a/addons/jam/magwells_9x18.hpp
+++ b/addons/jam/magwells_9x18.hpp
@@ -1,4 +1,5 @@
     class CBA_9x18_APS {};      // Stechkin automatic pistol (APS)
+    class CBA_9x18_CZ82 {};     // CZ 82, CZ 83
     class CBA_9x18_Fort12 {};   // Fort-12
     class CBA_9x18_GPP9M {};    // Grand Power K100 P9M
     class CBA_9x18_Ots01 {};    // OTs-01 Kobalt

--- a/addons/jam/magwells_9x19.hpp
+++ b/addons/jam/magwells_9x19.hpp
@@ -14,6 +14,8 @@
     class CBA_9x19_Glock_Full {};   // Fullsize Glock in 9x19mm (Glock 17, 18, 34, 45)
     class CBA_9x19_HiPower {};      // Browning HiPower
     class CBA_9x19_M9 {};           // Beretta M9
+    class CBA_9x19_MAB38 {};        // Beretta Model 38
+    class CBA_9x19_MP28 {};         // MP18 Straight Magazines, MP28, MP35
     class CBA_9x19_MP40 {};         // MP40, MP38
     class CBA_9x19_MP443 {};        // MP-443 Grach
     class CBA_9x19_MP5 {            // H&K MP5
@@ -25,7 +27,7 @@
         };
     };
     class CBA_9x19_Ots27 {};        // OTs-27 Berdysh
-    class CBA_9x19_P08 {};          // Luger P08
+    class CBA_9x19_P08 {};          // Luger P08, MP18
     class CBA_9x19_P226 {};         // SIG P226
     class CBA_9x19_P228 {};         // SIG P228
     class CBA_9x19_P239 {};         // SIG P239
@@ -53,4 +55,5 @@
     class CBA_9x19_Vis {};          // wz. 35 Vis (Radom)
     class CBA_9x19_Vityaz {};       // Vityaz-SN
     class CBA_9x19_Vz68 {};         // Škorpion (vz. 68)
-    class CBA_9x19_Welrod {};       // Welrod pistol in 9x19mm
+    class CBA_9x19_Welrod {};       // Welrod MkI in 9x19mm
+    class CBA_9x19_wz39Mors {};     // wz.39 Mors


### PR DESCRIPTION
**When merged this pull request will:**
- Add more WW2 era magwells to support CSA38 and September 39
- Add a couple other random missing ones
- Expand some comments to be more specific
- Increase whitespace after magwell includes because magwells_8x50mmR_Mannlicher.hpp is such a long name
