### PR TITLE
fix optic tilting in vehicles

### DIFF
--- a/addons/optics/fnc_gunBank.sqf
+++ b/addons/optics/fnc_gunBank.sqf
@@ -20,6 +20,8 @@ Author:
     commy2
 ---------------------------------------------------------------------------- */
 
+if !(cameraOn isKindOf "CAManBase") exitWith {0};
+
 private _unit = [] call CBA_fnc_currentUnit;
 
 private _pelvis = _unit modelToWorldVisualWorld (_unit selectionPosition "Pelvis");


### PR DESCRIPTION
**When merged this pull request will:**
- I heard scripted optics are weird in FFV animations. You can't lean in FFV anyway, so just always set the angle to 0 = upright.
