### PR TITLE
FSM Editor Config for CBA Statemachine

### DIFF
--- a/addons/statemachine/CBA_FSMEditor.cfg
+++ b/addons/statemachine/CBA_FSMEditor.cfg
@@ -1,0 +1,103 @@
+/* ----------------------------------------------------------------------------
+CBA Statemachine Config for use with FSM Editor
+
+Description:
+    This is a config that allows you to create and edit CBA Statemachines using
+    the Arma Tools FSM editor, for increased readability and expandability.
+	
+	It isn't by any means perfect, but it should be useable
+    
+Usage:
+    1. Select this config using FsmAttributes > Compile Config
+    2. Change FSM attributes under FsmAttributes > Attributes from Compile Config
+        2.1 'list' parameter is parsed as list = QUOTE(x);
+        2.2 'skipNull' parameter is parsed as skipNull = x;
+    3. States
+        3.1 'initCode' is parsed as is, and may contain onState = "", 
+            onStateEntered = "" and/or onStateLeaving = ""
+    4. Transitions
+        4.1 'targetState' does not need to be entered, and simply follows the
+            transition link
+        4.2 'condition' is parsed as condition = QUOTE(x)
+        4.3 'action' is parsed as is, and may contain onTransition = "" 
+            and/or events[] = {}
+			
+Dependencies:
+	In order to properly function, script_macros_common need to be included
+
+Author:
+    Freddo 2019-12-10
+---------------------------------------------------------------------------- */
+
+class Attributes
+{
+  names[] = {"list", "skipNull"};
+};
+
+class Compile
+{
+    clearNewLines = 0;
+//  indenting = -1;  //no indenting
+    rewriteFile = 1; //do not append result to the end of file, but rewriteIt
+    class Pass_States
+    {
+        print_sm =           "class %(fsmname)\n{\n";
+        indent_smOpen =      4;
+        print_attrList =     "list = QUOTE(%(list));\n";
+        print_attrSkipNull = "skipNull = %(skipNull);\n";
+        class State_Any
+        {
+            print_state =          "class %(statename)\n{\n";
+			indent_stateContents = 0; //Neccessary to preserve formatting
+            print_stateContents =  "%(stateinit)\n";
+			indent_stateOpen =     8;
+            class Links
+            {
+                    print_transition =          "class %(linkname)\n{\n";
+                    indent_transitionOpen =     12;
+                    print_target =             "targetState=QUOTE(%(to));\n";
+                    print_condition =           "condition=QUOTE(%(condition));\n";
+					indent_transitionContents = 0; //Neccessary to preserve formatting
+                    print_transitionContents =  "%(action)\n";
+                    indent_transitionClose =    8;
+                    print_transitionClose =     "};\n";
+            }
+            indent_stateClose = 4;
+            print_stateClose =  "};\n";
+        }
+        indent_smClose = 0;
+        print_smClose =  "};\n";
+    };
+};
+
+class Decompile
+{
+    process =         1; //0 for not processing Decompile info
+    FSMLeft =      "/*";
+    FSMRight =     "*/";
+    class FSMPrefix
+    {
+        default =    "";
+    };
+    class FSMPrefix2
+    {
+        default =    "";
+        head =     "*/";
+    };
+    class FSMSufix
+    {
+        default =    "";
+        compile =  "\n";
+        state =    "\n";
+        head = "\n/*\n";
+        link =     "\n";
+    };
+    class FSMSufix2
+    {
+        default =    "";
+        compile =    "";
+        state =    "\n";
+        head =     "\n";
+        link =     "\n";
+    };
+};

--- a/addons/statemachine/CBA_FSMEditor.cfg
+++ b/addons/statemachine/CBA_FSMEditor.cfg
@@ -4,96 +4,86 @@ CBA Statemachine Config for use with FSM Editor
 Description:
     This is a config that allows you to create and edit CBA Statemachines using
     the Arma Tools FSM editor, for increased readability and expandability.
-	
-	It isn't by any means perfect, but it should be useable
-    
+
+    It isn't by any means perfect, but it should be useable
+
 Usage:
     1. Select this config using FsmAttributes > Compile Config
-    2. Change FSM attributes under FsmAttributes > Attributes from Compile Config
+    2. Change FSM attributes under FsmAttributes > Attributes from Compile Config.
         2.1 'list' parameter is parsed as list = QUOTE(x);
         2.2 'skipNull' parameter is parsed as skipNull = x;
     3. States
-        3.1 'initCode' is parsed as is, and may contain onState = "", 
+        3.1 'initCode' is parsed as is, and may contain onState = "",
             onStateEntered = "" and/or onStateLeaving = ""
     4. Transitions
         4.1 'targetState' does not need to be entered, and simply follows the
-            transition link
+            transition link.
         4.2 'condition' is parsed as condition = QUOTE(x)
-        4.3 'action' is parsed as is, and may contain onTransition = "" 
+        4.3 'action' is parsed as is, and may contain onTransition = ""
             and/or events[] = {}
-			
+
 Dependencies:
-	In order to properly function, script_macros_common need to be included
+    In order to properly function, script_macros_common need to be included.
 
 Author:
-    Freddo 2019-12-10
+    Freddo
 ---------------------------------------------------------------------------- */
 
-class Attributes
-{
+class Attributes {
   names[] = {"list", "skipNull"};
 };
 
-class Compile
-{
+class Compile {
     clearNewLines = 0;
 //  indenting = -1;  //no indenting
     rewriteFile = 1; //do not append result to the end of file, but rewriteIt
-    class Pass_States
-    {
+    class Pass_States {
         print_sm =           "class %(fsmname)\n{\n";
         indent_smOpen =      4;
         print_attrList =     "list = QUOTE(%(list));\n";
         print_attrSkipNull = "skipNull = %(skipNull);\n";
-        class State_Any
-        {
+        class State_Any {
             print_state =          "class %(statename)\n{\n";
-			indent_stateContents = 0; //Neccessary to preserve formatting
+            indent_stateContents = 0; //Neccessary to preserve formatting
             print_stateContents =  "%(stateinit)\n";
-			indent_stateOpen =     8;
-            class Links
-            {
+            indent_stateOpen =     8;
+            class Links {
                     print_transition =          "class %(linkname)\n{\n";
                     indent_transitionOpen =     12;
                     print_target =             "targetState=QUOTE(%(to));\n";
                     print_condition =           "condition=QUOTE(%(condition));\n";
-					indent_transitionContents = 0; //Neccessary to preserve formatting
+                    indent_transitionContents = 0; //Neccessary to preserve formatting
                     print_transitionContents =  "%(action)\n";
                     indent_transitionClose =    8;
                     print_transitionClose =     "};\n";
-            }
+            };
             indent_stateClose = 4;
             print_stateClose =  "};\n";
-        }
+        };
         indent_smClose = 0;
         print_smClose =  "};\n";
     };
 };
 
-class Decompile
-{
+class Decompile {
     process =         1; //0 for not processing Decompile info
     FSMLeft =      "/*";
     FSMRight =     "*/";
-    class FSMPrefix
-    {
+    class FSMPrefix {
         default =    "";
     };
-    class FSMPrefix2
-    {
+    class FSMPrefix2 {
         default =    "";
         head =     "*/";
     };
-    class FSMSufix
-    {
+    class FSMSufix {
         default =    "";
         compile =  "\n";
         state =    "\n";
         head = "\n/*\n";
         link =     "\n";
     };
-    class FSMSufix2
-    {
+    class FSMSufix2 {
         default =    "";
         compile =    "";
         state =    "\n";

--- a/addons/statemachine/CBA_FSMEditor.cfg
+++ b/addons/statemachine/CBA_FSMEditor.cfg
@@ -1,11 +1,9 @@
 /* ----------------------------------------------------------------------------
-CBA Statemachine Config for use with FSM Editor
+CBA Statemachine Config for use with the FSM Editor
 
 Description:
     This is a config that allows you to create and edit CBA Statemachines using
-    the Arma Tools FSM editor, for increased readability and expandability.
-
-    It isn't by any means perfect, but it should be useable
+    the Arma Tools FSM editor for increased readability and expandability.
 
 Usage:
     1. Select this config using FsmAttributes > Compile Config
@@ -23,71 +21,80 @@ Usage:
             and/or events[] = {}
 
 Dependencies:
-    In order to properly function, script_macros_common need to be included.
+    In order to properly function, script_macros_common.hpp must be included.
 
 Author:
     Freddo
 ---------------------------------------------------------------------------- */
 
 class Attributes {
-  names[] = {"list", "skipNull"};
+    names[] = {"list", "skipNull"};
 };
 
 class Compile {
     clearNewLines = 0;
-//  indenting = -1;  //no indenting
-    rewriteFile = 1; //do not append result to the end of file, but rewriteIt
+//  indenting = -1; // no indenting
+    rewriteFile = 1; // Do not append result to the end of file, but rewrite it.
+
     class Pass_States {
-        print_sm =           "class %(fsmname)\n{\n";
-        indent_smOpen =      4;
-        print_attrList =     "list = QUOTE(%(list));\n";
+        print_sm = "class %(fsmname)\n{\n";
+        indent_smOpen = 4;
+        print_attrList = "list = QUOTE(%(list));\n";
         print_attrSkipNull = "skipNull = %(skipNull);\n";
+
         class State_Any {
-            print_state =          "class %(statename)\n{\n";
+            print_state = "class %(statename)\n{\n";
             indent_stateContents = 0; //Neccessary to preserve formatting
-            print_stateContents =  "%(stateinit)\n";
-            indent_stateOpen =     8;
+            print_stateContents = "%(stateinit)\n";
+            indent_stateOpen = 8;
+
             class Links {
-                    print_transition =          "class %(linkname)\n{\n";
-                    indent_transitionOpen =     12;
-                    print_target =             "targetState=QUOTE(%(to));\n";
-                    print_condition =           "condition=QUOTE(%(condition));\n";
-                    indent_transitionContents = 0; //Neccessary to preserve formatting
-                    print_transitionContents =  "%(action)\n";
-                    indent_transitionClose =    8;
-                    print_transitionClose =     "};\n";
+                print_transition = "class %(linkname)\n{\n";
+                indent_transitionOpen = 12;
+                print_target = "targetState=QUOTE(%(to));\n";
+                print_condition = "condition=QUOTE(%(condition));\n";
+                indent_transitionContents = 0; // Neccessary to preserve formatting.
+                print_transitionContents = "%(action)\n";
+                indent_transitionClose = 8;
+                print_transitionClose = "};\n";
             };
+
             indent_stateClose = 4;
-            print_stateClose =  "};\n";
+            print_stateClose = "};\n";
         };
+
         indent_smClose = 0;
-        print_smClose =  "};\n";
+        print_smClose = "};\n";
     };
 };
 
 class Decompile {
-    process =         1; //0 for not processing Decompile info
-    FSMLeft =      "/*";
-    FSMRight =     "*/";
+    process = 1; // 0 for not processing Decompile info.
+    FSMLeft = "/*";
+    FSMRight = "*/";
+
     class FSMPrefix {
-        default =    "";
+        default = "";
     };
+
     class FSMPrefix2 {
-        default =    "";
-        head =     "*/";
+        default = "";
+        head = "*/";
     };
+
     class FSMSufix {
-        default =    "";
-        compile =  "\n";
-        state =    "\n";
+        default = "";
+        compile = "\n";
+        state = "\n";
         head = "\n/*\n";
-        link =     "\n";
+        link = "\n";
     };
+
     class FSMSufix2 {
-        default =    "";
-        compile =    "";
-        state =    "\n";
-        head =     "\n";
-        link =     "\n";
+        default = "";
+        compile = "";
+        state = "\n";
+        head = "\n";
+        link = "\n";
     };
 };

--- a/addons/statemachine/CBA_FSMEditor.cfg
+++ b/addons/statemachine/CBA_FSMEditor.cfg
@@ -24,7 +24,7 @@ Dependencies:
     In order to properly function, script_macros_common.hpp must be included.
 
 Author:
-    Freddo
+    Freddo & PiZZADOX
 ---------------------------------------------------------------------------- */
 
 class Attributes {
@@ -33,27 +33,27 @@ class Attributes {
 
 class Compile {
     clearNewLines = 0;
-//  indenting = -1; // no indenting
+    indenting = 0; // no indenting
     rewriteFile = 1; // Do not append result to the end of file, but rewrite it.
 
     class Pass_States {
-        print_sm = "class %(fsmname)\n{\n";
+        print_sm = "class %(fsmname) {\n";
         indent_smOpen = 4;
         print_attrList = "list = QUOTE(%(list));\n";
         print_attrSkipNull = "skipNull = %(skipNull);\n";
 
         class State_Any {
-            print_state = "class %(statename)\n{\n";
-            indent_stateContents = 0; //Neccessary to preserve formatting
+            print_state = "class %(statename) {\n";
+            indent_stateContents = 8; //Neccessary to preserve formatting
             print_stateContents = "%(stateinit)\n";
             indent_stateOpen = 8;
 
             class Links {
-                print_transition = "class %(linkname)\n{\n";
+                print_transition = "class %(linkname) {\n";
                 indent_transitionOpen = 12;
-                print_target = "targetState=QUOTE(%(to));\n";
-                print_condition = "condition=QUOTE(%(condition));\n";
-                indent_transitionContents = 0; // Neccessary to preserve formatting.
+                print_target = "targetState = QUOTE(%(to));\n";
+                print_condition = "condition = QUOTE(%(condition));";
+                indent_transitionContents = 12; // Neccessary to preserve formatting.
                 print_transitionContents = "%(action)\n";
                 indent_transitionClose = 8;
                 print_transitionClose = "};\n";
@@ -69,7 +69,7 @@ class Compile {
 };
 
 class Decompile {
-    process = 1; // 0 for not processing Decompile info.
+    process = 0; // 1 for processing Decompile info.
     FSMLeft = "/*";
     FSMRight = "*/";
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add a FSM Editor config file that allows it to create and edit CBA Statemachine configs


<details>
<summary>Included instructions</summary>

```
/* ----------------------------------------------------------------------------
CBA Statemachine Config for use with FSM Editor

Description:
    This is a config that allows you to create and edit CBA Statemachines using
    the Arma Tools FSM editor, for increased readability and expandability.

    It isn't by any means perfect, but it should be useable
    
Usage:
    1. Select this config using FsmAttributes > Compile Config
    2. Change FSM attributes under FsmAttributes > Attributes from Compile Config
        2.1 'list' parameter is parsed as list = QUOTE(x);
        2.2 'skipNull' parameter is parsed as skipNull = x;
    3. States
        3.1 'initCode' is parsed as is, and may contain onState = "", 
            onStateEntered = "" and/or onStateLeaving = ""
    4. Transitions
        4.1 'targetState' does not need to be entered, and simply follows the
            transition link
        4.2 'condition' is parsed as condition = QUOTE(x)
        4.3 'action' is parsed as is, and may contain onTransition = "" 
            and/or events[] = {}
			
Dependencies:
	In order to properly function, script_macros_common need to be included
Author:
    Freddo 2019-12-10
---------------------------------------------------------------------------- */
```
</details>

Example FSM: 
![fsm_editor](https://user-images.githubusercontent.com/14627848/70553289-1fffb300-1b7b-11ea-996c-0554b65cbd37.PNG)

Same FSM but as text:
https://gist.github.com/Freddo3000/244d94c0056f2b4afb0f52fec73a57a2

Once ran through pboProject:
https://gist.github.com/Freddo3000/eab4a2afd7a4ffcbc688bcf37ce7e91d

While it could be prettier, it does its job well enough.