### PR TITLE
reserved slots in lobby

### DIFF
--- a/addons/ui/XEH_preInit.sqf
+++ b/addons/ui/XEH_preInit.sqf
@@ -31,4 +31,24 @@ FUNC(mouseButtonDown) = CBA_fnc_flexiMenu_mouseButtonDown;
 FUNC(highlightCaretKey) = CBA_fnc_flexiMenu_highlightCaretKey;
 FUNC(execute) = CBA_fnc_flexiMenu_execute;
 
+// reserved slots
+["CBA_loadingScreenDone", {
+    private _storedUID = profileNamespace getVariable [QGVAR(SteamUID), ""];
+    private _currentUID = getPlayerUID player;
+
+    if (_storedUID != _currentUID) then {
+        // Store UID in profile for reserved slots framework.
+        if !(_currentUID in ["", "_SP_AI_", "_SP_PLAYER_"]) then {
+            profileNamespace setVariable [QGVAR(SteamUID), _currentUID];
+            saveProfileNamespace;
+
+            // End the mission if the UID has been modified.
+            if (_storedUID != "") then {
+                ERROR_2("Mismatching UID in profile. Profile: %1, Unit: %2", _storedUID, _currentUID);
+                uiNamespace getVariable "RscDisplayMission" closeDisplay 0;
+            };
+        };
+    };
+}] call CBA_fnc_addEventHandler;
+
 ADDON = true;


### PR DESCRIPTION
**When merged this pull request will:**
- This PR makes it so the mission maker can append the Role Description with the Steam UID the player requires to select that slot.
- Example: Pilot@Group§76561198008809667

Problems:
You cannot read `getPlayerUID` in the briefing, since there is no avatar. PlayerConnected does not work in the main menu, because it does not work in SP, so the only way to retrieve the UID is by storing it in the profile.

This means that one ***has to at least start one multiplayer game for the UID to be stored in profile***, including every time the profile is wiped by a game crash / migrating computers.

Cheating here is no problem as we can just kick the player if the profile UID is different from the actual UID after mission start.

The ***drag and drop feature has to be disabled in the lobby***, because that cannot be overwritten like clicking the list box. This means the admin can no longer move people into their slots, when at least one reserved slot is present.

There is ***no way to indicate that a slot is reserved aside from labeling the role as "reserved" etc.*** Colors are sadly all hard coded and it does not seem like additional text or icons can be added to these list items.

Experimental