### PR TITLE
add CONTACT SERVER ADMIN header to signature mismatch message

### DIFF
--- a/addons/ui/CfgEventHandlers.hpp
+++ b/addons/ui/CfgEventHandlers.hpp
@@ -38,4 +38,7 @@ class Extended_DisplayLoad_EventHandlers {
     class RscDisplayCurator {
         ADDON = QUOTE(_this call (uiNamespace getVariable 'FUNC(initDisplayCurator)'));
     };
+    class RscMsgBox {
+        ADDON = QUOTE(_this call (uiNamespace getVariable 'FUNC(initDisplayMessageBox)'));
+    };
 };

--- a/addons/ui/XEH_preStart.sqf
+++ b/addons/ui/XEH_preStart.sqf
@@ -10,6 +10,7 @@ PREP(initDisplayRemoteMissions);
 PREP(initDisplayDiary);
 PREP(initDisplay3DEN);
 PREP(initDisplayCurator);
+PREP(initDisplayMessageBox);
 
 PREP(preload3DEN);
 PREP(preloadCurator);

--- a/addons/ui/fnc_initDisplayMessageBox.sqf
+++ b/addons/ui/fnc_initDisplayMessageBox.sqf
@@ -1,0 +1,16 @@
+#include "script_component.hpp"
+
+params ["_display"];
+
+private _messageBox = _display displayCtrl IDC_MSG_BOX_MESSAGE;
+private _message = ctrlText _messageBox;
+
+// This check has to work with all languages and without functions defined in mission namespace.
+private _isSignatureMissingMessage = _message find (with uiNamespace do {
+    [localize "str_signature_missing", "%s"] call CBA_fnc_split
+} select 1) != -1;
+
+if (_isSignatureMissingMessage) then {
+    private _messageBoxHeader = _display displayCtrl 11001;
+    _messageBoxHeader ctrlSetText toUpper LLSTRING(ContactServerAdmin);
+};

--- a/addons/ui/stringtable.xml
+++ b/addons/ui/stringtable.xml
@@ -151,5 +151,9 @@
         <Key ID="STR_CBA_Ui_NotifyLifetimeTooltip">
             <English>Notification display duration in seconds.</English>
         </Key>
+        <Key ID="STR_CBA_Ui_ContactServerAdmin">
+            <English>Contact the server admin.</English>
+            <German>Serveradministrator benachrichtigen.</German>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Tired of the workshop drones, so append the crappy BI error messages so blame does not get shifted to this (so _me_ by association).

Open for more suggestions as error messages in this game are generally horrendous and offensively so.