### PR TITLE
Add trigger options to weapon events

### DIFF
--- a/addons/events/XEH_postInit.sqf
+++ b/addons/events/XEH_postInit.sqf
@@ -66,3 +66,23 @@ if (isServer) then {
         };
     };
 }] call CBA_fnc_addEventHandler;
+
+// trigger pressed
+// using display EH due to better reliance compared to inputAction
+["MouseButtonDown", {
+    params ["", "_key"];
+
+    // TODO Support non-LMB (?)
+    if (_key == 0) {
+        CBA_triggerPressed = true;
+    };
+}] call CBA_fnc_addDisplayHandler;
+
+["MouseButtonUp", {
+    params ["", "_key"];
+
+    // TODO Support non-LMB (?)
+    if (_key == 0) {
+        CBA_triggerPressed = false;
+    };
+}] call CBA_fnc_addDisplayHandler;

--- a/addons/events/XEH_postInit.sqf
+++ b/addons/events/XEH_postInit.sqf
@@ -70,19 +70,19 @@ if (isServer) then {
 // trigger pressed
 // using display EH due to better reliance compared to inputAction
 ["MouseButtonDown", {
-    params ["", "_key"];
+    params ["", "_button"];
 
     // TODO Support non-LMB (?)
-    if (_key == 0) {
-        CBA_triggerPressed = true;
+    if (_button == 0) {
+        GVAR(triggerPressed) = true;
     };
 }] call CBA_fnc_addDisplayHandler;
 
 ["MouseButtonUp", {
-    params ["", "_key"];
+    params ["", "_button"];
 
     // TODO Support non-LMB (?)
-    if (_key == 0) {
-        CBA_triggerPressed = false;
+    if (_button == 0) {
+        GVAR(triggerPressed) = false;
     };
 }] call CBA_fnc_addDisplayHandler;

--- a/addons/events/XEH_postInit.sqf
+++ b/addons/events/XEH_postInit.sqf
@@ -73,7 +73,7 @@ if (isServer) then {
     params ["", "_button"];
 
     // TODO Support non-LMB (?)
-    if (_button == 0) {
+    if (_button == 0) then {
         GVAR(triggerPressed) = true;
     };
 }] call CBA_fnc_addDisplayHandler;
@@ -82,7 +82,7 @@ if (isServer) then {
     params ["", "_button"];
 
     // TODO Support non-LMB (?)
-    if (_button == 0) {
+    if (_button == 0) then {
         GVAR(triggerPressed) = false;
     };
 }] call CBA_fnc_addDisplayHandler;

--- a/addons/events/XEH_preInit.sqf
+++ b/addons/events/XEH_preInit.sqf
@@ -25,7 +25,12 @@ if (isServer) then {
 };
 
 #include "backwards_comp.sqf"
-#include "initSettings.sqf"
+
+["CBA_settingsInitialized", {
+    // Events required by settings
+    // make sure we load events settings after
+    #include "initSettings.sqf"
+}] call CBA_fnc_addEventHandler;
 
 ADDON = true;
 

--- a/addons/events/XEH_preInit.sqf
+++ b/addons/events/XEH_preInit.sqf
@@ -25,12 +25,7 @@ if (isServer) then {
 };
 
 #include "backwards_comp.sqf"
-
-["CBA_settingsInitialized", {
-    // Events required by settings
-    // make sure we load events settings after
-    #include "initSettings.sqf"
-}] call CBA_fnc_addEventHandler;
+#include "initSettings.sqf"
 
 ADDON = true;
 

--- a/addons/events/XEH_preInit.sqf
+++ b/addons/events/XEH_preInit.sqf
@@ -25,6 +25,7 @@ if (isServer) then {
 };
 
 #include "backwards_comp.sqf"
+#include "initSettings.sqf"
 
 ADDON = true;
 

--- a/addons/events/fnc_weaponEvents.sqf
+++ b/addons/events/fnc_weaponEvents.sqf
@@ -106,8 +106,8 @@ if (!_isEmpty || _onEmpty) then {
 
         if (_wait) exitWith {
             // Detect trigger release
-            if (GVAR(weaponEventMode) == 2 && !GVAR(triggerPressed) then {
-                _this set [9, true];
+            if (GVAR(weaponEventMode) == 2 && !GVAR(triggerPressed)) then {
+                _this set [10, true];
             };
 
             _this set [8, CBA_missionTime];

--- a/addons/events/fnc_weaponEvents.sqf
+++ b/addons/events/fnc_weaponEvents.sqf
@@ -102,7 +102,7 @@ if (!_isEmpty || _onEmpty) then {
 
         if (_wait) exitWith {
             if (GVAR(weaponEventMode) == 2) then {
-                _trigger = CBA_triggerPressed;
+                _this set [9, CBA_triggerPressed];
             };
 
             _this set [8, CBA_missionTime];

--- a/addons/events/fnc_weaponEvents.sqf
+++ b/addons/events/fnc_weaponEvents.sqf
@@ -102,11 +102,11 @@ if (!_isEmpty || _onEmpty) then {
             GVAR(triggerPressed)
         }, {
             !_triggerReleased || !GVAR(triggerPressed)
-        }] select GVAR(weaponEventMode));
+        }] select GVAR(repetitionMode));
 
         if (_wait) exitWith {
             // Detect trigger release
-            if (GVAR(weaponEventMode) == 2 && !GVAR(triggerPressed)) then {
+            if (GVAR(repetitionMode) == 2 && !GVAR(triggerPressed)) then {
                 _this set [10, true];
             };
 

--- a/addons/events/initSettings.sqf
+++ b/addons/events/initSettings.sqf
@@ -9,4 +9,4 @@
         [LLSTRING(WeaponEventModeTriggerPress), LLSTRING(WeaponEventModeTriggerPressTooltip)] // Click trigger again
     ], 1],
     2
-] call (uiNamespace getVariable "cba_settings_fnc_init");
+] call CBA_fnc_addSetting;

--- a/addons/events/initSettings.sqf
+++ b/addons/events/initSettings.sqf
@@ -1,0 +1,12 @@
+[
+    QGVAR(weaponEventMode),
+    "LIST",
+    [LLSTRING(WeaponEventMode), LLSTRING(WeaponEventModeTooltip)],
+    LLSTRING(Category),
+    [[0, 1, 2], [
+        [LLSTRING(WeaponEventModeOptic), LLSTRING(WeaponEventModeOpticTooltip)], // Exit optic view
+        [LLSTRING(WeaponEventModeTriggerRelease), LLSTRING(WeaponEventModeTriggerReleaseTooltip)], // Stop holding trigger
+        [LLSTRING(WeaponEventModeTriggerPress), LLSTRING(WeaponEventModeTriggerPressTooltip)] // Click trigger again
+    ], 0],
+    2
+] call CBA_settings_fnc_init;

--- a/addons/events/initSettings.sqf
+++ b/addons/events/initSettings.sqf
@@ -9,4 +9,4 @@
         [LLSTRING(WeaponEventModeTriggerPress), LLSTRING(WeaponEventModeTriggerPressTooltip)] // Click trigger again
     ], 1],
     2
-] call CBA_settings_fnc_init;
+] call (uiNamespace getVariable "cba_settings_fnc_init");

--- a/addons/events/initSettings.sqf
+++ b/addons/events/initSettings.sqf
@@ -1,12 +1,12 @@
 [
-    QGVAR(weaponEventMode),
+    QGVAR(repetitionMode),
     "LIST",
-    [LLSTRING(WeaponEventMode), LLSTRING(WeaponEventModeTooltip)],
-    LLSTRING(Category),
+    [LLSTRING(RepetitionMode), LLSTRING(RepetitionModeTooltip)],
+    LLSTRING(WeaponsCategory),
     [[0, 1, 2], [
-        [LLSTRING(WeaponEventModeOptic), LLSTRING(WeaponEventModeOpticTooltip)], // Exit optic view
-        [LLSTRING(WeaponEventModeTriggerRelease), LLSTRING(WeaponEventModeTriggerReleaseTooltip)], // Stop holding trigger
-        [LLSTRING(WeaponEventModeTriggerPress), LLSTRING(WeaponEventModeTriggerPressTooltip)] // Click trigger again
+        [LLSTRING(RepetitionModeOptic), LLSTRING(RepetitionModeOpticTooltip)], // Exit optic view
+        [LLSTRING(RepetitionModeTriggerRelease), LLSTRING(RepetitionModeTriggerReleaseTooltip)], // Stop holding trigger
+        [LLSTRING(RepetitionModeTriggerPress), LLSTRING(RepetitionModeTriggerPressTooltip)] // Click trigger again
     ], 1],
     2
 ] call CBA_fnc_addSetting;

--- a/addons/events/initSettings.sqf
+++ b/addons/events/initSettings.sqf
@@ -7,6 +7,6 @@
         [LLSTRING(WeaponEventModeOptic), LLSTRING(WeaponEventModeOpticTooltip)], // Exit optic view
         [LLSTRING(WeaponEventModeTriggerRelease), LLSTRING(WeaponEventModeTriggerReleaseTooltip)], // Stop holding trigger
         [LLSTRING(WeaponEventModeTriggerPress), LLSTRING(WeaponEventModeTriggerPressTooltip)] // Click trigger again
-    ], 0],
+    ], 1],
     2
 ] call CBA_settings_fnc_init;

--- a/addons/events/stringtable.xml
+++ b/addons/events/stringtable.xml
@@ -12,5 +12,32 @@
             <Polish>Community Base Addons - Zdarzenia</Polish>
             <Turkish>Community Base Addons - Durumlar</Turkish>
         </Key>
+        <Key ID="STR_CBA_Events_Category">
+            <English>CBA Events</English>
+        </Key>
+        <Key ID="STR_CBA_Events_WeaponEventMode">
+            <English>Weapon Event Mode</English>
+        </Key>
+        <Key ID="STR_CBA_Events_WeaponEventModeTooltip">
+            <English>Mode of bolting or pumping weapons supporting Weapon Animations Framework.</English>
+        </Key>
+        <Key ID="STR_CBA_Events_WeaponEventModeOptic">
+            <English>Leave Optics View</English>
+        </Key>
+        <Key ID="STR_CBA_Events_WeaponEventModeOpticTooltip">
+            <English>Bolt or rack weapon by leaving optics view.</English>
+        </Key>
+        <Key ID="STR_CBA_Events_WeaponEventModeTriggerRelease">
+            <English>Release Trigger</English>
+        </Key>
+        <Key ID="STR_CBA_Events_WeaponEventModeTriggerReleaseTooltip">
+            <English>Bolt or rack weapon by releasing trigger (hold trigger to prevent immediate action).</English>
+        </Key>
+        <Key ID="STR_CBA_Events_WeaponEventModeTriggerPress">
+            <English>Press Trigger</English>
+        </Key>
+        <Key ID="STR_CBA_Events_WeaponEventModeTriggerPressTooltip">
+            <English>Bolt or rack weapon by pressing the trigger again.</English>
+        </Key>
     </Package>
 </Project>

--- a/addons/events/stringtable.xml
+++ b/addons/events/stringtable.xml
@@ -12,32 +12,41 @@
             <Polish>Community Base Addons - Zdarzenia</Polish>
             <Turkish>Community Base Addons - Durumlar</Turkish>
         </Key>
-        <Key ID="STR_CBA_Events_Category">
-            <English>CBA Events</English>
+        <Key ID="STR_CBA_Events_WeaponsCategory">
+            <English>CBA Weapons</English>
+            <German>CBA Waffen</German>
         </Key>
-        <Key ID="STR_CBA_Events_WeaponEventMode">
-            <English>Weapon Event Mode</English>
+        <Key ID="STR_CBA_Events_RepetitionMode">
+            <English>Weapon Repetition Mode</English>
+            <German>Repetierwaffe laden</German>
         </Key>
-        <Key ID="STR_CBA_Events_WeaponEventModeTooltip">
-            <English>Mode of bolting or pumping weapons supporting Weapon Animations Framework.</English>
+        <Key ID="STR_CBA_Events_RepetitionModeTooltip">
+            <English>Mode of bolting or pumping weapons.</English>
+            <German>Art eine Waffe zu repetieren.</German>
         </Key>
-        <Key ID="STR_CBA_Events_WeaponEventModeOptic">
+        <Key ID="STR_CBA_Events_RepetitionModeOptic">
             <English>Leave Optics View</English>
+            <German>Optikansicht verlassen</German>
         </Key>
-        <Key ID="STR_CBA_Events_WeaponEventModeOpticTooltip">
+        <Key ID="STR_CBA_Events_RepetitionModeOpticTooltip">
             <English>Bolt or rack weapon by leaving optics view.</English>
+            <German>Waffe beim Verlassen der Optikansicht repetieren.</German>
         </Key>
-        <Key ID="STR_CBA_Events_WeaponEventModeTriggerRelease">
+        <Key ID="STR_CBA_Events_RepetitionModeTriggerRelease">
             <English>Release Trigger</English>
+            <German>Abzug losslassen</German>
         </Key>
-        <Key ID="STR_CBA_Events_WeaponEventModeTriggerReleaseTooltip">
+        <Key ID="STR_CBA_Events_RepetitionModeTriggerReleaseTooltip">
             <English>Bolt or rack weapon by releasing trigger (hold trigger to prevent immediate action).</English>
+            <German>Waffe beim Loslassen des Abzugs repetieren (Abzug halten, um Repetieren zu verzögern).</German>
         </Key>
-        <Key ID="STR_CBA_Events_WeaponEventModeTriggerPress">
+        <Key ID="STR_CBA_Events_RepetitionModeTriggerPress">
             <English>Press Trigger</English>
+            <German>Abzug betätigen</German>
         </Key>
-        <Key ID="STR_CBA_Events_WeaponEventModeTriggerPressTooltip">
+        <Key ID="STR_CBA_Events_RepetitionModeTriggerPressTooltip">
             <English>Bolt or rack weapon by pressing the trigger again.</English>
+            <German>Waffe beim erneuten Betätigen des Abzugs repetieren.</German>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Add options to weapon events / weapon animations framework:
  - Leave Optics: leave optics view to bolt/rack (old default)
  - Trigger Release: release trigger to bolt/rack
  - Trigger Press: press trigger again to bolt/rack

TODO:
- [x] Make `CBA_triggerPressed` GVAR or public API -> GVAR
- [x] Set default option to Trigger Release
  - Friendlier to new users and used in more games
- [X] Support non-LMB triggers -> **later if requested** (if anyone even uses non-LMB trigger)
- [X] Add option for vanilla behaviour (Trigger Release default accomplishes the same) -> **later if requested**
- [X] Rename "Trigger Press" to "Trigger Re-Press" -> **nope**