### PR TITLE
check masses of items of disposable framework

### DIFF
--- a/addons/disposable/XEH_preInit.sqf
+++ b/addons/disposable/XEH_preInit.sqf
@@ -47,6 +47,23 @@ private _cfgMagazines = configFile >> "CfgMagazines";
     if (GVAR(magazines) pushBackUnique _magazine != -1) then {
         GVAR(MagazineLaunchers) setVariable [_magazine, _loadedLauncher];
     };
+
+    // check if mass entries add up
+    private _massLauncher = getNumber (_cfgWeapons >> _launcher >> "WeaponSlotsInfo" >> "mass");
+    private _massMagazine = getNumber (_cfgMagazines >> _magazine >> "mass");
+    private _massLoadedLauncher = getNumber (_cfgWeapons >> _loadedLauncher >> "WeaponSlotsInfo" >> "mass");
+    private _massUsedLauncher = getNumber (_cfgWeapons >> _usedLauncher >> "WeaponSlotsInfo" >> "mass");
+
+    if (_massLauncher != _massUsedLauncher) then {
+        WARNING_4("Mass of launcher %1 (%2) is different from mass of used launcher %3 (%4).", _launcher, _massLauncher, _usedLauncher, _massUsedLauncher);
+    };
+
+    if (_massLauncher + _massMagazine != _massLoadedLauncher) then {
+        WARNING_7("Sum of mass of launcher %1 and mass of magazine %2 (%3+%4=%5) is different from mass of loaded launcher %6 (%7).",
+            _launcher, _magazine, _massLauncher, _massMagazine, _massLauncher + _massMagazine,
+            _loadedLauncher, _massLoadedLauncher
+        );
+    };
 } forEach configProperties [configFile >> "CBA_DisposableLaunchers", "isArray _x"];
 
 ["CBA_settingsInitialized", {


### PR DESCRIPTION
**When merged this pull request will:**
- title

Example:
```sqf
13:39:53 [CBA] (disposable) WARNING: Mass of launcher BWA3_PzF3 (314.6) is different from mass of used launcher BWA3_PzF3_Used (220). x\cba\addons\disposable\XEH_preInit.sqf:58
13:39:53 [CBA] (disposable) WARNING: Sum of mass of launcher BWA3_PzF3 and mass of magazine BWA3_PzF3_Tandem (314.6+94.6=409.2) is different from mass of loaded launcher BWA3_PzF3_Tandem_Loaded (120). x\cba\addons\disposable\XEH_preInit.sqf:65
```