### PR TITLE
Fix optics camera restart handling for Zeus

### DIFF
--- a/addons/optics/XEH_preInit.sqf
+++ b/addons/optics/XEH_preInit.sqf
@@ -96,7 +96,7 @@ GVAR(inArsenal) = false;
     GVAR(inArsenal) = false;
     private _unit = call CBA_fnc_currentUnit;
     _unit call FUNC(changeCarryHandleOpticClass);
-    [FUNC(restartCamera), [_unit, isNull curatorCamera]] call CBA_fnc_execNextFrame;
+    [FUNC(restartCamera), [_unit, true]] call CBA_fnc_execNextFrame;
 }] call CBA_fnc_addEventHandler;
 
 [missionNamespace, "arsenalClosed", {

--- a/addons/optics/XEH_preInit.sqf
+++ b/addons/optics/XEH_preInit.sqf
@@ -96,7 +96,7 @@ GVAR(inArsenal) = false;
     GVAR(inArsenal) = false;
     private _unit = call CBA_fnc_currentUnit;
     _unit call FUNC(changeCarryHandleOpticClass);
-    [FUNC(restartCamera), [_unit, true]] call CBA_fnc_execNextFrame;
+    [FUNC(restartCamera), [_unit, isNull curatorCamera]] call CBA_fnc_execNextFrame;
 }] call CBA_fnc_addEventHandler;
 
 [missionNamespace, "arsenalClosed", {

--- a/addons/optics/fnc_restartCamera.sqf
+++ b/addons/optics/fnc_restartCamera.sqf
@@ -25,6 +25,7 @@ if (
     !GVAR(usePipOptics)
     || {configProperties [configFile >> "CBA_PIPItems"] isEqualTo []}
     || {isNull (uiNamespace getVariable ["RscDisplayMission", displayNull])}
+    || {!isNull (uiNamespace getVariable ["RscDisplayCurator", displayNull])}
 ) exitWith {};
 
 params ["_unit", ["_reset", true]];

--- a/addons/optics/fnc_restartCamera.sqf
+++ b/addons/optics/fnc_restartCamera.sqf
@@ -21,9 +21,12 @@ Author:
     commy2
 ---------------------------------------------------------------------------- */
 
-if (!GVAR(usePipOptics)) exitWith {};
-if (configProperties [configFile >> "CBA_PIPItems"] isEqualTo []) exitWith {};
-if (isNull (uiNamespace getVariable ["RscDisplayMission", displayNull])) exitWith {};
+if (
+    !GVAR(usePipOptics)
+    || {configProperties [configFile >> "CBA_PIPItems"] isEqualTo []}
+    || {isNull (uiNamespace getVariable ["RscDisplayMission", displayNull])}
+    || {!isNull (uiNamespace getVariable ["RscDisplayCurator", displayNull])}
+) exitWith {};
 
 params ["_unit", ["_reset", true]];
 

--- a/addons/optics/fnc_restartCamera.sqf
+++ b/addons/optics/fnc_restartCamera.sqf
@@ -25,7 +25,6 @@ if (
     !GVAR(usePipOptics)
     || {configProperties [configFile >> "CBA_PIPItems"] isEqualTo []}
     || {isNull (uiNamespace getVariable ["RscDisplayMission", displayNull])}
-    || {!isNull (uiNamespace getVariable ["RscDisplayCurator", displayNull])}
 ) exitWith {};
 
 params ["_unit", ["_reset", true]];

--- a/addons/optics/script_component.hpp
+++ b/addons/optics/script_component.hpp
@@ -1,9 +1,9 @@
-﻿#define COMPONENT optics
+#define COMPONENT optics
 #include "\x\cba\addons\main\script_mod.hpp"
 
-//#define DEBUG_MODE_FULL
-//#define DISABLE_COMPILE_CACHE
-//#define DEBUG_ENABLED_OPTICS
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define DEBUG_ENABLED_OPTICS
 
 #ifdef DEBUG_ENABLED_OPTICS
     #define DEBUG_MODE_FULL


### PR DESCRIPTION
**When merged this pull request will:**
- Fix camera restart preventing returning to `curatorCamera` when using arsenal through Zeus (module)
- Related to #1234 
