### PR TITLE
fix minor ui issues with Contact DLC ui modifications

### DIFF
--- a/addons/settings/fnc_gui_sourceChanged.sqf
+++ b/addons/settings/fnc_gui_sourceChanged.sqf
@@ -26,7 +26,7 @@ private _selectedAddon = uiNamespace getVariable QGVAR(addon);
 // toggle source buttons
 {
     private _ctrlX = _display displayCtrl _x;
-    _ctrlX ctrlSetTextColor ([COLOR_BUTTON_ENABLED, COLOR_BUTTON_DISABLED] select (_control == _ctrlX));
+    _ctrlX ctrlSetTextColor ([COLOR_BUTTON_ENABLED, COLOR_BUTTON_DISABLED] select (_control == _ctrlX && {!isClass (configFile >> "CfgPatches" >> "A3_Data_F_Contact")}));
     _ctrlX ctrlSetBackgroundColor ([COLOR_BUTTON_DISABLED, COLOR_BUTTON_ENABLED] select (_control == _ctrlX));
 } forEach [IDC_BTN_SERVER, IDC_BTN_MISSION, IDC_BTN_CLIENT];
 

--- a/addons/ui/fnc_initDisplayInterrupt.sqf
+++ b/addons/ui/fnc_initDisplayInterrupt.sqf
@@ -44,11 +44,13 @@ if (!isMultiplayer && {getNumber (missionConfigFile >> "replaceAbortButton") > 0
 ];
 
 // --- create custom buttons
+private _buttonType = ["RscButtonMenu", "RscButtonMenuLeft"] select isClass (configFile >> "CfgPatches" >> "A3_Data_F_Contact");
+
 {
     _offset = _offset + 1.1;
     _x params ["_displayName", "_tooltip", "_dialog"];
 
-    private _button = _display ctrlCreate ["RscButtonMenu", -1];
+    private _button = _display ctrlCreate [_buttonType, -1];
 
     _button ctrlSetText toUpper _displayName;
     _button ctrlSetTooltip _tooltip;


### PR DESCRIPTION
This PR fixes:
- when Contact DLC is loaded only, when a tab in the ADDON OPTIONS menu is selected, but not focused, the text appears black on black background, when it should remain white. Without Contact DLC, it is supposed to still turn black.


before:
![https://i.imgur.com/RmOnPQp.png](https://i.imgur.com/RmOnPQp.png)

after:
![https://i.imgur.com/X5jaxix.png](https://i.imgur.com/X5jaxix.png)