### PR TITLE
fix crash when hosting server with large ui scale

### DIFF
--- a/addons/ui/fnc_initDisplayRemoteMissions.sqf
+++ b/addons/ui/fnc_initDisplayRemoteMissions.sqf
@@ -30,11 +30,13 @@ _ctrlMaps lbSetCurSel 0;
 
 ctrlPosition _ctrlMissions params ["_left", "_top", "_width", "_height"];
 
+private _widthSearchBar = (_width - 11 * GUI_GRID_W) min (10 * GUI_GRID_W);
+
 private _ctrlSearch = _display ctrlCreate ["RscEdit", IDC_SEARCH];
 _ctrlSearch ctrlSetPosition [
     _left + 0.1 * GUI_GRID_W,
     _top,
-    _width - 21.2 * GUI_GRID_W,
+    _widthSearchBar,
     GUI_GRID_H
 ];
 _ctrlSearch ctrlCommit 0;
@@ -44,7 +46,7 @@ _ctrlSearch ctrlSetText _filter;
 
 private _ctrlSearchButton = _display ctrlCreate ["RscButtonSearch", IDC_SEARCH_BUTTON];
 _ctrlSearchButton ctrlSetPosition [
-    _left + _width - 21 * GUI_GRID_W,
+    _left + 0.1 * GUI_GRID_W + _widthSearchBar,
     _top,
     GUI_GRID_W,
     GUI_GRID_H


### PR DESCRIPTION
**When merged this pull request will:**
- title
- Idk why this happens. Crashes after `ctrlCommit` after `ctrlSetPosition` set a very small width for RscEditBox controls.
- fixes the control being very small on low resolutions with very large ui
- fix #1180 fix #1218