### PR TITLE
Default transition targetstate to transition configName

### DIFF
--- a/addons/statemachine/fnc_createFromConfig.sqf
+++ b/addons/statemachine/fnc_createFromConfig.sqf
@@ -45,7 +45,10 @@ private _stateMachine = [_list, _skipNull] call FUNC(create);
     private _state = configName _x;
     {
         private _transition = configName _x;
-        private _targetState = [_x,"targetState",_transition] call BIS_fnc_returnConfigEntry;
+        private _targetState = _transition;
+        if (isText (_x >> "targetState")) then {
+            _targetState = getText (_x >> "targetState");
+        };
         GET_FUNCTION(_condition,_x >> "condition");
         GET_FUNCTION(_onTransition,_x >> "onTransition");
         private _events = getArray (_x >> "events");

--- a/addons/statemachine/fnc_createFromConfig.sqf
+++ b/addons/statemachine/fnc_createFromConfig.sqf
@@ -45,7 +45,7 @@ private _stateMachine = [_list, _skipNull] call FUNC(create);
     private _state = configName _x;
     {
         private _transition = configName _x;
-        private _targetState = getText (_x >> "targetState");
+        private _targetState = [_x,"targetState",_transition] call BIS_fnc_returnConfigEntry;
         GET_FUNCTION(_condition,_x >> "condition");
         GET_FUNCTION(_onTransition,_x >> "onTransition");
         private _events = getArray (_x >> "events");


### PR DESCRIPTION
**When merged this pull request will:**
- Change the default transition targetstate value to the transition configName, so that most transitions between states can have their transition state and targetstate defined without a near duplicate entry.

Example: 

```
class Init {
    onStateEntered = QFUNC(onCacheInit);
    class Cache {
        targetState = "Cache";
        events[] = {QGVAR(cache)};
    };

    class Uncache {
        targetState = "Uncache";
        events[] = {QGVAR(uncache)};
    };
};
```

Could now be written as: 

```
class Init {
    onStateEntered = QFUNC(onCacheInit);
    class Cache {
        events[] = {QGVAR(cache)};
    };

    class Uncache {
        events[] = {QGVAR(uncache)};
    };
};
```

while targetState 's that deviate from the transition configName are supported.