### PR TITLE
Change getVolume to use visual clipping type

### DIFF
--- a/addons/common/fnc_getVolume.sqf
+++ b/addons/common/fnc_getVolume.sqf
@@ -4,7 +4,8 @@ Function: CBA_fnc_getVolume
 
 Description:
     Return the volume of the bounding box of an object's model.
-    The bounding box is retrieved using boundingBoxReal instead of boundingBox for more precise measurements.
+    The bounding box is retrieved using boundingBoxReal instead of boundingBox
+    with visual clipping type for more precise measurements.
 
 Parameters:
     _object - Object to calculate the volume of <OBJECT>
@@ -24,6 +25,6 @@ SCRIPT(getVolume);
 
 params [["_object", objNull, [objNull]]];
 
-(boundingBoxReal _object) params ["_leftBackBottom", "_rightFrontTop"];
+(0 boundingBoxReal _object) params ["_leftBackBottom", "_rightFrontTop"];
 (_rightFrontTop vectorDiff _leftBackBottom) params ["_width", "_length", "_height"];
 _width * _length * _height


### PR DESCRIPTION
**When merged this pull request will:**
- Change [getVolume](https://cbateam.github.io/CBA_A3/docs/files/common/fnc_getVolume-sqf.html) to use visual instead of general clipping type for [boundingBoxReal](https://community.bistudio.com/wiki/boundingBoxReal).

Arma 3's [1.92 update](https://dev.arma3.com/post/spotrep-00088) changed [boundingBoxReal](https://community.bistudio.com/wiki/boundingBoxReal) so that it can be passed a number for clipping type. Visual clipping type (0) gives more precise measurements when estimating the volume of an object compared to general clipping type (3).

Real bounding boxes with visual and general clipping types are shown below for certain objects (a vehicle, an ammo box, and a building) where the differences are profound. Some objects have almost identical real bounding boxes despite different clipping types (e.g., a Strider has less than 1% difference in volume). Real bounding boxes with visual clipping type are colored in white and those with general clipping type are colored in black.

![Vehicle](https://user-images.githubusercontent.com/10010689/56947149-8aa03900-6b2c-11e9-8ed3-d2b82cb93876.jpg)
_Figure 1_. Real bounding box of a vehicle (I_Truck_02_fuel_F). Visual clipping type: 105.406 m³. General clipping type: 280.191 m³. Difference: ≈38%.

![Ammo box](https://user-images.githubusercontent.com/10010689/56947157-92f87400-6b2c-11e9-95ea-20c016be6fd2.jpg)
_Figure 2_. Real bounding of an ammo box (Box_T_East_Ammo_F). Visual clipping type: 0.171219 m³. General clipping type: 1.37109 m³. Difference: ≈12%.

![Building](https://user-images.githubusercontent.com/10010689/56947162-97249180-6b2c-11e9-984d-76917a0a392b.jpg)
_Figure 3_. Real bounding box of a building (Land_cargo_house_slum_F). Visual clipping type: 69.1653 m³. General clipping type: 174.096 m³. Difference: ≈40%.

There exists two other clipping types: shadow (1) and geometry (2). For the tested objects there were no differences in volume between shadow, geometry, and general clipping types. Regarding performance, there was no noticeable difference between any of the four clipping types. It thus seems motivated to use visual.