### PR TITLE
Add magwells for SCAR rifle magazines when EGLM is mounted

### DIFF
--- a/addons/jam/magwells_556x45.hpp
+++ b/addons/jam/magwells_556x45.hpp
@@ -16,6 +16,7 @@
 
     class CBA_556x45_TYPE97 {};         // QBZ-97 Stick Mags
     class CBA_556x45_TYPE97_XL {};      // QBB-97 LSW Drums
+    class CBA_556x45_SCAR_EGLM {};      // SCAR-L with EGLM/FN40GL/Mk 13 Mod 0 grenage launcher (This extends the length of the magwell and prevents mags that are too short or wide from being used)
     class CBA_556x45_SG550 {};
 
     class CBA_556x45_STANAG {           // STANAG mags, standard length, including small drums

--- a/addons/jam/magwells_762x51.hpp
+++ b/addons/jam/magwells_762x51.hpp
@@ -42,6 +42,7 @@
     };
 
     class CBA_762x51_SCAR {};       // SCAR-H
+    class CBA_762x51_SCAR_EGLM {};  // SCAR-H with EGLM/FN40GL/Mk 13 Mod 0 grenage launcher (This extends the length of the magwell and prevents mags that are too short or wide from being used)
     class CBA_762x51_SIGAMT {};     // SIG 510-4, AMT
 
     //Deprecated classes do not use


### PR DESCRIPTION
**When merged this pull request will:**
- The EGLM extends the length of the mag well, preventing many magazines from fitting.

![](http://www.imfdb.org/images/6/62/Scar_l_std.jpg)
![](http://www.imfdb.org/images/2/24/Scar-L_std_40gl.jpg)
![](http://www.imfdb.org/images/thumb/c/c5/SCAR-H_CQC.jpg/800px-SCAR-H_CQC.jpg)
![](http://www.imfdb.org/images/thumb/d/d1/Mk13_%28Mk17%29.jpg/799px-Mk13_%28Mk17%29.jpg)

