### PR TITLE
fix includeDisabled flag in CBA_fnc_supportMonitor

### DIFF
--- a/addons/xeh/fnc_supportMonitor.sqf
+++ b/addons/xeh/fnc_supportMonitor.sqf
@@ -29,7 +29,7 @@ private _notSupportingClasses = [];
 
 {
     if (_classFilter == "" || {configName _x isKindOf _classFilter}) then {
-        if (!isClass (_x >> "EventHandlers" >> QUOTE(XEH_CLASS))) then {
+        if (!isText (_x >> "EventHandlers" >> QUOTE(XEH_CLASS) >> "init")) then {
             // don't list duplicates
             if (!_includeDuplicates && {{configName _x == "EventHandlers"} count configProperties [_x, "isClass _x", false] == 0}) exitWith {};
 


### PR DESCRIPTION
**When merged this pull request will:**

`CBA_fnc_supportMonitor` with `includeDuplicates` and `includeDisabled` is supposed to report all classes that do not support XEH, including those that have it explicitly disabled.

The `XEH_DISABLED` macro sets a flag that is for bwc still named `SLX_XEH_DISABLED` to 1. This flags only remaining purpose is to indicate that at least one parent class disabled XEH intentionally. Intentional disabling is for example done when it is clear that a lot of ancestor classes will be created by BI or addon makers that create their own `EventHandler` classes without inheritance and therefore will not support XEH. This avoids unnecessary logging of incompatible classes and the starting of the fallback loop. (Think of one RPT line for every flagpole retexture: they all get their texture by `EventHandlers` class init event that is not inherited, and BI and addon makers keep adding flagpoles using the same template).

The `CBA_fnc_supportMonitor` function before checking `includeDuplicates` and `includeDisabled` only considers classes that have `EventHandlers\CBA_Extended_EventHandlers` not defined.

The `delete` config command when used in `XEH_DISABLED` was very unreliable and caused inconsistency and unintended behavior. So when rewriting XEH to use the `CBA_Extended_EventHandlers` sub class of the `EventHandlers` class, I made it overwrite with an empty class instead of using `delete`: https://github.com/CBATeam/CBA_A3/blob/master/addons/main/script_macros_common.hpp#L1759

This means however that `isClass` still reports true. The real check should be if the class has content, which here is implemented as `isText (X >> "init")`.

**Example:**
```sqf
"WeaponHolder" in ([false, true, true] call CBA_fnc_supportMonitor);
```
before: `false`
after: `true`
