### PR TITLE
adds optics hidePeripheralVision config entry

### DIFF
--- a/addons/optics/RscInGameUI.hpp
+++ b/addons/optics/RscInGameUI.hpp
@@ -49,16 +49,16 @@ class RscInGameUI {
         // It will ONLY effect tripple head users, as (safeZoneX == safeZoneXAbs) for everyone else.
         class TrippleHeadLeft: RscText {
             idc = IDC_BLACK_LEFT;
-            x = "safeZoneXAbs";
-            y = "safeZoneY";
-            w = "(safeZoneX - safeZoneXAbs) * ((getResolution select 4)/(16/3))";
-            h = "safeZoneH";
+            x = safezoneXAbs;
+            y = safezoneY;
+            w = THIRD_SCREEN_WIDTH;
+            h = safezoneH;
             colorBackground[] = {0,0,0,1};
         };
 
         class TrippleHeadRight: TrippleHeadLeft {
             idc = IDC_BLACK_RIGHT;
-            x = "safeZoneXAbs + safeZoneWAbs - (safeZoneX - safeZoneXAbs) * ((getResolution select 4)/(16/3))";
+            x = safezoneXAbs + safezoneWAbs - THIRD_SCREEN_WIDTH;
         };
 
         class Magnification: CA_Zeroing {

--- a/addons/optics/XEH_preInit.sqf
+++ b/addons/optics/XEH_preInit.sqf
@@ -33,6 +33,7 @@ GVAR(ppEffects) = [];
 GVAR(manualReticleNightSwitch) = false;
 GVAR(useReticleNight) = false;
 GVAR(reticleSafezoneSize) = RETICLE_SAFEZONE_DEFAULT_SIZE;
+GVAR(hidePeripheralVision) = false;
 
 // Update optic info.
 ["weapon", {

--- a/addons/optics/fnc_loadScriptedOptic.sqf
+++ b/addons/optics/fnc_loadScriptedOptic.sqf
@@ -82,6 +82,19 @@ _ctrlReticleSafezone ctrlSetPosition [
 ];
 _ctrlReticleSafezone ctrlCommit 0;
 
+private _width = THIRD_SCREEN_WIDTH;
+
+if (GVAR(hidePeripheralVision)) then {
+    _width = 0.5 - (_bodyPosition select 2)/2 - safezoneXAbs;
+};
+
+_ctrlBlackLeft ctrlSetPositionW _width;
+_ctrlBlackLeft ctrlCommit 0;
+
+_ctrlBlackRight ctrlSetPositionW _width;
+_ctrlBlackRight ctrlSetPositionX (safezoneXAbs + safezoneWAbs - _width);
+_ctrlBlackRight ctrlCommit 0;
+
 if (_init) then {
     [missionNamespace, "Draw3D", {
         if (isNull _thisArgs) exitWith {

--- a/addons/optics/fnc_updateOpticInfo.sqf
+++ b/addons/optics/fnc_updateOpticInfo.sqf
@@ -81,6 +81,8 @@ if (isNumber (_config >> "reticleSafezoneSize")) then {
     GVAR(reticleSafezoneSize) = getNumber (_config >> "reticleSafezoneSize");
 };
 
+GVAR(hidePeripheralVision) = getNumber (_config >> "hidePeripheralVision") != 0;
+
 // zeroing distances
 configProperties [configFile >> "CfgWeapons" >> _optic >> "ItemInfo" >> "OpticsModes"] findIf {
     GVAR(ZeroingDistances) = getArray (_x >> "discreteDistance");

--- a/addons/optics/script_component.hpp
+++ b/addons/optics/script_component.hpp
@@ -24,6 +24,7 @@
 #define WEAPON_MAGAZINES(unit,weapon) (weaponsItems (unit) select {_x select 0 == (weapon)} param [0, []] select {_x isEqualType []})
 
 #define SOUND_RETICLE_SWITCH ["A3\Sounds_F\arsenal\weapons\UGL\Firemode_ugl",0.31622776,1,5]
+#define THIRD_SCREEN_WIDTH ((safezoneX - safezoneXAbs) * ((getResolution select 4)/(16/3)))
 
 // control ids
 #define IDC_RETICLE 4000


### PR DESCRIPTION
**When merged this pull request will:**
- title
- need this for the Vector IV and probably Spotting Scope in ACE to black out the periphery outside of the scope body texture

Yay for ctrlSetPositionX, Y, W and H.