### PR TITLE
JR - Add muzzle slots for 4.6mm and 7.62x54R

### DIFF
--- a/addons/jr/jr_classes.hpp
+++ b/addons/jr/jr_classes.hpp
@@ -280,6 +280,15 @@ class asdg_MuzzleSlot_762R: asdg_MuzzleSlot { // for 7.62x39 suppressors
     class compatibleItems {};
 };
 
+
+class asdg_MuzzleSlot_762R_PK: asdg_MuzzleSlot { // for 7.62x54R PK mount suppressors
+    class compatibleItems {};
+};
+
+class asdg_MuzzleSlot_762R_SVD: asdg_MuzzleSlot { // for 7.62x54R SVD mount suppressors
+    class compatibleItems {};
+};
+
 class asdg_MuzzleSlot_58: asdg_MuzzleSlot { // for 5.8x42 suppressors
     class compatibleItems {
         muzzle_snds_58_blk_F = 1;
@@ -287,4 +296,8 @@ class asdg_MuzzleSlot_58: asdg_MuzzleSlot { // for 5.8x42 suppressors
         muzzle_snds_58_ghex_F = 1;
         muzzle_snds_58_hex_F = 1;
     };
+};
+
+class asdg_MuzzleSlot_46: asdg_MuzzleSlot { // for 4.6x30 suppressors
+    class compatibleItems {};
 };

--- a/addons/jr/jr_classes.hpp
+++ b/addons/jr/jr_classes.hpp
@@ -280,11 +280,9 @@ class asdg_MuzzleSlot_762R: asdg_MuzzleSlot { // for 7.62x39 suppressors
     class compatibleItems {};
 };
 
-
 class asdg_MuzzleSlot_762R_PK: asdg_MuzzleSlot { // for 7.62x54R PK mount suppressors
     class compatibleItems {};
 };
-
 class asdg_MuzzleSlot_762R_SVD: asdg_MuzzleSlot { // for 7.62x54R SVD mount suppressors
     class compatibleItems {};
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Add one single muzzle slot for 4.6x30mm, should cover both the MP7 and the UCP (if anybody ever makes one)
- Add two separate muzzle slots for 7.62x54R, one for SVDs and one for PKs; closes #1226.

**Potential TODO**
~- [ ] Remove `DMR_01` from legacy JR component~
~- [ ] Add new SVD muzzle slot to `DMR_01`~

- close  #1226