### PR TITLE
1.94 - Fix GL magwells

### DIFF
--- a/addons/jam/CfgWeapons.hpp
+++ b/addons/jam/CfgWeapons.hpp
@@ -22,14 +22,14 @@ class CfgWeapons {
 
     class GrenadeLauncher;
     class UGL_F: GrenadeLauncher {
-        magazineWell[] += {"CBA_40mm_M203","CBA_40mm_EGLM"}; // empty in vanilla
+        magazineWell[] += {"CBA_40mm_M203","CBA_40mm_EGLM"};
     };
 
     class arifle_MX_Base_F: Rifle_Base_F {
         magazineWell[] += {"CBA_65x39_MX","CBA_65x39_MX_XL"};
 
         class GL_3GL_F: UGL_F {
-            magazineWell[] += {"CBA_40mm_3GL","CBA_40mm_M203","CBA_40mm_EGLM"}; // [] in vanilla
+            magazineWell[] = {"UGL_40x36","3UGL_40x36","CBA_40mm_3GL","CBA_40mm_M203","CBA_40mm_EGLM"}; // just list all wells because of += limitations
         };
     };
 

--- a/addons/jam/CfgWeapons.hpp
+++ b/addons/jam/CfgWeapons.hpp
@@ -27,10 +27,6 @@ class CfgWeapons {
 
     class arifle_MX_Base_F: Rifle_Base_F {
         magazineWell[] += {"CBA_65x39_MX","CBA_65x39_MX_XL"};
-
-        class GL_3GL_F: UGL_F {
-            magazineWell[] += {"CBA_40mm_3GL"};
-        };
     };
 
     class arifle_Katiba_Base_F: Rifle_Base_F {

--- a/addons/jam/CfgWeapons.hpp
+++ b/addons/jam/CfgWeapons.hpp
@@ -29,7 +29,7 @@ class CfgWeapons {
         magazineWell[] += {"CBA_65x39_MX","CBA_65x39_MX_XL"};
 
         class GL_3GL_F: UGL_F {
-            magazineWell[] = {"UGL_40x36","3UGL_40x36","CBA_40mm_3GL","CBA_40mm_M203","CBA_40mm_EGLM"}; // just list all wells because of += limitations
+            magazineWell[] += {"CBA_40mm_3GL"};
         };
     };
 

--- a/addons/jam/jam_finish/CfgWeapons.hpp
+++ b/addons/jam/jam_finish/CfgWeapons.hpp
@@ -1,0 +1,10 @@
+class CfgWeapons {
+    class UGL_F;
+
+    class Rifle_Base_F;
+    class arifle_MX_Base_F: Rifle_Base_F {
+        class GL_3GL_F: UGL_F {
+            magazineWell[] += {"CBA_40mm_3GL","CBA_40mm_M203","CBA_40mm_EGLM"}; // Cannot use += without leaking values if used on parent class in the same config patch.
+        };
+    };
+};

--- a/addons/jam/jam_finish/config.cpp
+++ b/addons/jam/jam_finish/config.cpp
@@ -1,0 +1,16 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        author = "$STR_CBA_Author";
+        name = ECSTRING(jam,component);
+        url = "$STR_CBA_URL";
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"cba_jam"};
+        version = VERSION;
+    };
+};
+
+#include "CfgWeapons.hpp"

--- a/addons/jam/jam_finish/script_component.hpp
+++ b/addons/jam/jam_finish/script_component.hpp
@@ -1,0 +1,3 @@
+#define COMPONENT jam_finish
+#include "\x\cba\addons\main\script_mod.hpp"
+#include "\x\cba\addons\main\script_macros.hpp"


### PR DESCRIPTION
> Added: magazineWells to Underbarrel Grenade Launchers

New vanilla configs:
```
    class UGL_F: GrenadeLauncher {
        magazineWell[] = {"UGL_40x36"};
        
    class arifle_MX_GL_F: arifle_MX_Base_F {
        class GL_3GL_F: UGL_F {
                magazineWell[] = {"UGL_40x36","3UGL_40x36"};
```

This just uses `=` instead of `+=` because of problems with inhetiance
The proper way would be to add a subconfig: https://github.com/CBATeam/CBA_A3/commit/8e24cb6788dffe94b1ea8c015342494cea650975
but not sure if we want to add another cfgPatch just for something minor?