### PR TITLE
Scripted optics updates

### DIFF
--- a/addons/optics/XEH_preInit.sqf
+++ b/addons/optics/XEH_preInit.sqf
@@ -35,6 +35,7 @@ GVAR(useReticleNight) = false;
 GVAR(reticleSafezoneSize) = RETICLE_SAFEZONE_DEFAULT_SIZE;
 GVAR(hidePeripheralVision) = false;
 GVAR(hideMagnification) = false;
+GVAR(disableTilt) = false;
 
 // Update optic info.
 ["weapon", {

--- a/addons/optics/XEH_preInit.sqf
+++ b/addons/optics/XEH_preInit.sqf
@@ -46,6 +46,7 @@ GVAR(disableTilt) = false;
 ["loadout", {
     params ["_unit"];
     _unit call FUNC(updateOpticInfo);
+    _unit call FUNC(changePIPOpticClass);
     _unit call FUNC(changeCarryHandleOpticClass);
 }] call CBA_fnc_addPlayerEventHandler;
 

--- a/addons/optics/XEH_preInit.sqf
+++ b/addons/optics/XEH_preInit.sqf
@@ -34,6 +34,7 @@ GVAR(manualReticleNightSwitch) = false;
 GVAR(useReticleNight) = false;
 GVAR(reticleSafezoneSize) = RETICLE_SAFEZONE_DEFAULT_SIZE;
 GVAR(hidePeripheralVision) = false;
+GVAR(hideMagnification) = false;
 
 // Update optic info.
 ["weapon", {

--- a/addons/optics/fnc_animateScriptedOptic.sqf
+++ b/addons/optics/fnc_animateScriptedOptic.sqf
@@ -116,7 +116,13 @@ _ctrlBody ctrlSetTextColor [1,1,1,_dayOpacity];
 _ctrlBodyNight ctrlSetTextColor [1,1,1,_nightOpacity];
 _ctrlBlackScope ctrlShow (GVAR(usePipOptics) && !isPipEnabled);
 
-private _bank = call FUNC(gunBank);
+// tilt while leaning
+private _bank = 0;
+
+if (!GVAR(disableTilt)) then {
+    _bank = call FUNC(gunBank);
+};
+
 _ctrlReticle ctrlSetAngle [_bank, 0.5, 0.5];
 _ctrlBody ctrlSetAngle [_bank, 0.5, 0.5];
 _ctrlBodyNight ctrlSetAngle [_bank, 0.5, 0.5];

--- a/addons/optics/fnc_animateScriptedOptic.sqf
+++ b/addons/optics/fnc_animateScriptedOptic.sqf
@@ -78,7 +78,7 @@ _ctrlMagnification ctrlSetText format [
     [_zoom, 1, 1] call CBA_fnc_formatNumber
 ];
 
-_ctrlMagnification ctrlShow (_zoom >= 1);
+_ctrlMagnification ctrlShow (_zoom >= 1 && {!GVAR(hideMagnification)});
 
 private _positionMagnification = ctrlPosition _ctrlZeroing;
 _positionMagnification set [0, _positionMagnification#0 + ctrlTextWidth _ctrlZeroing];

--- a/addons/optics/fnc_updateOpticInfo.sqf
+++ b/addons/optics/fnc_updateOpticInfo.sqf
@@ -112,6 +112,7 @@ GVAR(ppEffects) = getArray (_config >> "opticsPPEffects") apply {
 };
 
 GVAR(hideMagnification) = getNumber (_config >> "hideMagnification") != 0;
+GVAR(disableTilt) = getNumber (_config >> "disableTilt") != 0;
 
 [uiNamespace getVariable QGVAR(ScriptedOpticDisplay), false] call FUNC(loadScriptedOptic);
 

--- a/addons/optics/fnc_updateOpticInfo.sqf
+++ b/addons/optics/fnc_updateOpticInfo.sqf
@@ -23,7 +23,7 @@ Author:
 params ["_unit"];
 
 // Update scripted optic cache.
-private _optic = _unit call FUNC(currentOptic);systemChat str [_optic, diag_frameNo];
+private _optic = _unit call FUNC(currentOptic);
 if (_optic isEqualTo GVAR(currentOptic)) exitWith {};
 GVAR(currentOptic) = _optic;
 

--- a/addons/optics/fnc_updateOpticInfo.sqf
+++ b/addons/optics/fnc_updateOpticInfo.sqf
@@ -23,7 +23,7 @@ Author:
 params ["_unit"];
 
 // Update scripted optic cache.
-private _optic = _unit call FUNC(currentOptic);
+private _optic = _unit call FUNC(currentOptic);systemChat str [_optic, diag_frameNo];
 if (_optic isEqualTo GVAR(currentOptic)) exitWith {};
 GVAR(currentOptic) = _optic;
 
@@ -110,6 +110,8 @@ GVAR(ppEffects) = getArray (_config >> "opticsPPEffects") apply {
     _ppEffect ppEffectCommit 0;
     _ppEffect
 };
+
+GVAR(hideMagnification) = getNumber (_config >> "hideMagnification") != 0;
 
 [uiNamespace getVariable QGVAR(ScriptedOpticDisplay), false] call FUNC(loadScriptedOptic);
 


### PR DESCRIPTION
**When merged this pull request will:**
- ADDED: `hideMagnification` parameter for scripted optics (#1176) __commy2__
- ADDED: `disableTilt` parameter for scripted optics (#1176) __commy2__
- FIXED: PIP camera not updated when changing optics while in optics view (#1176) __commy2__