### PR TITLE
joint rails - enoch attachment classes compatibility - Variant B

### DIFF
--- a/addons/jr/jr_prep/CfgWeapons.hpp
+++ b/addons/jr/jr_prep/CfgWeapons.hpp
@@ -91,15 +91,31 @@ class CfgWeapons {
         };
     };
 
-    class arifle_MXM_F: arifle_MX_Base_F {
+    class arifle_MX_F: arifle_MX_Base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
             delete MuzzleSlot;
+            delete PointerSlot;
+        };
+    };
+
+    class arifle_MX_GL_F: arifle_MX_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            delete MuzzleSlot;
+            delete PointerSlot;
         };
     };
 
     class arifle_MX_SW_F: arifle_MX_Base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
             delete MuzzleSlot;
+            delete PointerSlot;
+        };
+    };
+
+    class arifle_MXM_F: arifle_MX_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            delete MuzzleSlot;
+            delete PointerSlot;
         };
     };
 
@@ -178,6 +194,12 @@ class CfgWeapons {
             delete MuzzleSlot;
             delete CowsSlot;
             delete PointerSlot;
+        };
+    };
+
+    class arifle_AK12_F: arifle_AK12_base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            delete UnderBarrelSlot;
         };
     };
 


### PR DESCRIPTION
This PR fixes the following UBC classes since Arma 1.94 = Enoch:

```
 9:02:51 Updating base class MuzzleSlot_65->asdg_MuzzleSlot_65, by x\cba\addons\jr\config.cpp/CfgWeapons/arifle_MX_F/WeaponSlotsInfo/MuzzleSlot/ (original (no unload))
 9:02:51 Updating base class PointerSlot_Rail->asdg_FrontSideRail, by x\cba\addons\jr\config.cpp/CfgWeapons/arifle_MX_F/WeaponSlotsInfo/PointerSlot/ (original (no unload))
 9:02:51 Updating base class MuzzleSlot_65->asdg_MuzzleSlot_65, by x\cba\addons\jr\config.cpp/CfgWeapons/arifle_MX_GL_F/WeaponSlotsInfo/MuzzleSlot/ (original (no unload))
 9:02:51 Updating base class PointerSlot_Rail->asdg_FrontSideRail, by x\cba\addons\jr\config.cpp/CfgWeapons/arifle_MX_GL_F/WeaponSlotsInfo/PointerSlot/ (original (no unload))
 9:02:51 Updating base class PointerSlot_Rail->asdg_FrontSideRail, by x\cba\addons\jr\config.cpp/CfgWeapons/arifle_MX_SW_F/WeaponSlotsInfo/PointerSlot/ (original (no unload))
 9:02:51 Updating base class PointerSlot_Rail->asdg_FrontSideRail, by x\cba\addons\jr\config.cpp/CfgWeapons/arifle_MXM_F/WeaponSlotsInfo/PointerSlot/ (original (no unload))
 9:02:51 Updating base class PointerSlot->asdg_FrontSideRail, by x\cba\addons
 9:02:51 Updating base class UnderBarrelSlot_rail->asdg_UnderSlot, by x\cba\addons\jr\config.cpp/CfgWeapons/arifle_AK12_F/WeaponSlotsInfo/UnderBarrelSlot/ (original (no unload))
```
This is an alternative to #1184.

We avoid the UBC by deleting the new BI attachment classes in the sub config. But that means that CBA now breaks addons that work fine in vanilla, by deleting attachment compatibility if the author only adds to the vanilla attachment class. Hard pill to swallow and to explain when someone complains.

I like variant A more, but we can merge this one as well.

_________

The remaining errors:
```
10:02:56 Cannot delete class PointerSlot, it is referenced somewhere (used as a base class probably).
10:02:56 Updating base class PointerSlot->asdg_FrontSideRail, by x\cba\addons\jr\config.cpp/CfgWeapons/arifle_AK12_base_F/WeaponSlotsInfo/PointerSlot/ (original a3\weapons_f_exp\rifles\ak12\config.bin)
```
will be fixed later today...