### PR TITLE
fix updating flashlight fx after attachment switch

### DIFF
--- a/addons/accessory/fnc_switchAttachment.sqf
+++ b/addons/accessory/fnc_switchAttachment.sqf
@@ -56,15 +56,27 @@ if (!isNil "_switchItem") then {
     switch (_currWeaponType) do {
         case 0: {
             _unit removePrimaryWeaponItem _currItem;
-            [{_this#0 addPrimaryWeaponItem _this#1}, [_unit, _switchItem]] call CBA_fnc_execNextFrame;
+            [{
+                params ["_unit", "", "_switchItem"];
+                _unit addPrimaryWeaponItem _switchItem;
+                ["CBA_attachmentSwitched", _this] call CBA_fnc_localEvent;
+            }, [_unit, _currItem, _switchItem, _currWeaponType]] call CBA_fnc_execNextFrame;
         };
         case 1: {
             _unit removeHandgunItem _currItem;
-            [{_this#0 addHandgunItem _this#1}, [_unit, _switchItem]] call CBA_fnc_execNextFrame;
+            [{
+                params ["_unit", "", "_switchItem"];
+                _unit addHandgunItem _switchItem;
+                ["CBA_attachmentSwitched", _this] call CBA_fnc_localEvent;
+            }, [_unit, _currItem, _switchItem, _currWeaponType]] call CBA_fnc_execNextFrame;
         };
         case 2: {
             _unit removeSecondaryWeaponItem _currItem;
-            [{_this#0 addSecondaryWeaponItem _this#1}, [_unit, _switchItem]] call CBA_fnc_execNextFrame;
+            [{
+                params ["_unit", "", "_switchItem"];
+                _unit addSecondaryWeaponItem _switchItem;
+                ["CBA_attachmentSwitched", _this] call CBA_fnc_localEvent;
+            }, [_unit, _currItem, _switchItem, _currWeaponType]] call CBA_fnc_execNextFrame;
         };
     };
     private _switchItemHintText = getText (__cfgWeapons >> _switchItem >> "MRT_SwitchItemHintText");
@@ -72,7 +84,6 @@ if (!isNil "_switchItem") then {
         hintSilent format ["%1", _switchItemHintText];
     };
     playSound "click";
-    [{["CBA_attachmentSwitched", _this] call CBA_fnc_localEvent}, [_unit, _currItem, _switchItem, _currWeaponType]] call CBA_fnc_execNextFrame;
 } else {
     playSound "ClickSoft";
 };

--- a/addons/accessory/fnc_switchAttachment.sqf
+++ b/addons/accessory/fnc_switchAttachment.sqf
@@ -72,7 +72,7 @@ if (!isNil "_switchItem") then {
         hintSilent format ["%1", _switchItemHintText];
     };
     playSound "click";
-    ["CBA_attachmentSwitched", [_unit, _currItem, _switchItem, _currWeaponType]] call CBA_fnc_localEvent;
+    [{["CBA_attachmentSwitched", _this] call CBA_fnc_localEvent}, [_unit, _currItem, _switchItem, _currWeaponType]] call CBA_fnc_execNextFrame;
 } else {
     playSound "ClickSoft";
 };

--- a/addons/accessory/fnc_switchAttachment.sqf
+++ b/addons/accessory/fnc_switchAttachment.sqf
@@ -56,15 +56,15 @@ if (!isNil "_switchItem") then {
     switch (_currWeaponType) do {
         case 0: {
             _unit removePrimaryWeaponItem _currItem;
-            _unit addPrimaryWeaponItem _switchItem;
+            [{_this#0 addPrimaryWeaponItem _this#1}, [_unit, _switchItem]] call CBA_fnc_execNextFrame;
         };
         case 1: {
             _unit removeHandgunItem _currItem;
-            _unit addHandgunItem _switchItem;
+            [{_this#0 addHandgunItem _this#1}, [_unit, _switchItem]] call CBA_fnc_execNextFrame;
         };
         case 2: {
             _unit removeSecondaryWeaponItem _currItem;
-            _unit addSecondaryWeaponItem _switchItem;
+            [{_this#0 addSecondaryWeaponItem _this#1}, [_unit, _switchItem]] call CBA_fnc_execNextFrame;
         };
     };
     private _switchItemHintText = getText (__cfgWeapons >> _switchItem >> "MRT_SwitchItemHintText");


### PR DESCRIPTION
**When merged this pull request will:**
- Move adding of next attachment to next frame
- Move switched localEvent to next frame (after add**Item)
- Allows different flashlight modes to be used and update properly when switching
- Currently switching from one flashlight to another in the same frame whilst the flashlight is on causes the light effect not to update to the new flashlight

