### PR TITLE
Accessiblity - Allow changing marker colors

### DIFF
--- a/addons/accessiblity/$PBOPREFIX$
+++ b/addons/accessiblity/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\cba\addons\accessiblity

--- a/addons/accessiblity/CfgEventhandlers.hpp
+++ b/addons/accessiblity/CfgEventhandlers.hpp
@@ -1,0 +1,5 @@
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};

--- a/addons/accessiblity/CfgMarkerColors.hpp
+++ b/addons/accessiblity/CfgMarkerColors.hpp
@@ -1,0 +1,14 @@
+#define GET_COLOR(index,varName,defaultR,defaultG,defaultB) QUOTE((missionNamespace getVariable [ARR_2(QQGVAR(varName), [ARR_3(defaultR,defaultG,defaultB)])]) select index)
+
+class CfgMarkerColors {
+    class Default;
+    class ColorRed: Default {
+        color[] = {GET_COLOR(0,red,1,0,0), GET_COLOR(1,red,1,0,0), GET_COLOR(2,red,1,0,0), 1};
+    };
+    class ColorGreen: Default {
+        color[] = {GET_COLOR(0,green,0,1,0), GET_COLOR(1,green,0,1,0), GET_COLOR(2,green,0,1,0), 1};
+    };
+    class ColorBlue: Default {
+        color[] = {GET_COLOR(0,blue,0,0,1), GET_COLOR(1,blue,0,0,1), GET_COLOR(2,blue,0,0,1), 1};
+    };
+};

--- a/addons/accessiblity/XEH_preInit.sqf
+++ b/addons/accessiblity/XEH_preInit.sqf
@@ -1,0 +1,7 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+#include "initSettings.sqf"
+
+ADDON = true;

--- a/addons/accessiblity/config.cpp
+++ b/addons/accessiblity/config.cpp
@@ -1,0 +1,17 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        author = "$STR_CBA_Author";
+        name = CSTRING(component);
+        url = "$STR_CBA_URL";
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"cba_settings"};
+        version = VERSION;
+    };
+};
+
+#include "CfgEventhandlers.hpp"
+#include "CfgMarkerColors.hpp"

--- a/addons/accessiblity/initSettings.sqf
+++ b/addons/accessiblity/initSettings.sqf
@@ -1,0 +1,26 @@
+[
+QGVAR(red), "COLOR",
+["str_team_red"],
+["CBA Accessiblity"],
+[0.9, 0, 0, 1],
+2, // setting can't be overwritten
+{TRACE_1("red",_this);}
+] call CBA_settings_fnc_init;
+
+[
+QGVAR(blue), "COLOR",
+["str_team_blue"],
+["CBA Accessiblity"],
+[0, 0, 1, 1],
+2, // setting can't be overwritten
+{TRACE_1("blue",_this);}
+] call CBA_settings_fnc_init;
+
+[
+QGVAR(green), "COLOR",
+["str_team_green"],
+["CBA Accessiblity"],
+[0, 0.8, 0, 1],
+2, // setting can't be overwritten
+{TRACE_1("green",_this);}
+] call CBA_settings_fnc_init;

--- a/addons/accessiblity/script_component.hpp
+++ b/addons/accessiblity/script_component.hpp
@@ -1,0 +1,14 @@
+#define COMPONENT accessiblity
+#include "\x\cba\addons\main\script_mod.hpp"
+
+#define DEBUG_MODE_FULL
+
+#ifdef DEBUG_ENABLED_ACCESSIBLITY
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_HELP
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_ACCESSIBLITY
+#endif
+
+#include "\x\cba\addons\main\script_macros.hpp"

--- a/addons/accessiblity/stringtable.xml
+++ b/addons/accessiblity/stringtable.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project name="CBA_A3">
+    <Package name="accessiblity">
+    </Package>
+</Project>


### PR DESCRIPTION
Just proof of concept right now
allows changing lines/marker color for people with color problems
requires mission restart

Colors also usable by other mods?
I had been thinking of ace_nametags but those colors are different from map colors
and sthud and diwako_dui both already have good color options