### PR TITLE
fix scripted optics pip effect

### DIFF
--- a/addons/optics/fnc_restartCamera.sqf
+++ b/addons/optics/fnc_restartCamera.sqf
@@ -37,8 +37,8 @@ if (_reset) then {
     GVAR(camera) camSetTarget _unit;
     GVAR(camera) camCommit 1;
 
-    QGVAR(rendertarget0) setPiPEffect [2, 1.0, 1.0, 1.0, 0.0, [0.0, 1.0, 0.0, 0.25], [1.0, 0.0, 1.0, 1.0], [0.199, 0.587, 0.114, 0.0]];
     GVAR(camera) cameraEffect ["INTERNAL", "BACK", QGVAR(rendertarget0)];
+    QGVAR(rendertarget0) setPiPEffect [0];
 
     INFO("Scripted camera restarted.");
 };


### PR DESCRIPTION
**When merged this pull request will:**
- 2 etc is for thermal view, but the outside of the scope is supposed to be normal view, not thermal

See: https://community.bistudio.com/wiki/setPiPEffect