### PR TITLE
Notify - Skippable parameter, Lifetime Setting, Use in Accessory component

### DIFF
--- a/addons/accessory/fnc_switchAttachment.sqf
+++ b/addons/accessory/fnc_switchAttachment.sqf
@@ -36,7 +36,7 @@ private _currWeaponType = call {
     _currItem = "";
     -1
 };
-if (_currWeaponType < 0) exitWith {hint "You are not holding a weapon!"; false};
+if (_currWeaponType < 0) exitWith { false };
 
 #define __cfgWeapons configfile >> "CfgWeapons"
 #define __currItem __cfgWeapons >> _currItem
@@ -68,8 +68,9 @@ if (!isNil "_switchItem") then {
         };
     };
     private _switchItemHintText = getText (__cfgWeapons >> _switchItem >> "MRT_SwitchItemHintText");
+    private _switchItemHintImage = getText (__cfgWeapons >> _switchItem >> "picture");
     if !(_switchItemHintText isEqualTo "") then {
-        hintSilent format ["%1", _switchItemHintText];
+        [[_switchItemHintImage], [_switchItemHintText], true] call CBA_fnc_notify;
     };
     playSound "click";
     ["CBA_attachmentSwitched", [_unit, _currItem, _switchItem, _currWeaponType]] call CBA_fnc_localEvent;

--- a/addons/accessory/fnc_switchAttachment.sqf
+++ b/addons/accessory/fnc_switchAttachment.sqf
@@ -70,7 +70,7 @@ if (!isNil "_switchItem") then {
     private _switchItemHintText = getText (__cfgWeapons >> _switchItem >> "MRT_SwitchItemHintText");
     private _switchItemHintImage = getText (__cfgWeapons >> _switchItem >> "picture");
     if !(_switchItemHintText isEqualTo "") then {
-        [[_switchItemHintImage], [_switchItemHintText], true] call CBA_fnc_notify;
+        [[_switchItemHintImage, 2.0], [_switchItemHintText], true] call CBA_fnc_notify;
     };
     playSound "click";
     ["CBA_attachmentSwitched", [_unit, _currItem, _switchItem, _currWeaponType]] call CBA_fnc_localEvent;

--- a/addons/ui/XEH_preInit.sqf
+++ b/addons/ui/XEH_preInit.sqf
@@ -1,24 +1,8 @@
 #include "script_component.hpp"
 
-[
-    QGVAR(StorePasswords), "LIST",
-    [LLSTRING(StoreServerPasswords), LLSTRING(StoreServerPasswordsTooltip)],
-    LLSTRING(Category),
-    [[1, 0, -1], [
-        [LLSTRING(SavePasswords), LLSTRING(SavePasswordsTooltip)],
-        [LLSTRING(DoNotSavePasswords), LLSTRING(DoNotSavePasswordsTooltip)],
-        [LLSTRING(DeletePasswords), LLSTRING(DeletePasswordsTooltip)]
-    ], 0],
-    2,
-    {
-        if (_this isEqualTo -1) then {
-            profileNamespace setVariable [QGVAR(ServerPasswords), nil];
-        };
+ADDON = false;
 
-        profileNamespace setVariable [QGVAR(StorePasswords), _this];
-        saveProfileNamespace;
-    }
-] call cba_settings_fnc_init;
+#include "initSettings.sqf"
 
 if (hasInterface) then {
     call COMPILE_FILE(flexiMenu\init);
@@ -46,3 +30,5 @@ FUNC(menuShortcut) = CBA_fnc_flexiMenu_menuShortcut;
 FUNC(mouseButtonDown) = CBA_fnc_flexiMenu_mouseButtonDown;
 FUNC(highlightCaretKey) = CBA_fnc_flexiMenu_highlightCaretKey;
 FUNC(execute) = CBA_fnc_flexiMenu_execute;
+
+ADDON = true;

--- a/addons/ui/fnc_notify.sqf
+++ b/addons/ui/fnc_notify.sqf
@@ -35,7 +35,6 @@ params [
     ["_lifetime", 4, [0]]
 ];
 
-#define LIFE_TIME _lifetime
 #define FADE_IN_TIME 0.2
 #define FADE_OUT_TIME 1
 
@@ -177,7 +176,7 @@ private _fnc_processQueue = {
                 _x ctrlCommit (FADE_OUT_TIME);
             } forEach _controls;
         };
-    }, [_controls, _fnc_processQueue], LIFE_TIME] call CBA_fnc_waitAndExecute;
+    }, [_controls, _fnc_processQueue], _lifetime] call CBA_fnc_waitAndExecute;
 };
 
 if (count GVAR(notifyQueue) isEqualTo 1) then {

--- a/addons/ui/fnc_notify.sqf
+++ b/addons/ui/fnc_notify.sqf
@@ -85,7 +85,7 @@ if (_queue) then {
     // if queue param is true add the notify to the queue
     GVAR(notifyQueue) pushBack _composition;
 } else {
-    // otherwise resete the queue to force show the notify
+    // otherwise reset the queue to force show the notify
     GVAR(notifyQueue) = [];
 };
 

--- a/addons/ui/fnc_notify.sqf
+++ b/addons/ui/fnc_notify.sqf
@@ -14,10 +14,11 @@ Parameters:
             _text  - STRING, NUMBER: Text to display or path to .paa or .jpg image.
             _size  - NUMBER: Text or image size multiplier, optional, default: 1
             _color - ARRAY: RGB or RGBA color (range 0-1), optional, default: [1,1,1,1]
+    _queue  - BOOL: Defines if the notify will be queued or force shown, optional, default: true (queued)
 
 Examples:
     (begin example)
-        ["Banana", 1.5, [1, 1, 0, 1]] call CBA_fnc_notify;
+        [["Banana", 1.5, [1, 1, 0, 1]], false] call CBA_fnc_notify;
     (end)
 
 Returns:
@@ -26,6 +27,11 @@ Returns:
 Authors:
     commy2
 ---------------------------------------------------------------------------- */
+
+params [
+    ["_content", [], [[]]],
+    ["_queue", true, [false]]
+];
 
 #define LIFE_TIME 4
 #define FADE_IN_TIME 0.2
@@ -36,15 +42,6 @@ if (canSuspend) exitWith {
 };
 
 if (!hasInterface) exitWith {};
-
-// compose structured text
-if !(_this isEqualType []) then {
-    _this = [_this];
-};
-
-if !(_this select 0 isEqualType []) then {
-    _this = [_this];
-};
 
 private _composition = [];
 
@@ -73,7 +70,7 @@ private _composition = [];
     } else {
         _composition pushBack parseText format ["<t align='center' size='%2' color='%3'>%1</t>", _text, _size, _color];
     };
-} forEach _this;
+} forEach _content;
 
 _composition deleteAt 0;
 
@@ -82,7 +79,13 @@ if (isNil QGVAR(notifyQueue)) then {
     GVAR(notifyQueue) = [];
 };
 
-GVAR(notifyQueue) pushBack _composition;
+if (_queue) then {
+    // if queue param is true add the notify to the queue
+    GVAR(notifyQueue) pushBack _composition;
+} else {
+    // otherwise resete the queue to force show the notify
+    GVAR(notifyQueue) = [];
+};
 
 private _fnc_processQueue = {
     private _composition = _this;

--- a/addons/ui/fnc_notify.sqf
+++ b/addons/ui/fnc_notify.sqf
@@ -20,7 +20,7 @@ Examples:
     (begin example)
         "Banana" call CBA_fnc_notify;
         ["Banana", 1.5, [1, 1, 0, 1]] call CBA_fnc_notify;
-        [["Banana", 1.5, [1, 1, 0, 1]], false] call CBA_fnc_notify;
+        [["Banana", 1.5, [1, 1, 0, 1]], ["Not Apple"], true] call CBA_fnc_notify;
     (end)
 
 Returns:
@@ -30,11 +30,8 @@ Authors:
     commy2
 ---------------------------------------------------------------------------- */
 
-#define LIFE_TIME 4
 #define FADE_IN_TIME 0.2
 #define FADE_OUT_TIME 1
-
-params ["_content", ["_skippable", false, [false]]];
 
 if (canSuspend) exitWith {
     [CBA_fnc_notify, _this] call CBA_fnc_directCall;
@@ -43,17 +40,25 @@ if (canSuspend) exitWith {
 if (!hasInterface) exitWith {};
 
 // compose structured text
-if !(_content isEqualType []) then {
-    _content = [_content];
+if !(_this isEqualType []) then {
+    _this = [_this];
 };
 
-if !(_content select 0 isEqualType []) then {
-    _content = [_content];
+if !(_this select 0 isEqualType []) then {
+    _this = [_this];
 };
 
 private _composition = [];
+private _skippable = false;
 
 {
+    // Additional arguments at the end
+    if (_x isEqualType true) exitWith {
+        TRACE_1("Skippable argument",_x);
+        _skippable = _x;
+    };
+
+    // Line
     _composition pushBack lineBreak;
 
     _x params [["_text", "", ["", 0]], ["_size", 1, [0]], ["_color", [], [[]], [3,4]]];
@@ -78,7 +83,7 @@ private _composition = [];
     } else {
         _composition pushBack parseText format ["<t align='center' size='%2' color='%3'>%1</t>", _text, _size, _color];
     };
-} forEach _content;
+} forEach _this;
 
 _composition deleteAt 0;
 
@@ -190,7 +195,7 @@ private _fnc_processQueue = {
         LOG("Skipped queue process");
         params ["_fnc_popQueue", "_controls", "_fnc_processQueue"];
         [_controls, _fnc_processQueue] call _fnc_popQueue;
-    }, [_fnc_popQueue, _controls, _fnc_processQueue, _skippable], LIFE_TIME, {
+    }, [_fnc_popQueue, _controls, _fnc_processQueue, _skippable], GVAR(notifyLifetime), {
         // Normally move to next notification
         LOG("Normal queue process");
         params ["_fnc_popQueue", "_controls", "_fnc_processQueue"];

--- a/addons/ui/fnc_notify.sqf
+++ b/addons/ui/fnc_notify.sqf
@@ -6,15 +6,16 @@ Description:
     Display a text message. Multiple incoming messages are queued.
 
 Parameters:
-    _content - ARRAY
-        _line1 - ARRAY
-        _line2 - ARRAY
+    _content    - ARRAY
+        _line1      - ARRAY
+        _line2      - ARRAY
         ...
-        _lineN - ARRAY
-            _text  - STRING, NUMBER: Text to display or path to .paa or .jpg image.
-            _size  - NUMBER: Text or image size multiplier, optional, default: 1
-            _color - ARRAY: RGB or RGBA color (range 0-1), optional, default: [1,1,1,1]
-    _queue  - BOOL: Defines if the notify will be queued or force shown, optional, default: true (queued)
+        _lineN      - ARRAY
+            _text       - STRING, NUMBER: Text to display or path to .paa or .jpg image.
+            _size       - NUMBER: Text or image size multiplier, optional, default: 1
+            _color      - ARRAY: RGB or RGBA color (range 0-1), optional, default: [1,1,1,1]
+    _queue      - BOOL: Defines if the notify will be queued or force shown, optional, default: true (queued)
+    _lifetime   - NUMBER: Defines the lifetime of the notify, optional, default: 4
 
 Examples:
     (begin example)
@@ -30,10 +31,11 @@ Authors:
 
 params [
     ["_content", [], [[]]],
-    ["_queue", true, [false]]
+    ["_queue", true, [false]],
+    ["_lifetime", 4, [0]]
 ];
 
-#define LIFE_TIME 4
+#define LIFE_TIME _lifetime
 #define FADE_IN_TIME 0.2
 #define FADE_OUT_TIME 1
 

--- a/addons/ui/initSettings.sqf
+++ b/addons/ui/initSettings.sqf
@@ -16,7 +16,7 @@
         profileNamespace setVariable [QGVAR(StorePasswords), _this];
         saveProfileNamespace;
     }
-] call cba_settings_fnc_init;
+] call CBA_fnc_addSetting;
 
 [
     QGVAR(notifyLifetime),

--- a/addons/ui/initSettings.sqf
+++ b/addons/ui/initSettings.sqf
@@ -1,0 +1,28 @@
+[
+    QGVAR(StorePasswords), "LIST",
+    [LLSTRING(StoreServerPasswords), LLSTRING(StoreServerPasswordsTooltip)],
+    LLSTRING(Category),
+    [[1, 0, -1], [
+        [LLSTRING(SavePasswords), LLSTRING(SavePasswordsTooltip)],
+        [LLSTRING(DoNotSavePasswords), LLSTRING(DoNotSavePasswordsTooltip)],
+        [LLSTRING(DeletePasswords), LLSTRING(DeletePasswordsTooltip)]
+    ], 0],
+    2,
+    {
+        if (_this isEqualTo -1) then {
+            profileNamespace setVariable [QGVAR(ServerPasswords), nil];
+        };
+
+        profileNamespace setVariable [QGVAR(StorePasswords), _this];
+        saveProfileNamespace;
+    }
+] call cba_settings_fnc_init;
+
+[
+    QGVAR(notifyLifetime),
+    "SLIDER",
+    [LLSTRING(NotifyLifetime), LLSTRING(NotifyLifetimeTooltip)],
+    LLSTRING(Category),
+    [1, 10, 4, 1], // default value
+    2 // global
+] call CBA_fnc_addSetting;

--- a/addons/ui/script_component.hpp
+++ b/addons/ui/script_component.hpp
@@ -1,9 +1,9 @@
-﻿#define COMPONENT ui
+#define COMPONENT ui
 #include "\x\cba\addons\main\script_mod.hpp"
 
-//#define DEBUG_MODE_FULL
-//#define DISABLE_COMPILE_CACHE
-//#define DEBUG_ENABLED_UI
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define DEBUG_ENABLED_UI
 
 #ifdef DEBUG_ENABLED_UI
     #define DEBUG_MODE_FULL

--- a/addons/ui/stringtable.xml
+++ b/addons/ui/stringtable.xml
@@ -145,5 +145,11 @@
             <Polish>Pokaż własne/wgrane misje</Polish>
             <Italian>Mostra missioni custom</Italian>
         </Key>
+        <Key ID="STR_CBA_Ui_NotifyLifetime">
+            <English>Notification Lifetime</English>
+        </Key>
+        <Key ID="STR_CBA_Ui_NotifyLifetimeTooltip">
+            <English>Notification display duration in seconds.</English>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Replace #1146 
- Add Notify `_skippable` parameter, making the notification get immediately replaced if another enters queue
  - Uses `CBA_fnc_waitAndExecute` as before for non-skippable (default) notifications
  - Uses `CBA_fnc_waitUntilAndExecute` for skippable notifications, checks if any new notification entered, moves directly to it, otherwise fades it away after timeout (lifetime)
- Add Notify "Notification Lifetime" setting
  - Move UI settings to own file
  - Use `CBA_fnc_addSetting` for "Store Passwords" setting
- Use Notify in Accessory component - close #1167 
  - Add attachment image (config entry `"picture"`) display
  - Remove Accessory "no weapon in hands" hint/notification

https://i.imgur.com/g40d4df.gifv