### PR TITLE
Filtered getUnitLoadout

### DIFF
--- a/addons/common/CfgFunctions.hpp
+++ b/addons/common/CfgFunctions.hpp
@@ -78,6 +78,10 @@ class CfgFunctions {
             PATHTO_FNC(addBinocularMagazine);
             PATHTO_FNC(removeBinocularMagazine);
             PATHTO_FNC(randomizeFacewear);
+            PATHTO_FNC(getUnitLoadout);
+            PATHTO_FNC(filterLoadout);
+            PATHTO_FNC(addLoadoutFilter);
+            PATHTO_FNC(removeLoadoutFilter);
         };
 
         class Cargo {

--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -45,6 +45,7 @@ GVAR(featureCamerasNames) = [
 call COMPILE_FILE(init_gauss);
 call COMPILE_FILE(init_perFrameHandler);
 call COMPILE_FILE(init_delayLess);
+call COMPILE_FILE(init_filteredLoadout);
 
 // Due to activateAddons being overwritten by eachother (only the last executed command will be active), we apply this bandaid
 GVAR(addons) = call (uiNamespace getVariable [QGVAR(addons), {[]}]);

--- a/addons/common/fnc_addLoadoutFilter.sqf
+++ b/addons/common/fnc_addLoadoutFilter.sqf
@@ -1,0 +1,43 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_addLoadoutFilter
+
+Description:
+    Add a filter for
+
+Parameters:
+    _function - The function you wish to execute. <CODE>
+
+Passed Arguments:
+    _this <ARRAY>
+        0: _loadout - A getUnitLoadout array
+        1: _handle - A number representing the handle of the function. Same as '_handle' returned by this function. <NUMBER>
+
+Returns:
+    _handle - A number representing the handle of the function. Use this to remove the handler. <NUMBER>
+
+Examples:
+    Remove the radio from loadouts
+    (begin example)
+        _handle = [{
+            params ["_loadout", "_handle"];
+            if ((_loadout select 9) select 2 == "ItemRadio") then {
+                (_loadout select 9) set [2, ""];
+            };
+            _loadout
+        }] call CBA_fnc_addLoadoutFilter;
+    (end)
+
+Author:
+    SynixeBrett
+---------------------------------------------------------------------------- */
+
+params [["_function", {}, [{}]]];
+
+if (_function isEqualTo {}) exitWith {-1};
+
+private _handle = GVAR(filterLoadoutHandles) pushBack count GVAR(filterLoadoutArray);
+
+GVAR(filterLoadoutArray) pushBack [_function, _handle];
+
+_handle

--- a/addons/common/fnc_addLoadoutFilter.sqf
+++ b/addons/common/fnc_addLoadoutFilter.sqf
@@ -3,7 +3,7 @@
 Function: CBA_fnc_addLoadoutFilter
 
 Description:
-    Add a filter for CBA_fnc_getUnitLoadout
+    Add a filter for CBA_fnc_getUnitLoadout.
 
 Parameters:
     _function - The function you wish to execute. <CODE>

--- a/addons/common/fnc_addLoadoutFilter.sqf
+++ b/addons/common/fnc_addLoadoutFilter.sqf
@@ -3,7 +3,7 @@
 Function: CBA_fnc_addLoadoutFilter
 
 Description:
-    Add a filter for
+    Add a filter for CBA_fnc_getUnitLoadout
 
 Parameters:
     _function - The function you wish to execute. <CODE>

--- a/addons/common/fnc_filterLoadout.sqf
+++ b/addons/common/fnc_filterLoadout.sqf
@@ -3,14 +3,14 @@
 Function: CBA_fnc_filterLoadout
 
 Description:
-    Used to filter a getUnitLoadout array
+    Used to filter a getUnitLoadout array.
 
 Parameters:
     _loadout - getUnitLoadout array <ARRAY>
 
 Example:
     (begin example)
-        _loadout = [getUnitLoadout player] call CBA_fnc_filterLoadout
+        _loadout = [getUnitLoadout player] call CBA_fnc_filterLoadout;
     (end)
 
 Returns:

--- a/addons/common/fnc_filterLoadout.sqf
+++ b/addons/common/fnc_filterLoadout.sqf
@@ -1,0 +1,30 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_filterLoadout
+
+Description:
+    Used to filter a getUnitLoadout array
+
+Parameters:
+    _loadout - getUnitLoadout array <ARRAY>
+
+Example:
+    (begin example)
+        _loadout = [getUnitLoadout player] call CBA_fnc_filterLoadout
+    (end)
+
+Returns:
+    filtered getUnitLoadout array <ARRAY>
+
+Author:
+    SynixeBrett
+---------------------------------------------------------------------------- */
+SCRIPT(filterLoadout);
+
+params [["_loadout", [], [[]]]];
+
+{
+    _loadout = [_loadout] call (_x select 0);
+} forEach GVAR(filterLoadoutArray);
+
+_loadout

--- a/addons/common/fnc_getUnitLoadout.sqf
+++ b/addons/common/fnc_getUnitLoadout.sqf
@@ -3,7 +3,7 @@
 Function: CBA_fnc_getUnitLoadout
 
 Description:
-    Return the loadout of a unit with `CBA_fnc_filterLoadout` applied
+    Return the loadout of a unit with CBA_fnc_filterLoadout applied.
 
 Parameters:
     _unit - Unit to get loadout of <OBJECT>
@@ -13,7 +13,7 @@ Returns:
 
 Examples:
     (begin example)
-        private _loadout = [player] call CBA_fnc_getUnitLoadout
+        private _loadout = [player] call CBA_fnc_getUnitLoadout;
     (end)
 
 Author:

--- a/addons/common/fnc_getUnitLoadout.sqf
+++ b/addons/common/fnc_getUnitLoadout.sqf
@@ -1,0 +1,28 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_getUnitLoadout
+
+Description:
+    Return the loadout of a unit with `CBA_fnc_filterLoadout` applied
+
+Parameters:
+    _unit - Unit to get loadout of <OBJECT>
+
+Returns:
+    _loadout - `getUnitLoadout` array <ARRAY>
+
+Examples:
+    (begin example)
+        private _loadout = [player] call CBA_fnc_getUnitLoadout
+    (end)
+
+Author:
+    SynixeBrett
+---------------------------------------------------------------------------- */
+SCRIPT(getUnitLoadout);
+
+params [["_unit", objNull, [objNull]]];
+
+if (_unit isEqualTo objNull) exitWith {[]};
+
+[getUnitLoadout _unit] call CBA_fnc_filterLoadout

--- a/addons/common/fnc_removeLoadoutFilter.sqf
+++ b/addons/common/fnc_removeLoadoutFilter.sqf
@@ -1,0 +1,54 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_removeLoadoutFilter
+
+Description:
+    Remove a handler that you have added using CBA_fnc_addLoadoutFilter.
+
+Parameters:
+    _handle - The function handle you wish to remove. <NUMBER>
+
+Returns:
+    true if removed successful, false otherwise <BOOLEAN>
+
+Examples:
+    (begin example)
+        _handle = [myLoadoutFilter] call CBA_fnc_addLoadoutFilter;
+        sleep 10;
+        [_handle] call CBA_fnc_removeLoadoutFilter;
+    (end)
+
+Author:
+    Nou & Jaynus, SynixeBrett
+---------------------------------------------------------------------------- */
+
+params [["_handle", -1, [0]]];
+
+[{
+    params ["_handle"];
+
+    private _index = GVAR(filterLoadoutHandles) param [_handle];
+    if (isNil "_index") exitWith {false};
+
+    GVAR(filterLoadoutHandles) set [_handle, nil];
+    (GVAR(filterLoadoutArray) select _index) set [0, {}];
+
+    if (GVAR(filterLoadoutToRemove) isEqualTo []) then {
+        {
+            {
+                GVAR(filterLoadoutArray) set [_x, objNull];
+            } forEach GVAR(filterLoadoutToRemove);
+
+            GVAR(filterLoadoutArray) = GVAR(filterLoadoutArray) - [objNull];
+            GVAR(filterLoadoutToRemove) = [];
+
+            {
+                _x params ["", "_index"];
+                GVAR(filterLoadoutHandles) set [_index, _forEachIndex];
+            } forEach GVAR(filterLoadoutArray);
+        } call CBA_fnc_execNextFrame;
+    };
+
+    GVAR(filterLoadoutToRemove) pushBackUnique _index;
+    true
+}, _handle] call CBA_fnc_directCall;

--- a/addons/common/init_filteredLoadout.sqf
+++ b/addons/common/init_filteredLoadout.sqf
@@ -1,0 +1,5 @@
+#include "script_component.hpp"
+
+GVAR(filterLoadoutArray) = [];
+GVAR(filterLoadoutHandles) = [];
+GVAR(filterLoadoutToRemove) = [];


### PR DESCRIPTION
**When merged this pull request will:**
- Close #1236 
- `CBA_fnc_getUnitLoadout`
- `CBA_fnc_filterLoadout`
- `CBA_fnc_addLoadoutFilter`
- `CBA_fnc_removeLoadoutFilter`

```sqf
private _loadout = [player] call CBA_fnc_getUnitLoadout; // Loadout with ItemRadio

private _handle = [{ 
    params ["_loadout", "_handle"]; 
    if ((_loadout select 9) select 2 == "ItemRadio") then { 
        (_loadout select 9) set [2, ""]; 
    }; 
    _loadout
}] call CBA_fnc_addLoadoutFilter;

_loadout = [_loadout] call CBA_fnc_filterLoadout; // Previous loadout with ItemRadio removed
_loadout = [player] call CBA_fnc_getUnitLoadout; // Loadout without ItemRadio

[_handle] call CBA_fnc_removeLoadoutFilter;

_loadout = [player] call CBA_fnc_getUnitLoadout; // Loadout with ItemRadio
```