### PR TITLE
update scripted optics effect radblur classes

### DIFF
--- a/addons/optics/CfgOpticsEffect.hpp
+++ b/addons/optics/CfgOpticsEffect.hpp
@@ -1,7 +1,17 @@
 class CfgOpticsEffect {
     class CBA_OpticsRadBlur1 {
         type = "radialblur";
-        params[] = {0.015,0,0.14,0.2};
+        params[] = {0.005,0.005,0.20,0.20*16/9};
+        priority = 950;
+    };
+    class CBA_OpticsRadBlur2 {
+        type = "radialblur";
+        params[] = {0.01,0.01,0.20,0.20*16/9};
+        priority = 950;
+    };
+    class CBA_OpticsRadBlur3 {
+        type = "radialblur";
+        params[] = {0.015,0.015,0.20,0.20*16/9};
         priority = 950;
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- title

CBA_OpticsRadBlur1 weak
CBA_OpticsRadBlur2 medium
CBA_OpticsRadBlur3 strong

Radius of effect so it matches standard optic size.

Names are taken from OpticsBlur1, OpticsBlur2, OpticsBlur3 etc, which follow the same weak/medium/strong pattern.