### PR TITLE
Slider UI style improvements for cba_settings

### DIFF
--- a/addons/settings/gui.hpp
+++ b/addons/settings/gui.hpp
@@ -119,20 +119,43 @@ class RscDisplayClientGetReady: RscDisplayGetReady {
     };
 };
 
-class RscControlsGroupNoHScrollbars;
+class RscControlsGroup;
+class RscControlsGroupNoHScrollbars: RscControlsGroup {
+    class VScrollbar;
+};
+
 class GVAR(OptionsGroup): RscControlsGroupNoHScrollbars {
     x = POS_W(0);
     y = POS_H(3.5);
     w = POS_W(37.5);
     h = POS_H(13.8);
     lineHeight = POS_H(1);
+    class VScrollbar: VScrollbar {
+        thumb = "\a3\3DEN\Data\Controls\ctrlDefault\thumb_ca.paa";
+        border = "\a3\3DEN\Data\Controls\ctrlDefault\border_ca.paa";
+        arrowFull = "\a3\3DEN\Data\Controls\ctrlDefault\arrowFull_ca.paa";
+        arrowEmpty = "\a3\3DEN\Data\Controls\ctrlDefault\arrowEmpty_ca.paa";
+    };
+};
+
+class RscCombo {
+    class ComboScrollBar;
+};
+class GVAR(RscCombo): RscCombo {
+    arrowFull = "\a3\3DEN\Data\Controls\ctrlCombo\arrowFull_ca.paa";
+    arrowEmpty = "\a3\3DEN\Data\Controls\ctrlCombo\arrowEmpty_ca.paa";
+    class ComboScrollBar: ComboScrollBar {
+        thumb = "\a3\3DEN\Data\Controls\ctrlDefault\thumb_ca.paa";
+        border = "\a3\3DEN\Data\Controls\ctrlDefault\border_ca.paa";
+        arrowFull = "\a3\3DEN\Data\Controls\ctrlDefault\arrowFull_ca.paa";
+        arrowEmpty = "\a3\3DEN\Data\Controls\ctrlDefault\arrowEmpty_ca.paa";
+    };
 };
 
 // Has to be created dynamically for every options group, because they would
 // interfere with the controls groups otherwise. Scripted controls are always
 // placed below config controls.
-class RscCombo;
-class GVAR(AddonsList): RscCombo {
+class GVAR(AddonsList): GVAR(RscCombo) {
     linespacing = 1;
     text = "";
     wholeHeight = POS_H(12);
@@ -293,7 +316,7 @@ class GVAR(Row_List): GVAR(Row_Base) {
 
     class controls: controls {
         class Name: Name {};
-        class List: RscCombo {
+        class List: GVAR(RscCombo) {
             idc = IDC_SETTING_LIST;
             x = POS_W(16);
             y = POS_H(0) + TABLE_LINE_SPACING/2;
@@ -307,18 +330,18 @@ class GVAR(Row_List): GVAR(Row_Base) {
     };
 };
 
-class RscXSliderH;
+class ctrlXSliderH;
 
 class GVAR(Row_Slider): GVAR(Row_Base) {
     GVAR(script) = QFUNC(gui_settingSlider);
 
     class controls: controls {
         class Name: Name {};
-        class Slider: RscXSliderH {
+        class Slider: ctrlXSliderH {
             idc = IDC_SETTING_SLIDER;
             x = POS_W(16);
             y = POS_H(0) + TABLE_LINE_SPACING/2;
-            w = POS_W(8);
+            w = POS_W(7.9);
             h = POS_H(1);
         };
         class Edit: RscEdit {
@@ -350,14 +373,14 @@ class GVAR(Row_Color): GVAR(Row_Base) {
             w = POS_W(6);
             h = POS_H(1);
         };
-        class Red: RscXSliderH {
+        class Red: ctrlXSliderH {
             idc = IDC_SETTING_COLOR_RED;
             color[] = {1,0,0,0.6};
             colorActive[] = {1,0,0,1};
             colorDisable[] = {1,0,0,0.4};
             x = POS_W(16);
             y = POS_H(0) + TABLE_LINE_SPACING/2;
-            w = POS_W(8);
+            w = POS_W(7.9);
             h = POS_H(1);
         };
         class Red_Edit: RscEdit {
@@ -420,11 +443,11 @@ class GVAR(Row_ColorAlpha): GVAR(Row_Color) {
         class Green_Edit: Green_Edit {};
         class Blue: Blue {};
         class Blue_Edit: Blue_Edit {};
-        class Alpha: RscXSliderH {
+        class Alpha: ctrlXSliderH {
             idc = IDC_SETTING_COLOR_ALPHA;
             x = POS_W(16);
             y = POS_H(3) + TABLE_LINE_SPACING/2;
-            w = POS_W(8);
+            w = POS_W(7.9);
             h = POS_H(1);
         };
         class Alpha_Edit: RscEdit {
@@ -459,7 +482,7 @@ class GVAR(Row_Time): GVAR(Row_Base) {
         class Name: Name {
             y = POS_H(0.5) + TABLE_LINE_SPACING / 2;
         };
-        class Slider: RscXSliderH {
+        class Slider: ctrlXSliderH {
             idc = IDC_SETTING_TIME_SLIDER;
             x = POS_W(16);
             y = POS_H(0) + TABLE_LINE_SPACING / 2;
@@ -520,7 +543,6 @@ class GVAR(Row_Time): GVAR(Row_Base) {
     };
 };
 
-class RscControlsGroup;
 class RscTitle;
 class RscListBox;
 

--- a/addons/settings/gui.hpp
+++ b/addons/settings/gui.hpp
@@ -130,6 +130,7 @@ class GVAR(OptionsGroup): RscControlsGroupNoHScrollbars {
     w = POS_W(37.5);
     h = POS_H(13.8);
     lineHeight = POS_H(1);
+
     class VScrollbar: VScrollbar {
         thumb = "\a3\3DEN\Data\Controls\ctrlDefault\thumb_ca.paa";
         border = "\a3\3DEN\Data\Controls\ctrlDefault\border_ca.paa";
@@ -141,9 +142,11 @@ class GVAR(OptionsGroup): RscControlsGroupNoHScrollbars {
 class RscCombo {
     class ComboScrollBar;
 };
+
 class GVAR(RscCombo): RscCombo {
     arrowFull = "\a3\3DEN\Data\Controls\ctrlCombo\arrowFull_ca.paa";
     arrowEmpty = "\a3\3DEN\Data\Controls\ctrlCombo\arrowEmpty_ca.paa";
+
     class ComboScrollBar: ComboScrollBar {
         thumb = "\a3\3DEN\Data\Controls\ctrlDefault\thumb_ca.paa";
         border = "\a3\3DEN\Data\Controls\ctrlDefault\border_ca.paa";


### PR DESCRIPTION
**When merged this pull request will:**
- Fix overlap between sliders and their associated edit boxes
- Use 3DEN controls arrow images for sliders, combo boxes, and scroll bars
    - Somewhat subjective which is better but I think the filled arrows look better

<details>
<summary>Images</summary>

Before:
![cba_settings_1](https://user-images.githubusercontent.com/34453221/64915127-efe87580-d72d-11e9-8efb-16f0c0762f51.png)

After:
![cba_settings_2](https://user-images.githubusercontent.com/34453221/64915129-f4ad2980-d72d-11e9-9dd1-9f50816514bd.png)

</details>