### PR TITLE
Replace %20 with space when displaying mission name

### DIFF
--- a/addons/ui/CfgEventHandlers.hpp
+++ b/addons/ui/CfgEventHandlers.hpp
@@ -29,6 +29,9 @@ class Extended_DisplayLoad_EventHandlers {
     class RscDisplayRemoteMissions {
         ADDON = QUOTE(_this call (uiNamespace getVariable 'FUNC(initDisplayRemoteMissions)'));
     };
+    class RscDiary {
+        ADDON = QUOTE(_this call (uiNamespace getVariable 'FUNC(initDisplayDiary)'));
+    };
     class Display3DEN {
         ADDON = QUOTE(_this call (uiNamespace getVariable 'FUNC(initDisplay3DEN)'));
     };

--- a/addons/ui/XEH_preStart.sqf
+++ b/addons/ui/XEH_preStart.sqf
@@ -7,6 +7,7 @@ PREP(initDisplayMultiplayerSetup);
 PREP(initDisplayOptionsLayout);
 PREP(initDisplayPassword);
 PREP(initDisplayRemoteMissions);
+PREP(initDisplayDiary);
 PREP(initDisplay3DEN);
 PREP(initDisplayCurator);
 

--- a/addons/ui/fnc_initDisplayDiary.sqf
+++ b/addons/ui/fnc_initDisplayDiary.sqf
@@ -1,0 +1,11 @@
+#include "script_component.hpp"
+
+_this spawn {
+    isNil {
+        params ["_display"];
+
+        private _missionName = _display displayCtrl IDC_DIARY_MISSION_NAME;
+        private _text = [ctrlText _missionName, "%20", " "] call CBA_fnc_replace;
+        _missionName ctrlSetText _text;
+    };
+};

--- a/addons/ui/fnc_initDisplayMultiplayerSetup.sqf
+++ b/addons/ui/fnc_initDisplayMultiplayerSetup.sqf
@@ -42,6 +42,11 @@ private _fnc_update = {
         // value determines which slot is linked to the lb entry
         _playerList lbSetValue [_playerList lbAdd _text, _value];
     };
+
+    // replace %20 with space
+    private _missionName = _display displayCtrl IDC_MPSETUP_NAME;
+    private _text = [ctrlText _missionName, "%20", " "] call (uiNamespace getVariable "CBA_fnc_replace");
+    _missionName ctrlSetText _text;
 };
 
 _display setVariable [QFUNC(update), _fnc_update];

--- a/addons/ui/fnc_initDisplayRemoteMissions.sqf
+++ b/addons/ui/fnc_initDisplayRemoteMissions.sqf
@@ -89,8 +89,10 @@ private _fnc_storeMapMissions = {_this spawn {isNil { // delay a frame
     private _ctrlMissions = _display displayCtrl IDC_SERVER_MISSION;
 
     private _missions = [];
+    private _fnc_replace = uiNamespace getVariable "CBA_fnc_replace";
+
     for "_i" from 0 to (lbSize _ctrlMissions - 1) do {
-        private _name = _ctrlMissions lbText _i;
+        private _name = [_ctrlMissions lbText _i, "%20", " "] call _fnc_replace; // replace %20 with space
         private _value = _ctrlMissions lbValue _i;
         private _data = _ctrlMissions lbData _i;
         private _color = _ctrlMissions lbColor _i;


### PR DESCRIPTION
**When merged this pull request will:**
- Replaces %20 in the mission name with spaces on mission select screen, lobby, briefing and map.
