### PR TITLE
Remove high capacity magwells from mk20

### DIFF
--- a/addons/jam/CfgWeapons.hpp
+++ b/addons/jam/CfgWeapons.hpp
@@ -1,7 +1,7 @@
 class CfgWeapons {
     class Rifle_Base_F;
     class mk20_base_F: Rifle_Base_F {
-        magazineWell[] += {"CBA_556x45_STANAG","CBA_556x45_STANAG_L","CBA_556x45_STANAG_XL","CBA_556x45_STANAG_2D"};
+        magazineWell[] += {"CBA_556x45_STANAG"};
     };
 
     class SDAR_base_F: Rifle_Base_F {


### PR DESCRIPTION
**When merged this pull request will:**
- Remove high capacity magwells from mk20
* The Mk20 is based on the FN F2000.
The F2000 has a very deep magazine well that can't support magazines that are any wider, or which have a different curvature, than a standard 30 magazine.
No coffin magazines fit, no drum mags fit, and even extended stick magazines usually do not fix.
* This has the possibility to break some mission loadouts.

![](https://i.gyazo.com/088ce8e6a0ded9f1c468d107025525db.png)

