### PR TITLE
Add JR FrontSideRail to MX

### DIFF
--- a/addons/jr/CfgWeapons.hpp
+++ b/addons/jr/CfgWeapons.hpp
@@ -336,36 +336,6 @@ class CfgWeapons {
     };
 
     class mk20_base_F: Rifle_Base_F {
-        class WeaponSlotsInfo;
-    };
-
-    class arifle_Mk20_F: mk20_base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class CowsSlot: asdg_OpticRail1913 {
-                iconPosition[] = {0.45,0.25};
-                iconScale = 0.2;
-            };
-            class PointerSlot: asdg_FrontSideRail {
-                iconPosition[] = {0.35,0.35};
-                iconScale = 0.25;
-            };
-        };
-    };
-
-    class arifle_Mk20C_F: mk20_base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class PointerSlot: asdg_FrontSideRail {
-                iconPosition[] = {0.35,0.35};
-                iconScale = 0.25;
-            };
-            class CowsSlot: asdg_OpticRail1913 {
-                iconPosition[] = {0.45,0.25};
-                iconScale = 0.2;
-            };
-        };
-    };
-
-    class arifle_Mk20_GL_F: mk20_base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
             class PointerSlot: asdg_FrontSideRail {
                 iconPosition[] = {0.35,0.35};

--- a/addons/jr/CfgWeapons.hpp
+++ b/addons/jr/CfgWeapons.hpp
@@ -336,6 +336,36 @@ class CfgWeapons {
     };
 
     class mk20_base_F: Rifle_Base_F {
+        class WeaponSlotsInfo;
+    };
+
+    class arifle_Mk20_F: mk20_base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            class CowsSlot: asdg_OpticRail1913 {
+                iconPosition[] = {0.45,0.25};
+                iconScale = 0.2;
+            };
+            class PointerSlot: asdg_FrontSideRail {
+                iconPosition[] = {0.35,0.35};
+                iconScale = 0.25;
+            };
+        };
+    };
+
+    class arifle_Mk20C_F: mk20_base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            class PointerSlot: asdg_FrontSideRail {
+                iconPosition[] = {0.35,0.35};
+                iconScale = 0.25;
+            };
+            class CowsSlot: asdg_OpticRail1913 {
+                iconPosition[] = {0.45,0.25};
+                iconScale = 0.2;
+            };
+        };
+    };
+
+    class arifle_Mk20_GL_F: mk20_base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
             class PointerSlot: asdg_FrontSideRail {
                 iconPosition[] = {0.35,0.35};
@@ -349,6 +379,10 @@ class CfgWeapons {
     };
 
     class arifle_MX_Base_F: Rifle_Base_F {
+        class WeaponSlotsInfo;
+    };
+
+    class arifle_MXC_F: arifle_MX_Base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
             class PointerSlot: asdg_FrontSideRail {
                 iconPosition[] = {0.35,0.35};
@@ -363,6 +397,14 @@ class CfgWeapons {
 
     class arifle_MX_F: arifle_MX_Base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
+            class PointerSlot: asdg_FrontSideRail {
+                iconPosition[] = {0.35,0.35};
+                iconScale = 0.25;
+            };
+            class CowsSlot: asdg_OpticRail1913 {
+                iconPosition[] = {0.5,0.35};
+                iconScale = 0.2;
+            };
             class UnderBarrelSlot: asdg_UnderSlot {
                 iconPosition[] = {0.2,0.7};
                 iconScale = 0.2;
@@ -370,8 +412,29 @@ class CfgWeapons {
         };
     };
 
+    class arifle_MX_GL_F: arifle_MX_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            class PointerSlot: asdg_FrontSideRail {
+                iconPosition[] = {0.35,0.35};
+                iconScale = 0.25;
+            };
+            class CowsSlot: asdg_OpticRail1913 {
+                iconPosition[] = {0.5,0.35};
+                iconScale = 0.2;
+            };
+        };
+    };
+
     class arifle_MX_SW_F: arifle_MX_Base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
+            class PointerSlot: asdg_FrontSideRail {
+                iconPosition[] = {0.35,0.35};
+                iconScale = 0.25;
+            };
+            class CowsSlot: asdg_OpticRail1913 {
+                iconPosition[] = {0.5,0.35};
+                iconScale = 0.2;
+            };
             class UnderBarrelSlot: asdg_UnderSlot {
                 iconPosition[] = {0.2,0.7};
                 iconScale = 0.2;
@@ -381,6 +444,14 @@ class CfgWeapons {
 
     class arifle_MXM_F: arifle_MX_Base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
+            class PointerSlot: asdg_FrontSideRail {
+                iconPosition[] = {0.35,0.35};
+                iconScale = 0.25;
+            };
+            class CowsSlot: asdg_OpticRail1913 {
+                iconPosition[] = {0.5,0.35};
+                iconScale = 0.2;
+            };
             class UnderBarrelSlot: asdg_UnderSlot {
                 iconPosition[] = {0.2,0.7};
                 iconScale = 0.2;

--- a/addons/jr/CfgWeapons.hpp
+++ b/addons/jr/CfgWeapons.hpp
@@ -379,11 +379,11 @@ class CfgWeapons {
     };
 
     class arifle_MX_Base_F: Rifle_Base_F {
-        class WeaponSlotsInfo;
-    };
-
-    class arifle_MXC_F: arifle_MX_Base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
+            class PointerSlot: asdg_FrontSideRail {
+                iconPosition[] = {0.35,0.35};
+                iconScale = 0.25;
+            };
             class CowsSlot: asdg_OpticRail1913 {
                 iconPosition[] = {0.5,0.3};
                 iconScale = 0.2;
@@ -393,10 +393,6 @@ class CfgWeapons {
 
     class arifle_MX_F: arifle_MX_Base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            class CowsSlot: asdg_OpticRail1913 {
-                iconPosition[] = {0.5,0.35};
-                iconScale = 0.2;
-            };
             class UnderBarrelSlot: asdg_UnderSlot {
                 iconPosition[] = {0.2,0.7};
                 iconScale = 0.2;
@@ -404,21 +400,8 @@ class CfgWeapons {
         };
     };
 
-    class arifle_MX_GL_F: arifle_MX_Base_F {
-        class WeaponSlotsInfo: WeaponSlotsInfo {
-            class CowsSlot: asdg_OpticRail1913 {
-                iconPosition[] = {0.5,0.35};
-                iconScale = 0.2;
-            };
-        };
-    };
-
     class arifle_MX_SW_F: arifle_MX_Base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            class CowsSlot: asdg_OpticRail1913 {
-                iconPosition[] = {0.5,0.35};
-                iconScale = 0.2;
-            };
             class UnderBarrelSlot: asdg_UnderSlot {
                 iconPosition[] = {0.2,0.7};
                 iconScale = 0.2;
@@ -428,10 +411,6 @@ class CfgWeapons {
 
     class arifle_MXM_F: arifle_MX_Base_F {
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            class CowsSlot: asdg_OpticRail1913 {
-                iconPosition[] = {0.5,0.35};
-                iconScale = 0.2;
-            };
             class UnderBarrelSlot: asdg_UnderSlot {
                 iconPosition[] = {0.2,0.7};
                 iconScale = 0.2;


### PR DESCRIPTION
As per https://github.com/acemod/ACE3/issues/7182
The MX is missing the side rail, I don't know how that was not noticed before.

Also I noticed that we can directly modify in `arifle_MX_Base_F` as we already have the "WeaponSlotsInfo" declaration to inherit from, inside Rifle_Base_F. Thus we can do some optimizations here.

Same thing for `mk20_base_F`