### PR TITLE
add setting to disable disposable launchers 

### DIFF
--- a/addons/disposable/XEH_preInit.sqf
+++ b/addons/disposable/XEH_preInit.sqf
@@ -49,6 +49,8 @@ private _cfgMagazines = configFile >> "CfgMagazines";
     };
 } forEach configProperties [configFile >> "CBA_DisposableLaunchers", "isArray _x"];
 
-["All", "InitPost", FUNC(replaceMagazineCargo)] call CBA_fnc_addClassEventHandler;
+["CBA_settingsInitialized", {
+    ["All", "InitPost", FUNC(replaceMagazineCargo), nil, nil, true] call CBA_fnc_addClassEventHandler;
+}] call CBA_fnc_addEventHandler;
 
 ADDON = true;

--- a/addons/disposable/fnc_firedDisposable.sqf
+++ b/addons/disposable/fnc_firedDisposable.sqf
@@ -29,6 +29,8 @@ Author:
     commy2
 ---------------------------------------------------------------------------- */
 
+if (!GVAR(replaceDisposableLauncher)) exitWith {};
+
 params ["_unit", "_launcher", "_muzzle", "", "", "", "_projectile"];
 
 private _usedLauncher = GVAR(UsedLaunchers) getVariable _launcher;

--- a/addons/disposable/fnc_initDisplayInventory.sqf
+++ b/addons/disposable/fnc_initDisplayInventory.sqf
@@ -6,8 +6,7 @@ private _fnc_update = {
     params ["_display"];
     private _control = _display displayCtrl IDC_FG_SW_MAGAZINE;
 
-    private _unit = call CBA_fnc_currentUnit;
-    _control ctrlEnable isNil {GVAR(LoadedLaunchers) getVariable secondaryWeapon _unit};
+    _control ctrlEnable (!GVAR(replaceDisposableLauncher) || {isNil {GVAR(LoadedLaunchers) getVariable secondaryWeapon call CBA_fnc_currentUnit}});
 };
 
 _display displayAddEventHandler ["MouseMoving", _fnc_update];

--- a/addons/disposable/fnc_replaceMagazineCargo.sqf
+++ b/addons/disposable/fnc_replaceMagazineCargo.sqf
@@ -20,6 +20,8 @@ Author:
     commy2
 ---------------------------------------------------------------------------- */
 
+if (!GVAR(replaceDisposableLauncher)) exitWith {};
+
 params ["_box"];
 if (!local _box) exitWith {};
 if (missionNamespace getVariable [QGVAR(disableMagazineReplacement), false]) exitWith {};

--- a/addons/disposable/initSettings.sqf
+++ b/addons/disposable/initSettings.sqf
@@ -5,7 +5,11 @@
     ELSTRING(common,WeaponsCategory),
     [
         [0,1,2],
-        [LLSTRING(DropNever), LLSTRING(DropAIOnly), LLSTRING(DropSelectedAnotherWeapon)],
+        [
+            [LLSTRING(DropNever), LLSTRING(DropNeverTooltip)],
+            [LLSTRING(DropAIOnly), LLSTRING(DropAIOnlyTooltip)],
+            [LLSTRING(DropSelectedAnotherWeapon), LLSTRING(DropSelectedAnotherWeaponTooltip)]
+        ],
         2
     ],
     0 // isGlobal

--- a/addons/disposable/initSettings.sqf
+++ b/addons/disposable/initSettings.sqf
@@ -1,4 +1,13 @@
 [
+    QGVAR(replaceDisposableLauncher),
+    "CHECKBOX",
+    [LLSTRING(ReplaceDisposableLauncher), LLSTRING(ReplaceDisposableLauncherTooltip)],
+    ELSTRING(common,WeaponsCategory),
+    true, // default value
+    1 // isGlobal
+] call EFUNC(settings,init);
+
+[
     QGVAR(dropUsedLauncher),
     "LIST",
     LLSTRING(DropUsedLauncher),

--- a/addons/disposable/stringtable.xml
+++ b/addons/disposable/stringtable.xml
@@ -13,13 +13,25 @@
             <English>Never</English>
             <German>Niemals</German>
         </Key>
+        <Key ID="STR_CBA_disposable_DropNeverTooltip">
+            <English>Don't automatically drop the used disposable launcher.</English>
+            <German>Benutzten Einwegwerfer nicht automatisch ablegen.</German>
+        </Key>
         <Key ID="STR_CBA_disposable_DropAIOnly">
             <English>AI Only</English>
             <German>Nur KI</German>
         </Key>
+        <Key ID="STR_CBA_disposable_DropAIOnlyTooltip">
+            <English>Only AI drops the used disposable launcher.</English>
+            <German>Nur KI legt den benutzten Einwegwerfer ab.</German>
+        </Key>
         <Key ID="STR_CBA_disposable_DropSelectedAnotherWeapon">
             <English>Selected Another Weapon</English>
             <German>Andere Waffe ausgewählt</German>
+        </Key>
+        <Key ID="STR_CBA_disposable_DropSelectedAnotherWeaponTooltip">
+            <English>Automatically drop the used disposable launcher as soon as another weapon is selected.</English>
+            <German>Benutzten Einwegwerfer automatisch ablegen, sobald eine andere Waffe ausgewählt wurde.</German>
         </Key>
     </Package>
 </Project>

--- a/addons/disposable/stringtable.xml
+++ b/addons/disposable/stringtable.xml
@@ -33,5 +33,13 @@
             <English>Automatically drop the used disposable launcher as soon as another weapon is selected.</English>
             <German>Benutzten Einwegwerfer automatisch ablegen, sobald eine andere Waffe ausgewählt wurde.</German>
         </Key>
+        <Key ID="STR_CBA_disposable_ReplaceDisposableLauncher">
+            <English>Replace Disposable Launcher</English>
+            <German>Einwegwerfer ersetzten</German>
+        </Key>
+        <Key ID="STR_CBA_disposable_ReplaceDisposableLauncherTooltip">
+            <English>If enabled, disposable launchers can only be used once. Ammunition for disposable launchers in containers and vehicles will be replaced with loaded disposable launchers. If disabled, disposable launchers can be reloaded after use.</English>
+            <German>Wenn aktiviert, dann können Einwegwerfer nur einmal benutzt werden. Munition für Einwegwerfer in Kisten und Fahrzeugen wird durch geladene Einwegwerfer ersetzt. Wenn deaktiviert, dann können Einwegwerfer nach der Benutzung nachgeladen werden.</German>
+        </Key>
     </Package>
 </Project>

--- a/addons/events/initSettings.sqf
+++ b/addons/events/initSettings.sqf
@@ -3,10 +3,14 @@
     "LIST",
     [LLSTRING(RepetitionMode), LLSTRING(RepetitionModeTooltip)],
     ELSTRING(common,WeaponsCategory),
-    [[0, 1, 2], [
-        [LLSTRING(RepetitionModeOptic), LLSTRING(RepetitionModeOpticTooltip)], // Exit optic view
-        [LLSTRING(RepetitionModeTriggerRelease), LLSTRING(RepetitionModeTriggerReleaseTooltip)], // Stop holding trigger
-        [LLSTRING(RepetitionModeTriggerPress), LLSTRING(RepetitionModeTriggerPressTooltip)] // Click trigger again
-    ], 1],
-    2
+    [
+        [0, 1, 2],
+        [
+            [LLSTRING(RepetitionModeOptic), LLSTRING(RepetitionModeOpticTooltip)], // Exit optic view
+            [LLSTRING(RepetitionModeTriggerRelease), LLSTRING(RepetitionModeTriggerReleaseTooltip)], // Stop holding trigger
+            [LLSTRING(RepetitionModeTriggerPress), LLSTRING(RepetitionModeTriggerPressTooltip)] // Click trigger again
+        ],
+        1
+    ],
+    2 // client setting
 ] call CBA_fnc_addSetting;

--- a/addons/optics/XEH_preInit.sqf
+++ b/addons/optics/XEH_preInit.sqf
@@ -15,7 +15,7 @@ if (!hasInterface) exitWith {};
 QGVAR(pauseOpticLayer) cutText ["", "PLAIN"];
 
 GVAR(camera) = objNull;
-[QGVAR(camera), {!isNull GVAR(camera)}] call CBA_fnc_registerFeatureCamera;
+//[QGVAR(camera), {!isNull GVAR(camera)}] call CBA_fnc_registerFeatureCamera;
 
 // scripted optic data cache
 GVAR(currentOptic) = "";


### PR DESCRIPTION
**When merged this pull request will:**
- add setting to disable disposable launchers
- only if enabled (default) will disposable launcher be replaced with used tube after firing
- only if enabled will disposable launcher magazines in cargo be replaced with loaded disposable launchers
- if disabled, disposable launchers can be reloaded
- tooltips for auto-drop-used-launcher setting
