### PR TITLE
fix Russian keybinding localization error

### DIFF
--- a/addons/keybinding/XEH_preStart.sqf
+++ b/addons/keybinding/XEH_preStart.sqf
@@ -165,25 +165,13 @@ private _supportedKeys = [
     DIK_XBOX_RIGHT_THUMB
 ];
 
-_supportedKeys = _supportedKeys apply {
-    // strip away additional quote marks
-    // Turkish keyboard which has a double quotes key (41), will throw an error in parseSimpleArray
-
-    private _formatedKeyname = format ["[%1]", keyName _x];
-    private _keyName = if (_formatedKeyname != "[""""""]") then {
-        (parseSimpleArray _formatedKeyname) select 0;
-    } else {
-        "''"
-    };
-
-    [str _x, _keyName]
-};
+_supportedKeys = _supportedKeys apply {[str _x, KEY_NAME(_x)]};
 
 GVAR(keyNamesHash) = [_supportedKeys] call CBA_fnc_hashCreate;
 
 // manually add mouse key localizations to our inofficial DIK codes
 {
-    [GVAR(keyNamesHash), str (_x select 0), parseSimpleArray format ["[%1]", keyName (_x select 1)] select 0] call CBA_fnc_hashSet;
+    [GVAR(keyNamesHash), str (_x select 0), KEY_NAME(_x select 1)] call CBA_fnc_hashSet;
 } forEach [
     [0xF0, 0x10000], // LMB
     [0xF1, 0x10081], // RMB

--- a/addons/keybinding/script_component.hpp
+++ b/addons/keybinding/script_component.hpp
@@ -78,3 +78,4 @@
 #define NAMESPACE_NULL objNull
 #define HASH_NULL ([] call CBA_fnc_hashCreate)
 #define KEYBIND_NULL [0, [false, false, false]]
+#define KEY_NAME(x) (call {private _s = keyName (x); _s select [1, count _s - 2]})


### PR DESCRIPTION
**When merged this pull request will:**
- `parseSimpleArray` unreliable when resolving escaped strings, so avoid it
- close #1246
