### PR TITLE
Fix JIP event removal on dedicated client

### DIFF
--- a/addons/events/XEH_preInit.sqf
+++ b/addons/events/XEH_preInit.sqf
@@ -13,6 +13,8 @@ GVAR(eventHashes) = call CBA_fnc_createNamespace;
 if (isServer) then {
     GVAR(eventNamespaceJIP) = true call CBA_fnc_createNamespace;
     publicVariable QGVAR(eventNamespaceJIP);
+
+    [QGVAR(removeGlobalEventJIP), CBA_fnc_removeGlobalEventJIP] call CBA_fnc_addEventHandler;
 };
 
 // can't add at preInit

--- a/addons/events/fnc_removeGlobalEventJIP.sqf
+++ b/addons/events/fnc_removeGlobalEventJIP.sqf
@@ -7,7 +7,7 @@ Description:
 
 Parameters:
     _jipID  - A unique ID from CBA_fnc_globalEventJIP. <STRING>
-    _object - Will remove jip EH when object is deleted or immediately if omitted [optional] <OBJECT>
+    _object - Will remove JIP EH when object is deleted or immediately if omitted. (optional, default: objNull) <OBJECT>
 
 Returns:
     Nothing
@@ -19,10 +19,14 @@ SCRIPT(removeGlobalEventJIP);
 
 params [["_jipID", "", [""]], ["_object", objNull, [objNull]]];
 
-if (isNull _object) then {
-    GVAR(eventNamespaceJIP) setVariable [_jipID, nil, true];
+if (isServer) then {
+    if (isNull _object) then {
+        GVAR(eventNamespaceJIP) setVariable [_jipID, nil, true];
+    } else {
+        [_object, "Deleted", {
+            GVAR(eventNamespaceJIP) setVariable [_thisArgs, nil, true];
+        }, _jipID] call CBA_fnc_addBISEventHandler;
+    };
 } else {
-    [_object, "Deleted", {
-        GVAR(eventNamespaceJIP) setVariable [_thisArgs, nil, true];
-    }, _jipID] call CBA_fnc_addBISEventHandler;
+    [QGVAR(removeGlobalEventJIP), [_jipID, _object]] call CBA_fnc_serverEvent;
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Fix `CBA_fnc_removeGlobalEventJIP` not correctly removing events when called in "wait for object deletion" mode on non-server machine when the object is deleted after the client disconnects
- "Deleted" EH won't exist after the client disconnects and as such the event is never removed, unless added on server
