### PR TITLE
update CBA_fnc_uniqueUnitItems

### DIFF
--- a/addons/common/fnc_uniqueUnitItems.sqf
+++ b/addons/common/fnc_uniqueUnitItems.sqf
@@ -54,8 +54,7 @@ if (_weaponItems) then {
     _allItems append [
         primaryWeapon _unit,
         secondaryWeapon _unit,
-        handgunWeapon _unit,
-        binocular _unit
+        handgunWeapon _unit // binocular covered by assignedItems
     ];
 
     _allItems append primaryWeaponItems _unit;

--- a/addons/common/fnc_uniqueUnitItems.sqf
+++ b/addons/common/fnc_uniqueUnitItems.sqf
@@ -8,10 +8,11 @@ Description:
 Parameters:
     _unit           - Unit to retrieve the items from
     _weaponItems    - Include weapons, attachments, loaded magazines (Default: false)
-    _backpack       - Include items in backpack (Default: true)
-    _vest           - Include items in vest     (Default: true)
-    _uniform        - Include items in uniform  (Default: true)
-    _assignedItems  - Include assigned items    (Default: true)
+    _backpack       - Include items in backpack    (Default: true)
+    _vest           - Include items in vest        (Default: true)
+    _uniform        - Include items in uniform     (Default: true)
+    _assignedItems  - Include assigned items       (Default: true)
+    _magazines      - Include not loaded magazines (Default: false)
 
 Example:
     (begin example)
@@ -22,28 +23,67 @@ Returns:
     Array of item classnames <ARRAY>
 
 Author:
-    Dedmen
+    Dedmen, commy2
 ---------------------------------------------------------------------------- */
-SCRIPT(uniqueUnitItems);
 
-params [["_unit", objNull, [objNull]], ["_weaponItems", false, [true]], ["_backpack", true, [true]], ["_vest", true, [true]], ["_uniform", true, [true]], ["_assignedItems", true, [true]]];
+params [
+    ["_unit", objNull, [objNull]],
+    ["_weaponItems", false, [false]],
+    ["_backpack", true, [false]],
+    ["_vest", true, [false]],
+    ["_uniform", true, [false]],
+    ["_assignedItems", true, [false]],
+    ["_magazines", false, [false]]
+];
 
 private _allItems = if (_assignedItems) then {assignedItems _unit} else {[]};
-if (_uniform) then {_allItems append ((getItemCargo (uniformContainer _unit)) select 0)};
-if (_vest) then {_allItems append ((getItemCargo (vestContainer _unit)) select 0)};
-if (_backpack) then {_allItems append ((getItemCargo (backpackContainer _unit)) select 0)};
+
+if (_uniform) then {
+    _allItems append (getItemCargo uniformContainer _unit select 0);
+};
+
+if (_vest) then {
+    _allItems append (getItemCargo vestContainer _unit select 0);
+};
+
+if (_backpack) then {
+    _allItems append (getItemCargo backpackContainer _unit select 0);
+};
 
 if (_weaponItems) then {
-    _allItems append (primaryWeaponItems _unit);
-    _allItems append (secondaryWeaponItems _unit);
-    _allItems append (handgunItems _unit);
-    _allItems append (primaryWeaponMagazine _unit);
-    _allItems append (secondaryWeaponMagazine _unit);
-    _allItems append (handgunMagazine _unit);
     _allItems append [
-        primaryWeapon _unit, secondaryWeapon _unit, handgunWeapon _unit
-     ];
-     _allItems pushBack (_unit call CBA_fnc_binocularMagazine);
+        primaryWeapon _unit,
+        secondaryWeapon _unit,
+        handgunWeapon _unit,
+        binocular _unit
+    ];
+
+    _allItems append primaryWeaponItems _unit;
+    _allItems append secondaryWeaponItems _unit;
+    _allItems append handgunItems _unit;
+
+    if (_magazines) then {
+        _allItems append primaryWeaponMagazine _unit;
+        _allItems append secondaryWeaponMagazine _unit;
+        _allItems append handgunMagazine _unit;
+        _allItems pushBack (_unit call CBA_fnc_binocularMagazine);
+    };
+
+    _allItems = _allItems - [""];
+};
+
+if (_magazines) then {
+    if (_uniform) then {
+        _allItems append (getMagazineCargo uniformContainer _unit select 0);
+    };
+
+    if (_vest) then {
+        _allItems append (getMagazineCargo vestContainer _unit select 0);
+    };
+
+    if (_backpack) then {
+        _allItems append (getMagazineCargo backpackContainer _unit select 0);
+    };
 };
 
 _allItems arrayIntersect _allItems //Remove duplicates


### PR DESCRIPTION
**When merged this pull request will:**
- close #1156
- added `_magazines` flag, default false. Unless set to true, no mags will be reported (even with `_weaponItems` set to true)
- `_magazines` flag will not report *loaded* mags unless `_weaponItems` flag is also set to true.
- added note why `binocular` command is not needed (covered by `assignedItems`)
- no longer reports empty string
- formatting