### PR TITLE
add CBA_fnc_addSetting

### DIFF
--- a/addons/settings/CfgFunctions.hpp
+++ b/addons/settings/CfgFunctions.hpp
@@ -1,0 +1,7 @@
+class CfgFunctions {
+    class CBA {
+        class Settings {
+            PATHTO_FNC(addSetting);
+        };
+    };
+};

--- a/addons/settings/config.cpp
+++ b/addons/settings/config.cpp
@@ -15,6 +15,7 @@ class CfgPatches {
 };
 
 #include "CfgEventHandlers.hpp"
+#include "CfgFunctions.hpp"
 #include "Cfg3DEN.hpp"
 #include "Display3DEN.hpp"
 #include "gui.hpp"

--- a/addons/settings/fnc_addSetting.sqf
+++ b/addons/settings/fnc_addSetting.sqf
@@ -1,0 +1,48 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_addSetting
+
+Description:
+    Creates a new setting for that session.
+
+Parameters:
+    _setting     - Unique setting name. Matches resulting variable name <STRING>
+    _settingType - Type of setting. Can be "CHECKBOX", "EDITBOX", "LIST", "SLIDER" or "COLOR" <STRING>
+    _title       - Display name or display name + tooltip (optional, default: same as setting name) <STRING, ARRAY>
+    _category    - Category for the settings menu + optional sub-category <STRING, ARRAY>
+    _valueInfo   - Extra properties of the setting depending of _settingType. See examples below <ANY>
+    _isGlobal    - 1: all clients share the same setting, 2: setting can't be overwritten (optional, default: 0) <ARRAY>
+    _script      - Script to execute when setting is changed. (optional) <CODE>
+    _needRestart - Setting will be marked as needing mission restart after being changed. (optional, default false) <BOOL>
+
+Returns:
+    _return - Error code <BOOLEAN>
+        true: Success, no error
+        false: Failure, error
+
+Examples:
+    (begin example)
+        // CHECKBOX --- extra argument: default value
+        ["Test_Setting_1", "CHECKBOX", ["-test checkbox-", "-tooltip-"], "My Category", true] call CBA_fnc_addSetting;
+
+        // LIST --- extra arguments: [_values, _valueTitles, _defaultIndex]
+        ["Test_Setting_2", "LIST",     ["-test list-",     "-tooltip-"], "My Category", [[1, 0], ["enabled","disabled"], 1]] call CBA_fnc_addSetting;
+
+        // SLIDER --- extra arguments: [_min, _max, _default, _trailingDecimals]
+        ["Test_Setting_3", "SLIDER",   ["-test slider-",   "-tooltip-"], "My Category", [0, 10, 5, 0]] call CBA_fnc_addSetting;
+
+        // COLOR PICKER --- extra argument: _color
+        ["Test_Setting_4", "COLOR",    ["-test color-",    "-tooltip-"], "My Category", [1, 1, 0]] call CBA_fnc_addSetting;
+
+        // EDITBOX --- extra argument: default value
+        ["Test_Setting_5", "EDITBOX",  ["-test editbox-", "-tooltip-"], "My Category", "defaultValue"] call CBA_fnc_addSetting;
+
+        // TIME PICKER (time in seconds) --- extra arguments: [_min, _max, _default]
+        ["Test_Setting_6", "TIME",     ["-test time-",    "-tooltip-"], "My Category", [0, 3600, 60]] call CBA_fnc_addSetting;
+    (end)
+
+Author:
+    commy2
+---------------------------------------------------------------------------- */
+
+call (uiNamespace getVariable QFUNC(init)) == 0

--- a/addons/settings/fnc_init.sqf
+++ b/addons/settings/fnc_init.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 /* ----------------------------------------------------------------------------
-Function: CBA_settings_fnc_init
+Internal Function: CBA_settings_fnc_init
 
 Description:
     Creates a new setting for that session.


### PR DESCRIPTION
**When merged this pull request will:**
- `CBA_fnc_addSettings` is defined by CfgFunctions, `cba_settings_fnc_init` by PREP.
- This means that `cba_settings_fnc_init` will be undefined when used by an addon in preInit that does not require cba_settings and is therefore likely loaded before the settings XEH preInit can define the function.
- `CBA_fnc_addSettings` reads the function from the ui namespace cache and therefore gets around the requirement of putting cba_settings into requiredAddons of the mod that wants to add a setting.
