### PR TITLE
6.5mm magwells fix

### DIFF
--- a/addons/jam/magwells_65x39.hpp
+++ b/addons/jam/magwells_65x39.hpp
@@ -1,15 +1,21 @@
     class CBA_65x39_MX {
         BI_mags[] = {
             "30Rnd_65x39_caseless_mag",
-            "30Rnd_65x39_caseless_green",
             "30Rnd_65x39_caseless_mag_Tracer",
-            "30Rnd_65x39_caseless_green_mag_Tracer"
+            "30Rnd_65x39_caseless_khaki_mag_Tracer",
+            "30Rnd_65x39_caseless_khaki_mag",
+            "30Rnd_65x39_caseless_black_mag_Tracer",
+            "30Rnd_65x39_caseless_black_mag",
         };
     };
     class CBA_65x39_MX_XL {
         BI_mags[] = {
             "100Rnd_65x39_caseless_mag",
-            "100Rnd_65x39_caseless_mag_Tracer"
+            "100Rnd_65x39_caseless_mag_Tracer",
+            "100Rnd_65x39_caseless_khaki_mag_Tracer",
+            "100Rnd_65x39_caseless_khaki_mag",
+            "100Rnd_65x39_caseless_black_mag_Tracer",
+            "100Rnd_65x39_caseless_black_mag",
         };
     };
 

--- a/addons/jam/magwells_65x39.hpp
+++ b/addons/jam/magwells_65x39.hpp
@@ -1,10 +1,10 @@
     class CBA_65x39_MX {
         BI_mags[] = {
             "30Rnd_65x39_caseless_mag",
-            "30Rnd_65x39_caseless_khaki_mag",
-            "30Rnd_65x39_caseless_black_mag",
             "30Rnd_65x39_caseless_mag_Tracer",
+            "30Rnd_65x39_caseless_khaki_mag",
             "30Rnd_65x39_caseless_khaki_mag_Tracer",
+            "30Rnd_65x39_caseless_black_mag",
             "30Rnd_65x39_caseless_black_mag_Tracer"
         };
     };
@@ -12,10 +12,10 @@
     class CBA_65x39_MX_XL {
         BI_mags[] = {
             "100Rnd_65x39_caseless_mag",
-            "100Rnd_65x39_caseless_khaki_mag",
-            "100Rnd_65x39_caseless_black_mag",
             "100Rnd_65x39_caseless_mag_Tracer",
+            "100Rnd_65x39_caseless_khaki_mag",
             "100Rnd_65x39_caseless_khaki_mag_Tracer",
+            "100Rnd_65x39_caseless_black_mag",
             "100Rnd_65x39_caseless_black_mag_Tracer"
         };
     };

--- a/addons/jam/magwells_65x39.hpp
+++ b/addons/jam/magwells_65x39.hpp
@@ -1,21 +1,22 @@
     class CBA_65x39_MX {
         BI_mags[] = {
             "30Rnd_65x39_caseless_mag",
+            "30Rnd_65x39_caseless_khaki_mag",
+            "30Rnd_65x39_caseless_black_mag",
             "30Rnd_65x39_caseless_mag_Tracer",
             "30Rnd_65x39_caseless_khaki_mag_Tracer",
-            "30Rnd_65x39_caseless_khaki_mag",
-            "30Rnd_65x39_caseless_black_mag_Tracer",
-            "30Rnd_65x39_caseless_black_mag",
+            "30Rnd_65x39_caseless_black_mag_Tracer"
         };
     };
+
     class CBA_65x39_MX_XL {
         BI_mags[] = {
             "100Rnd_65x39_caseless_mag",
+            "100Rnd_65x39_caseless_khaki_mag",
+            "100Rnd_65x39_caseless_black_mag",
             "100Rnd_65x39_caseless_mag_Tracer",
             "100Rnd_65x39_caseless_khaki_mag_Tracer",
-            "100Rnd_65x39_caseless_khaki_mag",
-            "100Rnd_65x39_caseless_black_mag_Tracer",
-            "100Rnd_65x39_caseless_black_mag",
+            "100Rnd_65x39_caseless_black_mag_Tracer"
         };
     };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add colored MX magazines to both MX magwells
- Remove unintended Katiba magazines from 30rnd MX magwell

MX magwells seemed broken if combined with other addons (e.g. colored mags wouldn't appear in arsenal, don't know which mod causes this exactly), also 30rnd Katiba mags shouldn't be able to be loaded into MX rifles.