### PR TITLE
Add period at the end of target debug info log

### DIFF
--- a/addons/diagnostic/XEH_preInit.sqf
+++ b/addons/diagnostic/XEH_preInit.sqf
@@ -19,7 +19,7 @@ GVAR(projectileTrackedUnits) = [];
 ADDON = true;
 
 if (getMissionConfigValue ["EnableTargetDebug", 0] == 1 || {getNumber (configFile >> "EnableTargetDebug") == 1}) then {
-    INFO("EnableTargetDebug is enabled");
+    INFO("EnableTargetDebug is enabled.");
 
     [QGVAR(watchVariable), {
         params ["_clientID", "_varIndex", "_statementText"];


### PR DESCRIPTION
**When merged this pull request will:**
- Make @commy2's message less :hankey:.

> commy2:
| 17:52:19 [CBA] (diagnostic) INFO: EnableTargetDebug is enabled
Shit message. No period at the end of the sentence.