### PR TITLE
joint rails - enoch attachment classes compatibility - Variant A

### DIFF
--- a/addons/jr/CfgWeapons.hpp
+++ b/addons/jr/CfgWeapons.hpp
@@ -433,34 +433,18 @@ class CfgWeapons {
 
     class arifle_MXC_F: arifle_MX_Base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: asdg_MuzzleSlot_65 {
-                iconPosition[] = {0,0.4};
-                iconScale = 0.2;
-            };
             class CowsSlot: asdg_OpticRail1913 {
                 iconPosition[] = {0.5,0.3};
                 iconScale = 0.2;
-            };
-            class PointerSlot: asdg_FrontSideRail {
-                iconPosition[] = {0.2,0.4};
-                iconScale = 0.25;
             };
         };
     };
 
     class arifle_MX_F: arifle_MX_Base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: asdg_MuzzleSlot_65 {
-                iconPosition[] = {0,0.45};
-                iconScale = 0.2;
-            };
             class CowsSlot: asdg_OpticRail1913 {
                 iconPosition[] = {0.5,0.35};
                 iconScale = 0.2;
-            };
-            class PointerSlot: asdg_FrontSideRail {
-                iconPosition[] = {0.2,0.45};
-                iconScale = 0.25;
             };
             class UnderBarrelSlot: asdg_UnderSlot {
                 iconPosition[] = {0.2,0.7};
@@ -471,34 +455,18 @@ class CfgWeapons {
 
     class arifle_MX_GL_F: arifle_MX_Base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: asdg_MuzzleSlot_65 {
-                iconPosition[] = {0,0.45};
-                iconScale = 0.2;
-            };
             class CowsSlot: asdg_OpticRail1913 {
                 iconPosition[] = {0.5,0.35};
                 iconScale = 0.2;
-            };
-            class PointerSlot: asdg_FrontSideRail {
-                iconPosition[] = {0.2,0.45};
-                iconScale = 0.25;
             };
         };
     };
 
     class arifle_MX_SW_F: arifle_MX_Base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: asdg_MuzzleSlot_65 {
-                iconPosition[] = {0,0.45};
-                iconScale = 0.2;
-            };
             class CowsSlot: asdg_OpticRail1913 {
                 iconPosition[] = {0.5,0.35};
                 iconScale = 0.2;
-            };
-            class PointerSlot: asdg_FrontSideRail {
-                iconPosition[] = {0.2,0.45};
-                iconScale = 0.25;
             };
             class UnderBarrelSlot: asdg_UnderSlot {
                 iconPosition[] = {0.2,0.7};
@@ -509,17 +477,9 @@ class CfgWeapons {
 
     class arifle_MXM_F: arifle_MX_Base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: asdg_MuzzleSlot_65 {
-                iconPosition[] = {0,0.4};
-                iconScale = 0.2;
-            };
             class CowsSlot: asdg_OpticRail1913 {
                 iconPosition[] = {0.5,0.35};
                 iconScale = 0.2;
-            };
-            class PointerSlot: asdg_FrontSideRail {
-                iconPosition[] = {0.2,0.45};
-                iconScale = 0.25;
             };
             class UnderBarrelSlot: asdg_UnderSlot {
                 iconPosition[] = {0.2,0.7};
@@ -694,19 +654,6 @@ class CfgWeapons {
             class CowsSlot: asdg_OpticRail1913 {
                 iconPosition[] = {0.5,0.25};
                 iconScale = 0.2;
-            };
-            class PointerSlot: asdg_FrontSideRail {
-                iconPosition[] = {0.3,0.35};
-                iconScale = 0.2;
-            };
-        };
-    };
-
-    class arifle_AK12_F: arifle_AK12_base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class UnderBarrelSlot: asdg_UnderSlot {
-                iconPosition[] = {0.35,0.7};
-                iconScale = 0.3;
             };
         };
     };
@@ -931,41 +878,41 @@ class CfgWeapons {
         model = "\a3\weapons_f\acc\acca_snds_338_green_F";
     };
 
-    class SMG_03_TR_BASE : Rifle_Base_F {
+    class SMG_03_TR_BASE: Rifle_Base_F {
         class WeaponSlotsInfo;
     };
-    class SMG_03C_BASE : SMG_03_TR_BASE {};
-    class SMG_03_TR_black : SMG_03_TR_BASE {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
-            class CowsSlot : asdg_OpticRail1913_short {
+    class SMG_03C_BASE: SMG_03_TR_BASE {};
+    class SMG_03_TR_black: SMG_03_TR_BASE {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            class CowsSlot: asdg_OpticRail1913_short {
                 iconPosition[] = {0.4, 0.3};
                 iconScale = 0.2;
             };
-            class PointerSlot : asdg_FrontSideRail {
+            class PointerSlot: asdg_FrontSideRail {
                 iconPosition[] = {0.33, 0.37};
                 iconScale = 0.25;
             };
         };
     };
-    class SMG_03_TR_hex : SMG_03_TR_BASE {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
-            class CowsSlot : asdg_OpticRail1913_short {
+    class SMG_03_TR_hex: SMG_03_TR_BASE {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            class CowsSlot: asdg_OpticRail1913_short {
                 iconPosition[] = {0.4, 0.3};
                 iconScale = 0.2;
             };
-            class PointerSlot : asdg_FrontSideRail {
+            class PointerSlot: asdg_FrontSideRail {
                 iconPosition[] = {0.33, 0.37};
                 iconScale = 0.25;
             };
         };
     };
-    class SMG_03C_TR_black : SMG_03C_BASE {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
-            class CowsSlot : asdg_OpticRail1913_short {
+    class SMG_03C_TR_black: SMG_03C_BASE {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            class CowsSlot: asdg_OpticRail1913_short {
                 iconPosition[] = {0.4, 0.3};
                 iconScale = 0.2;
             };
-            class PointerSlot : asdg_FrontSideRail {
+            class PointerSlot: asdg_FrontSideRail {
                 iconPosition[] = {0.33, 0.37};
                 iconScale = 0.25;
             };

--- a/addons/jr/CfgWeapons.hpp
+++ b/addons/jr/CfgWeapons.hpp
@@ -40,10 +40,6 @@ class CfgWeapons {
 
     class srifle_EBR_F: EBR_base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: asdg_MuzzleSlot_762 {
-                iconPosition[] = {0.05,0.38};
-                iconScale = 0.2;
-            };
             class CowsSlot: asdg_OpticRail1913 {
                 iconPosition[] = {0.5,0.3};
                 iconScale = 0.2;
@@ -87,10 +83,6 @@ class CfgWeapons {
 
     class srifle_DMR_01_F: DMR_01_base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: asdg_MuzzleSlot_762 {
-                iconPosition[] = {0,0.45};
-                iconScale = 0.2;
-            };
             class CowsSlot: asdg_OpticRail1913 {
                 iconPosition[] = {0.45,0.38};
                 iconScale = 0.2;
@@ -137,10 +129,6 @@ class CfgWeapons {
 
     class srifle_DMR_03_F: DMR_03_base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: asdg_MuzzleSlot_762 {
-                iconPosition[] = {0.12,0.431};
-                iconScale = 0.15;
-            };
             class CowsSlot: asdg_OpticRail1913 {
                 iconPosition[] = {0.5,0.36};
                 iconScale = 0.15;
@@ -208,10 +196,6 @@ class CfgWeapons {
 
     class srifle_DMR_06_camo_F: DMR_06_base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: asdg_MuzzleSlot_762 {
-                iconPosition[] = {0.06,0.4};
-                iconScale = 0.15;
-            };
             class CowsSlot: asdg_OpticRail1913_short {
                 iconPosition[] = {0.52,0.36};
                 iconScale = 0.15;
@@ -225,15 +209,6 @@ class CfgWeapons {
 
     class LMG_Mk200_F: Rifle_Long_Base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: asdg_MuzzleSlot_762MG {
-                iconPosition[] = {0.1,0.5};
-                iconScale = 0.2;
-                class compatibleItems: compatibleItems {
-                    muzzle_snds_h = 1;
-                    muzzle_snds_h_khk_F = 1;
-                    muzzle_snds_h_snd_F = 1;
-                };
-            };
             class CowsSlot: asdg_OpticRail1913_short_MG {
                 iconPosition[] = {0.6,0.45};
                 iconScale = 0.2;
@@ -323,10 +298,6 @@ class CfgWeapons {
 
     class arifle_Katiba_F: arifle_Katiba_Base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: asdg_MuzzleSlot_65 {
-                iconPosition[] = {0,0.45};
-                iconScale = 0.2;
-            };
             class CowsSlot: asdg_OpticRail1913 {
                 iconPosition[] = {0.45,0.28};
                 iconScale = 0.2;
@@ -340,10 +311,6 @@ class CfgWeapons {
 
     class arifle_Katiba_C_F: arifle_Katiba_Base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: asdg_MuzzleSlot_65 {
-                iconPosition[] = {0.1,0.45};
-                iconScale = 0.2;
-            };
             class CowsSlot: asdg_OpticRail1913 {
                 iconPosition[] = {0.45,0.28};
                 iconScale = 0.2;
@@ -357,10 +324,6 @@ class CfgWeapons {
 
     class arifle_Katiba_GL_F: arifle_Katiba_Base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: asdg_MuzzleSlot_65 {
-                iconPosition[] = {0,0.45};
-                iconScale = 0.2;
-            };
             class CowsSlot: asdg_OpticRail1913 {
                 iconPosition[] = {0.45,0.28};
                 iconScale = 0.2;
@@ -378,10 +341,6 @@ class CfgWeapons {
 
     class arifle_Mk20_F: mk20_base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: asdg_MuzzleSlot_556 {
-                iconPosition[] = {0,0.36};
-                iconScale = 0.2;
-            };
             class CowsSlot: asdg_OpticRail1913 {
                 iconPosition[] = {0.45,0.25};
                 iconScale = 0.2;
@@ -395,10 +354,6 @@ class CfgWeapons {
 
     class arifle_Mk20C_F: mk20_base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: asdg_MuzzleSlot_556 {
-                iconPosition[] = {0.1,0.36};
-                iconScale = 0.2;
-            };
             class PointerSlot: asdg_FrontSideRail {
                 iconPosition[] = {0.35,0.35};
                 iconScale = 0.25;
@@ -412,10 +367,6 @@ class CfgWeapons {
 
     class arifle_Mk20_GL_F: mk20_base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: asdg_MuzzleSlot_556 {
-                iconPosition[] = {0.1,0.36};
-                iconScale = 0.2;
-            };
             class PointerSlot: asdg_FrontSideRail {
                 iconPosition[] = {0.35,0.35};
                 iconScale = 0.25;

--- a/addons/jr/CfgWeapons.hpp
+++ b/addons/jr/CfgWeapons.hpp
@@ -445,10 +445,6 @@ class CfgWeapons {
 
     class arifle_TRG21_F: Tavor_base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: asdg_MuzzleSlot_556 {
-                iconPosition[] = {0,0.4};
-                iconScale = 0.2;
-            };
             class CowsSlot: asdg_OpticRail1913_short {
                 iconPosition[] = {0.45,0.28};
                 iconScale = 0.2;
@@ -462,10 +458,6 @@ class CfgWeapons {
 
     class arifle_TRG20_F: Tavor_base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: asdg_MuzzleSlot_556 {
-                iconPosition[] = {0.1,0.4};
-                iconScale = 0.2;
-            };
             class CowsSlot: asdg_OpticRail1913_short {
                 iconPosition[] = {0.45,0.28};
                 iconScale = 0.2;
@@ -592,18 +584,58 @@ class CfgWeapons {
     };
 */
     class arifle_AK12_base_F: Rifle_Base_F {
+        class WeaponSlotsInfo;
+    };
+
+    class arifle_AK12_F: arifle_AK12_base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            class MuzzleSlot: asdg_MuzzleSlot_762R {
-                iconPosition[] = {0,0.35};
+            class PointerSlot: asdg_FrontSideRail {
+                iconPosition[] = {0.3,0.35};
                 iconScale = 0.2;
-                class compatibleItems: compatibleItems {
-                    muzzle_snds_B = 1;
-                    muzzle_snds_B_khk_F = 1;
-                    muzzle_snds_B_snd_F = 1;
-                };
             };
-            class CowsSlot: asdg_OpticRail1913 {
-                iconPosition[] = {0.5,0.25};
+        };
+    };
+
+    class arifle_AK12_lush_F: arifle_AK12_base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            class PointerSlot: asdg_FrontSideRail {
+                iconPosition[] = {0.3,0.35};
+                iconScale = 0.2;
+            };
+        };
+    };
+
+    class arifle_AK12_arid_F: arifle_AK12_base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            class PointerSlot: asdg_FrontSideRail {
+                iconPosition[] = {0.3,0.35};
+                iconScale = 0.2;
+            };
+        };
+    };
+
+    class arifle_AK12_GL_base_F: arifle_AK12_base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            class PointerSlot: asdg_FrontSideRail {
+                iconPosition[] = {0.3,0.35};
+                iconScale = 0.2;
+            };
+        };
+    };
+
+    class arifle_AK12U_base_F: arifle_AK12_base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            class PointerSlot: asdg_FrontSideRail {
+                iconPosition[] = {0.3,0.35};
+                iconScale = 0.2;
+            };
+        };
+    };
+
+    class arifle_RPK12_base_F: arifle_AK12_base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            class PointerSlot: asdg_FrontSideRail {
+                iconPosition[] = {0.3,0.35};
                 iconScale = 0.2;
             };
         };

--- a/addons/jr/jr_prep/CfgWeapons.hpp
+++ b/addons/jr/jr_prep/CfgWeapons.hpp
@@ -123,9 +123,18 @@ class CfgWeapons {
     };
 */
     class arifle_AK12_base_F: Rifle_Base_F {
+        class WeaponSlotsInfo;
+    };
+
+    class arifle_AK12U_base_F: arifle_AK12_base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            delete MuzzleSlot;
-            delete CowsSlot;
+            delete PointerSlot;
+        };
+    };
+
+    class arifle_RPK12_base_F: arifle_AK12_base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            delete PointerSlot;
         };
     };
 

--- a/addons/jr/jr_prep/CfgWeapons.hpp
+++ b/addons/jr/jr_prep/CfgWeapons.hpp
@@ -1,27 +1,27 @@
 class CfgWeapons {
     class Rifle;
-    class Rifle_Base_F : Rifle {
+    class Rifle_Base_F: Rifle {
         class WeaponSlotsInfo;
     };
-    class Rifle_Short_Base_F : Rifle_Base_F {
+    class Rifle_Short_Base_F: Rifle_Base_F {
         class WeaponSlotsInfo;
     };
-    class Rifle_Long_Base_F : Rifle_Base_F {
+    class Rifle_Long_Base_F: Rifle_Base_F {
         class WeaponSlotsInfo;
     };
 
     class Launcher;
-    class Launcher_Base_F : Launcher {
+    class Launcher_Base_F: Launcher {
         class WeaponSlotsInfo;
     };
 
-    class launch_Titan_base : Launcher_Base_F {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
+    class launch_Titan_base: Launcher_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
             delete PointerSlot;
         };
     };
-    class launch_MRAWS_base_F : Launcher_Base_F {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
+    class launch_MRAWS_base_F: Launcher_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
             delete PointerSlot;
         };
     };
@@ -30,7 +30,7 @@ class CfgWeapons {
         class WeaponSlotsInfo;
     };
 
-    class srifle_EBR_F : EBR_base_F {
+    class srifle_EBR_F: EBR_base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
             delete UnderBarrelSlot;
         };
@@ -38,26 +38,26 @@ class CfgWeapons {
 
     class GM6_base_F: Rifle_Long_Base_F {};
 
-    class srifle_GM6_F : GM6_base_F {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
+    class srifle_GM6_F: GM6_base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
             delete CowsSlot;
         };
     };
 
     class LRR_base_F: Rifle_Long_Base_F {};
 
-    class srifle_LRR_F : LRR_base_F {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
+    class srifle_LRR_F: LRR_base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
             delete CowsSlot;
         };
     };
 
-    class DMR_01_base_F : Rifle_Long_Base_F {
+    class DMR_01_base_F: Rifle_Long_Base_F {
         class WeaponSlotsInfo;
     };
 
-    class srifle_DMR_01_F : DMR_01_base_F {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
+    class srifle_DMR_01_F: DMR_01_base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
             delete UnderBarrelSlot;
         };
     };
@@ -83,32 +83,18 @@ class CfgWeapons {
         class WeaponSlotsInfo;
     };
 
-    class arifle_MXC_F : arifle_MX_Base_F {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
-            delete MuzzleSlot;
+    class arifle_MXC_F: arifle_MX_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
             delete CowsSlot;
-            delete PointerSlot;
         };
     };
 
-    class arifle_MXM_F : arifle_MX_Base_F {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
-            delete MuzzleSlot;
-        };
-    };
-
-    class arifle_MX_SW_F : arifle_MX_Base_F {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
-            delete MuzzleSlot;
-        };
-    };
-
-    class arifle_Katiba_Base_F : Rifle_Base_F {
+    class arifle_Katiba_Base_F: Rifle_Base_F {
         class WeaponSlotsInfo;
     };
 
-    class arifle_Katiba_C_F : arifle_Katiba_Base_F {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
+    class arifle_Katiba_C_F: arifle_Katiba_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
             delete MuzzleSlot;
         };
     };
@@ -117,14 +103,14 @@ class CfgWeapons {
         class WeaponSlotsInfo;
     };
 
-    class arifle_Mk20C_F : mk20_base_F {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
+    class arifle_Mk20C_F: mk20_base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
             delete MuzzleSlot;
         };
     };
 
-    class arifle_Mk20_GL_F : mk20_base_F {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
+    class arifle_Mk20_GL_F: mk20_base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
             delete MuzzleSlot;
         };
     };
@@ -133,14 +119,14 @@ class CfgWeapons {
         class WeaponSlotsInfo;
     };
 
-    class arifle_TRG20_F : Tavor_base_F {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
+    class arifle_TRG20_F: Tavor_base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
             delete MuzzleSlot;
         };
     };
 
-    class LMG_03_base_F : Rifle_Long_Base_F {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
+    class LMG_03_base_F: Rifle_Long_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
             delete MuzzleSlot;
             delete CowsSlot;
             delete PointerSlot;
@@ -148,16 +134,16 @@ class CfgWeapons {
         };
     };
 
-    class DMR_07_base_F : Rifle_Long_Base_F {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
+    class DMR_07_base_F: Rifle_Long_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
             delete MuzzleSlot;
             delete CowsSlot;
             delete PointerSlot;
         };
     };
 
-    class SMG_05_base_F : Rifle_Short_Base_F {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
+    class SMG_05_base_F: Rifle_Short_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
             delete MuzzleSlot;
             delete CowsSlot;
             delete PointerSlot;
@@ -165,7 +151,7 @@ class CfgWeapons {
         };
     };
 /*
-    class arifle_AKS_base_F : Rifle_Base_F {
+    class arifle_AKS_base_F: Rifle_Base_F {
         class WeaponSlotsInfo {
             delete MuzzleSlot;
             delete CowsSlot;
@@ -173,33 +159,23 @@ class CfgWeapons {
         };
     };
 */
-    class arifle_AK12_base_F : Rifle_Base_F {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
+    class arifle_AK12_base_F: Rifle_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            delete MuzzleSlot;
+            delete CowsSlot;
+        };
+    };
+
+    class arifle_SPAR_01_base_F: Rifle_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
             delete MuzzleSlot;
             delete CowsSlot;
             delete PointerSlot;
         };
     };
 
-    class arifle_SPAR_01_base_F : Rifle_Base_F {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
-            delete MuzzleSlot;
-            delete CowsSlot;
-            delete PointerSlot;
-        };
-    };
-
-    class arifle_SPAR_02_base_F : Rifle_Base_F {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
-            delete MuzzleSlot;
-            delete CowsSlot;
-            delete PointerSlot;
-            delete UnderBarrelSlot;
-        };
-    };
-
-    class arifle_SPAR_03_base_F : Rifle_Base_F {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
+    class arifle_SPAR_02_base_F: Rifle_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
             delete MuzzleSlot;
             delete CowsSlot;
             delete PointerSlot;
@@ -207,24 +183,33 @@ class CfgWeapons {
         };
     };
 
-    class arifle_CTAR_base_F : Rifle_Base_F {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
+    class arifle_SPAR_03_base_F: Rifle_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            delete MuzzleSlot;
+            delete CowsSlot;
+            delete PointerSlot;
+            delete UnderBarrelSlot;
+        };
+    };
+
+    class arifle_CTAR_base_F: Rifle_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
             delete MuzzleSlot;
             delete CowsSlot;
             delete PointerSlot;
         };
     };
 
-    class arifle_CTARS_base_F : Rifle_Base_F {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
+    class arifle_CTARS_base_F: Rifle_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
             delete MuzzleSlot;
             delete CowsSlot;
             delete PointerSlot;
         };
     };
 
-    class arifle_ARX_base_F : Rifle_Base_F {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
+    class arifle_ARX_base_F: Rifle_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
             delete MuzzleSlot;
             delete CowsSlot;
             delete PointerSlot;
@@ -233,51 +218,51 @@ class CfgWeapons {
     };
 
     class Pistol;
-    class Pistol_Base_F : Pistol {
+    class Pistol_Base_F: Pistol {
         class WeaponSlotsInfo;
     };
 
-    class hgun_ACPC2_F : Pistol_Base_F {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
+    class hgun_ACPC2_F: Pistol_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
             delete MuzzleSlot;
             delete PointerSlot;
         };
    };
 
-    class hgun_P07_F : Pistol_Base_F {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
+    class hgun_P07_F: Pistol_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
             delete MuzzleSlot;
         };
     };
 
-    class hgun_Pistol_heavy_01_F : Pistol_Base_F {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
+    class hgun_Pistol_heavy_01_F: Pistol_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
             delete CowsSlot;
             delete MuzzleSlot;
             delete PointerSlot;
         };
     };
 
-    class hgun_Pistol_heavy_02_F : Pistol_Base_F {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
+    class hgun_Pistol_heavy_02_F: Pistol_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
             delete CowsSlot;
             delete MuzzleSlot;
             delete PointerSlot;
         };
     };
 
-    class hgun_Rook40_F : Pistol_Base_F {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
+    class hgun_Rook40_F: Pistol_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
             delete MuzzleSlot;
         };
     };
 
-    class SMG_03_TR_BASE : Rifle_Base_F {
+    class SMG_03_TR_BASE: Rifle_Base_F {
         class WeaponSlotsInfo;
     };
-    class SMG_03C_BASE : SMG_03_TR_BASE {};
-    class SMG_03C_TR_black : SMG_03C_BASE {
-        class WeaponSlotsInfo : WeaponSlotsInfo {
+    class SMG_03C_BASE: SMG_03_TR_BASE {};
+    class SMG_03C_TR_black: SMG_03C_BASE {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
             delete CowsSlot;
             delete PointerSlot;
         };

--- a/addons/jr/jr_prep/CfgWeapons.hpp
+++ b/addons/jr/jr_prep/CfgWeapons.hpp
@@ -64,7 +64,6 @@ class CfgWeapons {
 
     class LMG_Mk200_F: Rifle_Long_Base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            delete MuzzleSlot;
             delete CowsSlot;
             delete PointerSlot;
             delete UnderBarrelSlot;
@@ -86,42 +85,6 @@ class CfgWeapons {
     class arifle_MXC_F: arifle_MX_Base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
             delete CowsSlot;
-        };
-    };
-
-    class arifle_Katiba_Base_F: Rifle_Base_F {
-        class WeaponSlotsInfo;
-    };
-
-    class arifle_Katiba_C_F: arifle_Katiba_Base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            delete MuzzleSlot;
-        };
-    };
-
-    class mk20_base_F: Rifle_Base_F {
-        class WeaponSlotsInfo;
-    };
-
-    class arifle_Mk20C_F: mk20_base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            delete MuzzleSlot;
-        };
-    };
-
-    class arifle_Mk20_GL_F: mk20_base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            delete MuzzleSlot;
-        };
-    };
-
-    class Tavor_base_F: Rifle_Base_F {
-        class WeaponSlotsInfo;
-    };
-
-    class arifle_TRG20_F: Tavor_base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            delete MuzzleSlot;
         };
     };
 


### PR DESCRIPTION
This PR fixes the following UBC classes since Arma 1.94 = Enoch:

```
 9:02:51 Cannot delete class PointerSlot, it is referenced somewhere (used as a base class probably).
 9:02:51 Updating base class MuzzleSlot_65->asdg_MuzzleSlot_65, by x\cba\addons\jr\config.cpp/CfgWeapons/arifle_MX_F/WeaponSlotsInfo/MuzzleSlot/ (original (no unload))
 9:02:51 Updating base class PointerSlot_Rail->asdg_FrontSideRail, by x\cba\addons\jr\config.cpp/CfgWeapons/arifle_MX_F/WeaponSlotsInfo/PointerSlot/ (original (no unload))
 9:02:51 Updating base class MuzzleSlot_65->asdg_MuzzleSlot_65, by x\cba\addons\jr\config.cpp/CfgWeapons/arifle_MX_GL_F/WeaponSlotsInfo/MuzzleSlot/ (original (no unload))
 9:02:51 Updating base class PointerSlot_Rail->asdg_FrontSideRail, by x\cba\addons\jr\config.cpp/CfgWeapons/arifle_MX_GL_F/WeaponSlotsInfo/PointerSlot/ (original (no unload))
 9:02:51 Updating base class PointerSlot_Rail->asdg_FrontSideRail, by x\cba\addons\jr\config.cpp/CfgWeapons/arifle_MX_SW_F/WeaponSlotsInfo/PointerSlot/ (original (no unload))
 9:02:51 Updating base class PointerSlot_Rail->asdg_FrontSideRail, by x\cba\addons\jr\config.cpp/CfgWeapons/arifle_MXM_F/WeaponSlotsInfo/PointerSlot/ (original (no unload))
 9:02:51 Updating base class PointerSlot->asdg_FrontSideRail, by x\cba\addons\jr\config.cpp/CfgWeapons/arifle_AK12_base_F/WeaponSlotsInfo/PointerSlot/ (original a3\weapons_f_exp\rifles\ak12\config.bin)
 9:02:51 Updating base class UnderBarrelSlot_rail->asdg_UnderSlot, by x\cba\addons\jr\config.cpp/CfgWeapons/arifle_AK12_F/WeaponSlotsInfo/UnderBarrelSlot/ (original (no unload))
```

This means that we drop Joint Rails support for muzzle and pointer slots of the MX series, and pointer and bipod support for the AK12 series.

The benefit of this is, that addons that only add items to the new vanilla attachment classes and no JR, will not be broken by CBA_A3 in the future.

The drawback of this is, that addons that already add items to these specific joint rails classes, will have to add their items to both the new BI classes and the CBA_A3 joint rails classes to support both MX and AK12, as well as future third party classes coping these vanilla attachment classes, as well as old third party classes that already use the joint rails classes.