### PR TITLE
Update loadorder for 1.94 Contact DLC

### DIFF
--- a/addons/common/config.cpp
+++ b/addons/common/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"A3_Data_F_Tank_Loadorder"};
+        requiredAddons[] = {"A3_Data_F_Enoch_Loadorder"};
         version = VERSION;
         authors[] = {"Spooner","Sickboy","Rocko"};
     };

--- a/addons/common/config.cpp
+++ b/addons/common/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"A3_Data_F_Enoch_Loadorder"};
+        requiredAddons[] = {"A3_Data_F_Enoch_Loadorder", "A3_Data_F_Mod_Loadorder"};
         version = VERSION;
         authors[] = {"Spooner","Sickboy","Rocko"};
     };

--- a/addons/main/script_mod.hpp
+++ b/addons/main/script_mod.hpp
@@ -9,7 +9,7 @@
 #define VERSION_AR MAJOR,MINOR,PATCHLVL,BUILD
 
 // MINIMAL required version for the Mod. Components can specify others..
-#define REQUIRED_VERSION 1.92
+#define REQUIRED_VERSION 1.94
 
 /*
 // Defined DEBUG_MODE_NORMAL in a few CBA_fncs to prevent looped logging :)


### PR DESCRIPTION
Update our requiredAddons to include all of Contact DLC.
Don't merge before 1.94.
