### PR TITLE
Attack Module Override enables AI pathing

### DIFF
--- a/addons/ai/fnc_taskAttack.sqf
+++ b/addons/ai/fnc_taskAttack.sqf
@@ -34,6 +34,7 @@ if !(local _group) exitWith {}; // Don't create waypoints on each machine
 // Allow TaskAttack to override other set waypoints
 if (_override) then {
     [_group] call CBA_fnc_clearWaypoints;
+    { _x enableAI "PATH"; } foreach (units _group);
 };
 
 [_group, _position, _radius, "SAD", "COMBAT", "RED"] call CBA_fnc_addWaypoint;

--- a/addons/ai/fnc_taskAttack.sqf
+++ b/addons/ai/fnc_taskAttack.sqf
@@ -34,7 +34,9 @@ if !(local _group) exitWith {}; // Don't create waypoints on each machine
 // Allow TaskAttack to override other set waypoints
 if (_override) then {
     [_group] call CBA_fnc_clearWaypoints;
-    { _x enableAI "PATH"; } foreach (units _group);
+    {
+        _x enableAI "PATH";
+    } forEach units _group;
 };
 
 [_group, _position, _radius, "SAD", "COMBAT", "RED"] call CBA_fnc_addWaypoint;


### PR DESCRIPTION
Issue: when a group is set to defend with a high percentage of "hold" and a trigger activates a sync'd attack module which wants all units on defend to attack a location the behaviour currently is that all units will have the new waypoint and all units with pathing disabled because of "holding" will stand still which presents a inflexible scenario without custom logic elements to enable good timing of releasing "waves" of units as a Zeus.

Proposal: Enable the override parameter to re enable pathing so it can override any blocking previous command given to the unit such as the "defend module's hold". This should make that option act more as expected by overriding previous orders and allow more dynamic options for mission makers.
