### PR TITLE
add XEH support to WeaponHolder(Simulated)

### DIFF
--- a/addons/xeh/CfgVehicles.hpp
+++ b/addons/xeh/CfgVehicles.hpp
@@ -229,6 +229,16 @@ class CfgVehicles {
         XEH_ENABLED;
     };
 
+    class ReammoBox;
+    class WeaponHolder: ReammoBox {
+        XEH_ENABLED;
+    };
+
+    class ThingX;
+    class WeaponHolderSimulated: ThingX {
+        XEH_ENABLED;
+    };
+
     // backwards comp, inert
     class SLX_XEH_Logic: Logic {
         scope = 1;
@@ -348,7 +358,6 @@ class CfgVehicles {
         XEH_ENABLED;
     };
 
-    class ThingX;
     class Alien_MatterBall_01_base_F: ThingX {
         XEH_ENABLED;
     };


### PR DESCRIPTION
**When merged this pull request will:**
- title

```sqf
["WeaponHolder", "InitPost", {
    systemChat str ["WH", _this];
}] call CBA_fnc_addClassEventHandler;

["WeaponHolderSimulated", "InitPost", {
    systemChat str ["WHS", _this];
}] call CBA_fnc_addClassEventHandler;


["WeaponHolder", "Deleted", {
    systemChat str ["WH del", _this];
}] call CBA_fnc_addClassEventHandler;

["WeaponHolderSimulated", "Deleted", {
    systemChat str ["WHS del", _this];
}] call CBA_fnc_addClassEventHandler;
```

Open inventory
-> WH

Close Inventory (without dropping a weapon)
-> WH del

Drop Item and then Close Inventory
-> nothing (WH survives)

Kill a person
-> WHS

Take their weapon (when not having one yourself)
-> WHS del