### PR TITLE
handle returned assignments in key events

### DIFF
--- a/addons/events/fnc_keyHandlerDown.sqf
+++ b/addons/events/fnc_keyHandlerDown.sqf
@@ -72,7 +72,7 @@ private _blockInput = false;
             _params pushBack + _keybindParams;
             _params pushBack _x;
 
-            _blockInput = ([_params call _code] param [0, false] isEqualTo true) || {_blockInput};
+            _blockInput = ([nil] apply {_params call _code} param [0, false] isEqualTo true) || {_blockInput};
         };
     };
 } forEach (GVAR(keyDownStates) param [_inputKey, []]);


### PR DESCRIPTION
**When merged this pull request will:**
- Atm. keybindings that return assignments error:

Test script (15 is tab key):
```
["Test001", "Action001", "Test Text", {
    systemChat str diag_frameNo;
    0 = 0
}, {}, [15, [false, false, false]], false] call CBA_fnc_addKeybind;
```
Before: generic error in expression
After: works, assignment treated as "false" (like any other non boolean return value).
