### PR TITLE
Change descriptionShort of legacy Zafir mags

### DIFF
--- a/addons/jam/CfgMagazines.hpp
+++ b/addons/jam/CfgMagazines.hpp
@@ -1,0 +1,14 @@
+class CfgMagazines {
+    class CA_Magazine;
+    class 150Rnd_762x51_Box: CA_Magazine {
+        descriptionShort = "$STR_CBA_JAM_150rnd_762x51_box_description";
+    };
+
+    class 150Rnd_762x51_Box_Tracer: 150Rnd_762x51_Box {
+        descriptionShort = "$STR_CBA_JAM_150rnd_762x51_box_tracer_description";
+    };
+
+    class 150Rnd_762x54_Box: 150Rnd_762x51_Box {
+        descriptionShort = "$STR_A3_CfgMagazines_150Rnd_762x51_Box_Tracer1"; // Was inherited from 150Rnd_762x51_Box in vanilla
+    };
+};

--- a/addons/jam/config.cpp
+++ b/addons/jam/config.cpp
@@ -16,5 +16,6 @@ class CfgPatches {
     };
 };
 
+#include "CfgMagazines.hpp"
 #include "CfgMagazineWells.hpp"
 #include "CfgWeapons.hpp"

--- a/addons/jam/stringtable.xml
+++ b/addons/jam/stringtable.xml
@@ -10,7 +10,7 @@
             <Japanese>Community Base Addons - 統合的弾倉</Japanese>
         </Key>
         <Key ID="STR_CBA_JAM_150rnd_762x51_box_tracer_description">
-            <Original>Caliber: 7.62x51 mm Tracer - Green&lt;br/&gt;Rounds: 150</Original>
+            <English>Caliber: 7.62x51 mm Tracer - Green&lt;br/&gt;Rounds: 150</English>
             <Chinese>口徑：7.62x51 mm 曳光彈－綠&lt;br/&gt;個數：150</Chinese>
             <French>Calibre : 7,62x51 mm traçant - Vert&lt;br/&gt;Munitions : 150</French>
             <Spanish>Calibre: 7,62x51 mm trazadora (verde)&lt;br/&gt;Cargas: 150</Spanish>
@@ -19,7 +19,6 @@
             <Russian>Калибр: 7,62x51 мм Трассер - зеленый&lt;br/&gt;Количество патронов: 150</Russian>
             <German>Kaliber: 7,62x51 mm Leuchtspur - grün&lt;br/&gt;Patronen: 150</German>
             <Czech>Ráže: 7.62x51 mm stopovky - zelené&lt;br/&gt;Munice: 150</Czech>
-            <English>Caliber: 7.62x51 mm Tracer - Green&lt;br/&gt;Rounds: 150</English>
             <Portuguese>Calibre: Traçante 7,62 x 51 mm – Verde&lt;br/&gt;Balas: 150r</Portuguese>
             <Korean>구경: 7.62x51mm 예광탄 - 녹색&lt;br /&gt;탄 수: 150</Korean>
             <Chinesesimp>口径：7.62x51 毫米曳光弹 - 绿色&lt;br/&gt;容弹量：150</Chinesesimp>
@@ -27,7 +26,7 @@
             <Turkish>Kalibre: 7.62x51 mm İzli - Yeşil&lt;br/&gt;Mermi: 150</Turkish>
         </Key>
         <Key ID="STR_CBA_JAM_150rnd_762x51_box_description">
-            <Original>Caliber: 7.62x51 mm&lt;br/&gt;Rounds: 150</Original>
+            <English>Caliber: 7.62x51 mm&lt;br/&gt;Rounds: 150</English>
             <Chinese>口徑：7.62x51 mm&lt;br/&gt;個數：150</Chinese>
             <French>Calibre : 7,62x51 mm&lt;br/&gt;Munitions : 150</French>
             <Spanish>Calibre: 7,62x51 mm&lt;br/&gt;Cargas: 150</Spanish>
@@ -36,7 +35,6 @@
             <Russian>Калибр: 7,62x51 мм&lt;br/&gt;Количество патронов: 150</Russian>
             <German>Kaliber: 7,62x51 mm&lt;br/&gt;Patronen: 150</German>
             <Czech>Ráže: 7.62x51 mm&lt;br/&gt;Munice: 150</Czech>
-            <English>Caliber: 7.62x51 mm&lt;br/&gt;Rounds: 150</English>
             <Portuguese>Calibre: 7,62 x 51 mm&lt;br/&gt;Balas: 150r</Portuguese>
             <Korean>구경: 7.62x51mm&lt;br /&gt;탄 수: 150</Korean>
             <Chinesesimp>口径：7.62x51 毫米&lt;br/&gt;容弹量：150</Chinesesimp>

--- a/addons/jam/stringtable.xml
+++ b/addons/jam/stringtable.xml
@@ -28,7 +28,7 @@
         </Key>
         <Key ID="STR_CBA_JAM_150rnd_762x51_box_description">
             <Original>Caliber: 7.62x51 mm&lt;br/&gt;Rounds: 150</Original>
-            <Chinese>口徑：7.62x51 mm&lt;br/&gt;個數：150&lt;br /&gt;用於：Zafir</Chinese>
+            <Chinese>口徑：7.62x51 mm&lt;br/&gt;個數：150</Chinese>
             <French>Calibre : 7,62x51 mm&lt;br/&gt;Munitions : 150</French>
             <Spanish>Calibre: 7,62x51 mm&lt;br/&gt;Cargas: 150</Spanish>
             <Italian>Calibro: 7,62x51 mm&lt;br/&gt;Munizioni: 150</Italian>

--- a/addons/jam/stringtable.xml
+++ b/addons/jam/stringtable.xml
@@ -9,5 +9,39 @@
             <Turkish>Community Base Addons - Birleştirilmiş Cephane Şarjörleri</Turkish>
             <Japanese>Community Base Addons - 統合的弾倉</Japanese>
         </Key>
+        <Key ID="STR_CBA_JAM_150rnd_762x51_box_tracer_description">
+            <Original>Caliber: 7.62x51 mm Tracer - Green&lt;br/&gt;Rounds: 150</Original>
+            <Chinese>口徑：7.62x51 mm 曳光彈－綠&lt;br/&gt;個數：150</Chinese>
+            <French>Calibre : 7,62x51 mm traçant - Vert&lt;br/&gt;Munitions : 150</French>
+            <Spanish>Calibre: 7,62x51 mm trazadora (verde)&lt;br/&gt;Cargas: 150</Spanish>
+            <Italian>Calibro: tracciante 7,62x51 mm - verde&lt;br /&gt;Munizioni: 150</Italian>
+            <Polish>Kaliber: 7,62x51 mm smugowy - zielony&lt;br/&gt;Pociski: 150</Polish>
+            <Russian>Калибр: 7,62x51 мм Трассер - зеленый&lt;br/&gt;Количество патронов: 150</Russian>
+            <German>Kaliber: 7,62x51 mm Leuchtspur - grün&lt;br/&gt;Patronen: 150</German>
+            <Czech>Ráže: 7.62x51 mm stopovky - zelené&lt;br/&gt;Munice: 150</Czech>
+            <English>Caliber: 7.62x51 mm Tracer - Green&lt;br/&gt;Rounds: 150</English>
+            <Portuguese>Calibre: Traçante 7,62 x 51 mm – Verde&lt;br/&gt;Balas: 150r</Portuguese>
+            <Korean>구경: 7.62x51mm 예광탄 - 녹색&lt;br /&gt;탄 수: 150</Korean>
+            <Chinesesimp>口径：7.62x51 毫米曳光弹 - 绿色&lt;br/&gt;容弹量：150</Chinesesimp>
+            <Japanese>口径：7.62x51 mm トレーサー - 緑&lt;br/&gt;弾薬：150</Japanese>
+            <Turkish>Kalibre: 7.62x51 mm İzli - Yeşil&lt;br/&gt;Mermi: 150</Turkish>
+        </Key>
+        <Key ID="STR_CBA_JAM_150rnd_762x51_box_description">
+            <Original>Caliber: 7.62x51 mm&lt;br/&gt;Rounds: 150</Original>
+            <Chinese>口徑：7.62x51 mm&lt;br/&gt;個數：150&lt;br /&gt;用於：Zafir</Chinese>
+            <French>Calibre : 7,62x51 mm&lt;br/&gt;Munitions : 150</French>
+            <Spanish>Calibre: 7,62x51 mm&lt;br/&gt;Cargas: 150</Spanish>
+            <Italian>Calibro: 7,62x51 mm&lt;br/&gt;Munizioni: 150</Italian>
+            <Polish>Kaliber: 7,62x51 mm&lt;br/&gt;Pociski: 150</Polish>
+            <Russian>Калибр: 7,62x51 мм&lt;br/&gt;Количество патронов: 150</Russian>
+            <German>Kaliber: 7,62x51 mm&lt;br/&gt;Patronen: 150</German>
+            <Czech>Ráže: 7.62x51 mm&lt;br/&gt;Munice: 150</Czech>
+            <English>Caliber: 7.62x51 mm&lt;br/&gt;Rounds: 150</English>
+            <Portuguese>Calibre: 7,62 x 51 mm&lt;br/&gt;Balas: 150r</Portuguese>
+            <Korean>구경: 7.62x51mm&lt;br /&gt;탄 수: 150</Korean>
+            <Chinesesimp>口径：7.62x51 毫米&lt;br/&gt;容弹量：150</Chinesesimp>
+            <Japanese>口径：7.62x51 mm&lt;br/&gt;弾薬：150</Japanese>
+            <Turkish>Kalibre: 7.62x51 mm&lt;br/&gt;Mermi: 150</Turkish>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- title
- Problem explained here https://github.com/CBATeam/CBA_A3/issues/1147#issuecomment-495294901
- Fixes #1147 

Translations have changed calibre and removed mention that it's used in Zafir (as these mags do not fit anymore).

Should make usage of these mags less confusing to end user when using JAM Magwells.