### PR TITLE
Cleanup CfgPatches and use VERSION_CONFIG consistently

### DIFF
--- a/addons/accessory/MRT_AccFncs/config.cpp
+++ b/addons/accessory/MRT_AccFncs/config.cpp
@@ -2,6 +2,5 @@ class CfgPatches {
     class MRT_AccFncs {
         units[] = {};
         requiredAddons[] = {"cba_accessory"};
-        versionDesc = "MRT Attachment Functions";
     };
 };

--- a/addons/accessory/MRT_AccFncs/config.cpp
+++ b/addons/accessory/MRT_AccFncs/config.cpp
@@ -1,7 +1,7 @@
 class CfgPatches {
     class MRT_AccFncs {
+        units[] = {};
         requiredAddons[] = {"cba_accessory"};
         versionDesc = "MRT Attachment Functions";
-        units[] = {};
     };
 };

--- a/addons/accessory/config.cpp
+++ b/addons/accessory/config.cpp
@@ -2,15 +2,15 @@
 
 class CfgPatches {
     class ADDON {
-        author = "$STR_CBA_Author";
         name = CSTRING(component);
-        url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_common", "cba_events"};
+        author = "$STR_CBA_Author";
         authors[] = {"da12thMonkey", "Robalo", "Tupolov"};
-        version = VERSION;
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
     };
 };
 

--- a/addons/ai/config.cpp
+++ b/addons/ai/config.cpp
@@ -2,14 +2,15 @@
 
 class CfgPatches {
     class ADDON {
-        author = "$STR_CBA_Author";
         name = CSTRING(component);
-        url = "$STR_CBA_URL";
         units[] = {"CBA_B_InvisibleTarget","CBA_O_InvisibleTarget","CBA_I_InvisibleTarget","CBA_BuildingPos"};
+        weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_common"};
-        version = VERSION;
+        author = "$STR_CBA_Author";
         authors[] = {"Rommel"};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
     };
 };
 

--- a/addons/arrays/config.cpp
+++ b/addons/arrays/config.cpp
@@ -2,14 +2,15 @@
 
 class CfgPatches {
     class ADDON {
-        author = "$STR_CBA_Author";
         name = CSTRING(component);
-        url = "$STR_CBA_URL";
         units[] = {};
+        weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_common"};
-        version = VERSION;
+        author = "$STR_CBA_Author";
         authors[] = {"Spooner"};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
     };
 };
 

--- a/addons/common/config.cpp
+++ b/addons/common/config.cpp
@@ -2,15 +2,15 @@
 
 class CfgPatches {
     class ADDON {
-        author = "$STR_CBA_Author";
         name = CSTRING(component);
-        url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"A3_Data_F_Enoch_Loadorder", "A3_Data_F_Mod_Loadorder"};
-        version = VERSION;
+        author = "$STR_CBA_Author";
         authors[] = {"Spooner","Sickboy","Rocko"};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
     };
 };
 

--- a/addons/diagnostic/config.cpp
+++ b/addons/diagnostic/config.cpp
@@ -2,14 +2,15 @@
 
 class CfgPatches {
     class ADDON {
-        author = "$STR_CBA_Author";
         name = CSTRING(component);
-        url = "$STR_CBA_URL";
         units[] = {};
+        weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_common", "cba_events"};
-        version = VERSION;
+        author = "$STR_CBA_Author";
         authors[] = {"Spooner", "Sickboy"};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
     };
 };
 

--- a/addons/disposable/config.cpp
+++ b/addons/disposable/config.cpp
@@ -2,15 +2,15 @@
 
 class CfgPatches {
     class ADDON {
-        author = "$STR_CBA_Author";
         name = CSTRING(component);
-        url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_common","cba_events"};
-        version = VERSION;
+        author = "$STR_CBA_Author";
         authors[] = {"commy2"};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
     };
 };
 

--- a/addons/events/config.cpp
+++ b/addons/events/config.cpp
@@ -2,14 +2,15 @@
 
 class CfgPatches {
     class ADDON {
-        author = "$STR_CBA_Author";
         name = CSTRING(component);
-        url = "$STR_CBA_URL";
         units[] = {};
+        weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_common"};
-        version = VERSION;
+        author = "$STR_CBA_Author";
         authors[] = {"Spooner", "Sickboy", "Xeno", "commy2"};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
     };
 };
 

--- a/addons/hashes/config.cpp
+++ b/addons/hashes/config.cpp
@@ -2,14 +2,15 @@
 
 class CfgPatches {
     class ADDON {
-        author = "$STR_CBA_Author";
         name = CSTRING(component);
-        url = "$STR_CBA_URL";
         units[] = {};
+        weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_common"};
-        version = VERSION;
+        author = "$STR_CBA_Author";
         authors[] = {"Spooner"};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
     };
 };
 

--- a/addons/help/config.cpp
+++ b/addons/help/config.cpp
@@ -2,15 +2,15 @@
 
 class CfgPatches {
     class ADDON {
-        author = "$STR_CBA_Author";
         name = CSTRING(component);
-        url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_common","cba_keybinding"};
-        version = VERSION;
+        author = "$STR_CBA_Author";
         authors[] = {"alef","Rocko","Sickboy"};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
     };
 };
 

--- a/addons/jam/config.cpp
+++ b/addons/jam/config.cpp
@@ -2,15 +2,15 @@
 
 class CfgPatches {
     class ADDON {
-        author = "$STR_CBA_Author";
         name = CSTRING(component);
-        url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_common"};
-        version = VERSION;
+        author = "$STR_CBA_Author";
         authors[] = {"Robalo"};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
     };
 };
 

--- a/addons/jam/jam_finish/config.cpp
+++ b/addons/jam/jam_finish/config.cpp
@@ -2,14 +2,15 @@
 
 class CfgPatches {
     class ADDON {
-        author = "$STR_CBA_Author";
         name = ECSTRING(jam,component);
-        url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_jam"};
-        version = VERSION;
+        author = "$STR_CBA_Author";
+        authors[] = {};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
     };
 };
 

--- a/addons/jr/config.cpp
+++ b/addons/jr/config.cpp
@@ -11,15 +11,15 @@
 
 class CfgPatches {
     class ADDON {
-        author = "$STR_CBA_Author";
         name = CSTRING(component);
-        url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_jr_prep"};
-        version = VERSION;
+        author = "$STR_CBA_Author";
         authors[] = {"Robalo"};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
     };
 };
 

--- a/addons/jr/jr_prep/config.cpp
+++ b/addons/jr/jr_prep/config.cpp
@@ -2,14 +2,15 @@
 
 class CfgPatches {
     class ADDON {
-        author = "$STR_CBA_Author";
         name = ECSTRING(jr,component);
-        url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_common"};
-        version = VERSION;
+        author = "$STR_CBA_Author";
+        authors[] = {};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
     };
 };
 

--- a/addons/keybinding/config.cpp
+++ b/addons/keybinding/config.cpp
@@ -2,14 +2,14 @@
 
 class CfgPatches {
     class ADDON {
-        author = "$STR_CBA_Author";
         name = CSTRING(component);
-        url = "$STR_CBA_URL";
         units[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_common", "cba_events"};
-        version = VERSION;
+        author = "$STR_CBA_Author";
         authors[] = {"Taosenai"};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
     };
 };
 

--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -37,7 +37,6 @@ class CfgPatches {
         authors[] = {};
         url = "$STR_CBA_URL";
         VERSION_CONFIG;
-        versionDesc = "C.B.A.";
     };
 };
 

--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -3,9 +3,7 @@
 // Simply a package which requires other addons.
 class CfgPatches {
     class ADDON {
-        author = "$STR_CBA_Author";
         name = CSTRING(component);
-        url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
@@ -35,9 +33,11 @@ class CfgPatches {
             "cba_optics",
             "cba_disposable"
         };
-        versionDesc = "C.B.A.";
-        VERSION_CONFIG;
+        author = "$STR_CBA_Author";
         authors[] = {};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
+        versionDesc = "C.B.A.";
     };
 };
 

--- a/addons/main_a3/config.cpp
+++ b/addons/main_a3/config.cpp
@@ -2,15 +2,15 @@
 
 class CfgPatches {
     class ADDON {
-        author = "$STR_CBA_Author";
         name = ECSTRING(main,component);
-        url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_main"};
-        VERSION_CONFIG;
+        author = "$STR_CBA_Author";
         authors[] = {};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
     };
 };
 

--- a/addons/modules/config.cpp
+++ b/addons/modules/config.cpp
@@ -2,15 +2,15 @@
 
 class CfgPatches {
     class ADDON {
-        author = "$STR_CBA_Author";
         name = CSTRING(component);
-        url = "$STR_CBA_URL";
         units[] = {"CBA_ModuleAttack", "CBA_ModuleDefend", "CBA_ModulePatrol"};
+        weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_common"};
-        version = VERSION;
+        author = "$STR_CBA_Author";
         authors[] = {"WiredTiger"};
-
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
     };
 };
 

--- a/addons/music/config.cpp
+++ b/addons/music/config.cpp
@@ -2,14 +2,15 @@
 
 class CfgPatches {
     class ADDON {
-        author = "$STR_CBA_Author";
         name = CSTRING(component);
-        url = "$STR_CBA_URL";
         units[] = {};
+        weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_common"};
-        version = VERSION;
+        author = "$STR_CBA_Author";
         authors[] = {"Dedmen", "Dorbedo", "Fishy"};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
     };
 };
 

--- a/addons/network/config.cpp
+++ b/addons/network/config.cpp
@@ -2,15 +2,15 @@
 
 class CfgPatches {
     class ADDON {
-        author = "$STR_CBA_Author";
         name = CSTRING(component);
-        url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_common", "cba_events"};
-        version = VERSION;
+        author = "$STR_CBA_Author";
         authors[] = {"Sickboy"};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
     };
 };
 

--- a/addons/optics/config.cpp
+++ b/addons/optics/config.cpp
@@ -1,16 +1,16 @@
-﻿#include "script_component.hpp"
+#include "script_component.hpp"
 
 class CfgPatches {
     class ADDON {
-        author = "$STR_CBA_Author";
         name = CSTRING(component);
-        url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_common","cba_events","cba_jr"};
-        version = VERSION;
+        author = "$STR_CBA_Author";
         authors[] = {"commy2"};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
     };
 };
 

--- a/addons/settings/config.cpp
+++ b/addons/settings/config.cpp
@@ -2,15 +2,15 @@
 
 class CfgPatches {
     class ADDON {
-        author = "$STR_CBA_Author";
         name = CSTRING(component);
-        url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_common", "cba_events"};
-        version = VERSION;
+        author = "$STR_CBA_Author";
         authors[] = {"commy2"};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
     };
 };
 

--- a/addons/statemachine/config.cpp
+++ b/addons/statemachine/config.cpp
@@ -2,14 +2,15 @@
 
 class CfgPatches {
     class ADDON {
-        author = "$STR_CBA_Author";
         name = CSTRING(component);
-        url = "$STR_CBA_URL";
         units[] = {};
+        weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_common"};
-        version = VERSION;
+        author = "$STR_CBA_Author";
         authors[] = {"BaerMitUmlaut"};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
     };
 };
 

--- a/addons/strings/config.cpp
+++ b/addons/strings/config.cpp
@@ -2,14 +2,15 @@
 
 class CfgPatches {
     class ADDON {
-        author = "$STR_CBA_Author";
         name = CSTRING(component);
-        url = "$STR_CBA_URL";
         units[] = {};
+        weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_common"};
-        version = VERSION;
+        author = "$STR_CBA_Author";
         authors[] = {"Spooner", "Kronzky"};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
     };
 };
 

--- a/addons/ui/config.cpp
+++ b/addons/ui/config.cpp
@@ -1,15 +1,16 @@
-﻿#include "script_component.hpp"
+#include "script_component.hpp"
 
 class CfgPatches {
     class ADDON {
-        author = "$STR_CBA_Author";
         name = CSTRING(component);
-        url = "$STR_CBA_URL";
         units[] = {};
-        requiredVersion = 1;
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_common", "cba_arrays"};
-        version = VERSION;
+        author = "$STR_CBA_Author";
         authors[] = {"Dr Eyeball", "commy2"};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
     };
 };
 

--- a/addons/vectors/config.cpp
+++ b/addons/vectors/config.cpp
@@ -2,14 +2,15 @@
 
 class CfgPatches {
     class ADDON {
-        author = "$STR_CBA_Author";
         name = CSTRING(component);
-        url = "$STR_CBA_URL";
         units[] = {};
+        weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_common"};
-        version = VERSION;
+        author = "$STR_CBA_Author";
         authors[] = {"Vigilante"};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
     };
 };
 

--- a/addons/versioning/config.cpp
+++ b/addons/versioning/config.cpp
@@ -2,14 +2,15 @@
 
 class CfgPatches {
     class ADDON {
-        author = "$STR_CBA_Author";
         name = CSTRING(component);
-        url = "$STR_CBA_URL";
         units[] = {};
+        weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_common", "cba_strings", "cba_hashes", "cba_diagnostic", "cba_events", "cba_network"};
-        version = VERSION;
+        author = "$STR_CBA_Author";
         authors[] = {"Sickboy"};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
     };
 };
 

--- a/addons/xeh/config.cpp
+++ b/addons/xeh/config.cpp
@@ -2,17 +2,15 @@
 
 class CfgPatches {
     class ADDON {
-        author = "$STR_CBA_Author";
         name = CSTRING(component);
-        url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_common"};
-        requiredVersion = 0.1;
-        version = "4.0.0"; // Due to older mod versions requiring > 3,3,3 etc
-        versionStr = "4.0.0";
-        versionAr[] = {4, 0, 0};
+        author = "$STR_CBA_Author";
         authors[] = {"Solus", "Killswitch", "commy2"};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
 
         // this prevents any patched class from requiring XEH
         addonRootClass = "A3_Characters_F";


### PR DESCRIPTION
**When merged this pull request will:**
- Cleanup all `CfgPatches` for consistency - follow order in ACE3.
- Use `VERSION_CONFIG` in all components - compliments #1221, previously only `version` was defined so Credits showed short version `v3.12`.
- Use `requiredVersion = REQUIRED_VERSION;` consistently.
- Remove now (probably) outdated `4.0.0` version from XEH component.
- Remove outdated `versionDesc`.