### PR TITLE
Standardize XEH and Versioning logging prefixs

### DIFF
--- a/addons/disposable/script_component.hpp
+++ b/addons/disposable/script_component.hpp
@@ -13,7 +13,6 @@
     #define DEBUG_SETTINGS DEBUG_SETTINGS_DISPOSABLE
 #endif
 
-#define DEBUG_MODE_NORMAL
 #define DEBUG_SYNCHRONOUS
 #include "\x\cba\addons\main\script_macros.hpp"
 

--- a/addons/optics/script_component.hpp
+++ b/addons/optics/script_component.hpp
@@ -13,7 +13,6 @@
     #define DEBUG_SETTINGS DEBUG_SETTINGS_OPTICS
 #endif
 
-#define DEBUG_MODE_NORMAL
 #define DEBUG_SYNCHRONOUS
 #include "\x\cba\addons\main\script_macros.hpp"
 

--- a/addons/versioning/XEH_postInit.sqf
+++ b/addons/versioning/XEH_postInit.sqf
@@ -9,8 +9,9 @@ if (!SLX_XEH_DisableLogging) then {
     private _logMsgs = [];
     private _filter = {if (_x isEqualType 1) then {[_x] call CBA_fnc_formatNumber} else {_x}};
     [GVAR(versions), { _logMsgs pushBack format["%1=%2", _key, ([_value select 0, _filter] call CBA_fnc_filter) joinString "."]}] call CBA_fnc_hashEachPair;
+    private _logMsg = _logMsgs joinString ", ";
 
-     diag_log text format ["[CBA] (versioning) [%1,%2,%3] %4", diag_frameNo, diag_tickTime, time, _logMsgs joinString ", "];
+    INFO_2("%1 VERSIONING:%2", [ARR_3(diag_frameNo, diag_tickTime, time)], _logMsg);
 };
 
 // Dependency check and warn

--- a/addons/versioning/XEH_postInit.sqf
+++ b/addons/versioning/XEH_postInit.sqf
@@ -6,11 +6,11 @@ SCRIPT(XEH_postInit);
 */
 
 if (!SLX_XEH_DisableLogging) then {
-    private _logMsg = "CBA_VERSIONING: ";
+    private _logMsgs = [];
     private _filter = {if (_x isEqualType 1) then {[_x] call CBA_fnc_formatNumber} else {_x}};
-    [GVAR(versions), { _logMsg = (_logMsg + format["%1=%2, ", _key, ([_value select 0, _filter] call CBA_fnc_filter) joinString "."])}] call CBA_fnc_hashEachPair;
+    [GVAR(versions), { _logMsgs pushBack format["%1=%2", _key, ([_value select 0, _filter] call CBA_fnc_filter) joinString "."]}] call CBA_fnc_hashEachPair;
 
-    diag_log [diag_frameNo, diag_tickTime, time, _logMsg];
+     diag_log text format ["[CBA] (versioning) [%1,%2,%3] %4", diag_frameNo, diag_tickTime, time, _logMsgs joinString ", "];
 };
 
 // Dependency check and warn

--- a/addons/versioning/XEH_postInitClient.sqf
+++ b/addons/versioning/XEH_postInitClient.sqf
@@ -5,11 +5,11 @@ if (isServer) exitWith {};
 SLX_XEH_STR spawn {
     waitUntil {!(isNil QGVAR(versions_serv))};
     if (!SLX_XEH_DisableLogging) then {
-        private "_logMsg";
-        _logMsg = "CBA_VERSIONING_SERVER: ";
-        [GVAR(versions_serv), { _logMsg = (_logMsg + format["%1=%2, ", _key, (_value select 0) joinString "."])}] call CBA_fnc_hashEachPair;
+        private _logMsgs = [];
+        [GVAR(versions_serv), { _logMsgs pushBack format["%1=%2", _key, (_value select 0) joinString "."]}] call CBA_fnc_hashEachPair;
+        private _logMsg = _logMsgs joinString ", ";
 
-        diag_log [diag_frameNo, diag_tickTime, time, _logMsg];
+        INFO_2("%1 VERSIONING_SERVER:%2", [ARR_3(diag_frameNo, diag_tickTime, time)], _logMsg);
     };
     [GVAR(versions_serv), {call FUNC(version_check)}] call CBA_fnc_hashEachPair;
 };

--- a/addons/versioning/script_component.hpp
+++ b/addons/versioning/script_component.hpp
@@ -9,4 +9,5 @@
     #define DEBUG_SETTINGS DEBUG_SETTINGS_VERSIONING
 #endif
 
+#define DEBUG_SYNCHRONOUS
 #include "\x\cba\addons\main\script_macros.hpp"

--- a/addons/xeh/fnc_addClassEventHandler.sqf
+++ b/addons/xeh/fnc_addClassEventHandler.sqf
@@ -33,7 +33,7 @@ private _config = configFile >> "CfgVehicles" >> _className;
 
 // init fallback loop when executing on incompatible class for the first time
 if (!GVAR(fallbackRunning) && {ISINCOMP(_className)}) then {
-    WARNING_1("One or more children of class %1 do not support Extended Event Handlers. Fall back to loop.", configName _config);
+    LOG_SYS("WARNING",FORMAT_1("One or more children of class ""%1"" do not support Extended Event Handlers. Fall back to loop.", configName _config));
     call CBA_fnc_startFallbackLoop;
 };
 

--- a/addons/xeh/fnc_addClassEventHandler.sqf
+++ b/addons/xeh/fnc_addClassEventHandler.sqf
@@ -33,7 +33,7 @@ private _config = configFile >> "CfgVehicles" >> _className;
 
 // init fallback loop when executing on incompatible class for the first time
 if (!GVAR(fallbackRunning) && {ISINCOMP(_className)}) then {
-    diag_log text format ["[XEH]: One or more children of class %1 do not support Extended Event Handlers. Fall back to loop.", configName _config];
+    diag_log text format ["[CBA] (XEH): One or more children of class %1 do not support Extended Event Handlers. Fall back to loop.", configName _config];
     call CBA_fnc_startFallbackLoop;
 };
 

--- a/addons/xeh/fnc_addClassEventHandler.sqf
+++ b/addons/xeh/fnc_addClassEventHandler.sqf
@@ -33,7 +33,7 @@ private _config = configFile >> "CfgVehicles" >> _className;
 
 // init fallback loop when executing on incompatible class for the first time
 if (!GVAR(fallbackRunning) && {ISINCOMP(_className)}) then {
-    diag_log text format ["[CBA] (XEH): One or more children of class %1 do not support Extended Event Handlers. Fall back to loop.", configName _config];
+    WARNING_1("One or more children of class %1 do not support Extended Event Handlers. Fall back to loop.", configName _config);
     call CBA_fnc_startFallbackLoop;
 };
 

--- a/addons/xeh/fnc_addClassEventHandler.sqf
+++ b/addons/xeh/fnc_addClassEventHandler.sqf
@@ -33,7 +33,7 @@ private _config = configFile >> "CfgVehicles" >> _className;
 
 // init fallback loop when executing on incompatible class for the first time
 if (!GVAR(fallbackRunning) && {ISINCOMP(_className)}) then {
-    LOG_SYS("WARNING",FORMAT_1("One or more children of class ""%1"" do not support Extended Event Handlers. Fall back to loop.", configName _config));
+    WARNING_1("One or more children of class %1 do not support Extended Event Handlers. Fall back to loop.", configName _config);
     call CBA_fnc_startFallbackLoop;
 };
 

--- a/addons/xeh/fnc_addClassEventHandler.sqf
+++ b/addons/xeh/fnc_addClassEventHandler.sqf
@@ -44,7 +44,7 @@ _eventName = toLower _eventName;
 
 // no such event
 if (_eventName == "FiredBIS") exitWith {
-    WARNING("Cannot add 'FiredBIS' - Use 'Fired' instead");
+    WARNING("Cannot add ""FiredBIS"" - Use ""Fired"" instead.");
     false
 };
 if !(_eventName in GVAR(EventsLowercase)) exitWith {false};

--- a/addons/xeh/fnc_compileEventHandlers.sqf
+++ b/addons/xeh/fnc_compileEventHandlers.sqf
@@ -123,7 +123,7 @@ if (_allowRecompile) then {
         if (_eventName == "fired") then {
             // generate backwards compatible format of _this
             _eventFuncBase = "private _this = [_this select 0, _this select 1, _this select 2, _this select 3, _this select 4, _this select 6, _this select 5];";
-            WARNING_4("Usage of deprecated Extended Event Handler ""fired"". Use ""firedBIS"" instead. Path: %1\%2\%3\%4.", configSourceMod _x, _baseConfig, XEH_FORMAT_CONFIG_NAME(_eventName), _className);
+            LOG_SYS("WARNING",FORMAT_4("Usage of deprecated Extended Event Handler ""fired"". Use ""firedBIS"" instead. Path: %1\%2\%3\%4.", configSourceMod _x, _baseConfig, XEH_FORMAT_CONFIG_NAME(_eventName), _className));
         };
 
         {

--- a/addons/xeh/fnc_compileEventHandlers.sqf
+++ b/addons/xeh/fnc_compileEventHandlers.sqf
@@ -123,7 +123,7 @@ if (_allowRecompile) then {
         if (_eventName == "fired") then {
             // generate backwards compatible format of _this
             _eventFuncBase = "private _this = [_this select 0, _this select 1, _this select 2, _this select 3, _this select 4, _this select 6, _this select 5];";
-            LOG_SYS("WARNING",FORMAT_4("Usage of deprecated Extended Event Handler ""fired"". Use ""firedBIS"" instead. Path: %1\%2\%3\%4.", configSourceMod _x, _baseConfig, XEH_FORMAT_CONFIG_NAME(_eventName), _className));
+            WARNING_4("Usage of deprecated Extended Event Handler ""fired"". Use ""firedBIS"" instead. Path: %1\%2\%3\%4.", configSourceMod _x, _baseConfig, XEH_FORMAT_CONFIG_NAME(_eventName), _className);
         };
 
         {

--- a/addons/xeh/fnc_compileEventHandlers.sqf
+++ b/addons/xeh/fnc_compileEventHandlers.sqf
@@ -31,7 +31,7 @@ private _allowRecompile = _baseConfig isEqualTo configFile;
 
 if (_allowRecompile) then {
     if ("compile" call CBA_fnc_isRecompileEnabled || {isFilePatchingEnabled}) then {
-        XEH_LOG("XEH: init function preProcessing disabled [recompile or filepatching enabled]");
+        XEH_LOG("init function preProcessing disabled [recompile or filepatching enabled]");
         _allowRecompile = false;
     };
 };
@@ -123,7 +123,7 @@ if (_allowRecompile) then {
         if (_eventName == "fired") then {
             // generate backwards compatible format of _this
             _eventFuncBase = "private _this = [_this select 0, _this select 1, _this select 2, _this select 3, _this select 4, _this select 6, _this select 5];";
-            diag_log text format ["[XEH]: Usage of deprecated Extended Event Handler ""fired"". Use ""firedBIS"" instead. Path: %1\%2\%3\%4.", configSourceMod _x, _baseConfig, XEH_FORMAT_CONFIG_NAME(_eventName), _className];
+            diag_log text format ["[CBA] (XEH): Usage of deprecated Extended Event Handler ""fired"". Use ""firedBIS"" instead. Path: %1\%2\%3\%4.", configSourceMod _x, _baseConfig, XEH_FORMAT_CONFIG_NAME(_eventName), _className];
         };
 
         {

--- a/addons/xeh/fnc_compileEventHandlers.sqf
+++ b/addons/xeh/fnc_compileEventHandlers.sqf
@@ -123,7 +123,7 @@ if (_allowRecompile) then {
         if (_eventName == "fired") then {
             // generate backwards compatible format of _this
             _eventFuncBase = "private _this = [_this select 0, _this select 1, _this select 2, _this select 3, _this select 4, _this select 6, _this select 5];";
-            diag_log text format ["[CBA] (XEH): Usage of deprecated Extended Event Handler ""fired"". Use ""firedBIS"" instead. Path: %1\%2\%3\%4.", configSourceMod _x, _baseConfig, XEH_FORMAT_CONFIG_NAME(_eventName), _className];
+            WARNING_4("Usage of deprecated Extended Event Handler ""fired"". Use ""firedBIS"" instead. Path: %1\%2\%3\%4.", configSourceMod _x, _baseConfig, XEH_FORMAT_CONFIG_NAME(_eventName), _className);
         };
 
         {

--- a/addons/xeh/fnc_init.sqf
+++ b/addons/xeh/fnc_init.sqf
@@ -1,4 +1,3 @@
-#define DEBUG_SYNCHRONOUS
 #include "script_component.hpp"
 /* ----------------------------------------------------------------------------
 Function: CBA_fnc_init

--- a/addons/xeh/fnc_initDisplay3DEN.sqf
+++ b/addons/xeh/fnc_initDisplay3DEN.sqf
@@ -4,7 +4,7 @@ params ["_display"];
 
 private _fnc_watchDog = {
     if (!ISPROCESSED(missionNamespace)) then {
-        diag_log text format ["XEH: missionNamespace processed [%1]", ISPROCESSED(missionNamespace)];
+        diag_log text format ["[CBA] (XEH): missionNamespace processed [%1]", ISPROCESSED(missionNamespace)];
         [] call CBA_fnc_preInit;
     };
 };

--- a/addons/xeh/fnc_initDisplay3DEN.sqf
+++ b/addons/xeh/fnc_initDisplay3DEN.sqf
@@ -4,7 +4,7 @@ params ["_display"];
 
 private _fnc_watchDog = {
     if (!ISPROCESSED(missionNamespace)) then {
-        diag_log text format ["[CBA] (XEH): missionNamespace processed [%1]", ISPROCESSED(missionNamespace)];
+        INFO_1("missionNamespace processed [%1]", ISPROCESSED(missionNamespace));
         [] call CBA_fnc_preInit;
     };
 };

--- a/addons/xeh/fnc_postInit.sqf
+++ b/addons/xeh/fnc_postInit.sqf
@@ -17,7 +17,7 @@ Author:
 ---------------------------------------------------------------------------- */
 
 isNil {
-    XEH_LOG("XEH: PostInit started. " + PFORMAT_9("MISSIONINIT",missionName,missionVersion,worldName,isMultiplayer,isServer,isDedicated,CBA_isHeadlessClient,hasInterface,didJIP));
+    XEH_LOG("PostInit started. " + PFORMAT_9("MISSIONINIT",missionName,missionVersion,worldName,isMultiplayer,isServer,isDedicated,CBA_isHeadlessClient,hasInterface,didJIP));
 
     // fix CBA_missionTime being -1 on (non-JIP) clients at mission start.
     if (CBA_missionTime == -1) then {
@@ -60,7 +60,7 @@ isNil {
 
     SLX_XEH_MACHINE set [8, true]; // PostInit passed
 
-    XEH_LOG("XEH: PostInit finished.");
+    XEH_LOG("PostInit finished.");
 };
 
 nil

--- a/addons/xeh/fnc_preInit.sqf
+++ b/addons/xeh/fnc_preInit.sqf
@@ -17,7 +17,7 @@ Author:
 ---------------------------------------------------------------------------- */
 
 if (ISPROCESSED(missionNamespace)) exitWith {
-    diag_log text "[CBA] (XEH): preInit already executed. Abort preInit.";
+    XEH_LOG("preInit already executed. Abort preInit.");
 };
 SETPROCESSED(missionNamespace);
 

--- a/addons/xeh/fnc_preInit.sqf
+++ b/addons/xeh/fnc_preInit.sqf
@@ -17,13 +17,13 @@ Author:
 ---------------------------------------------------------------------------- */
 
 if (ISPROCESSED(missionNamespace)) exitWith {
-    diag_log text "[XEH]: preInit already executed. Abort preInit.";
+    diag_log text "[CBA] (XEH): preInit already executed. Abort preInit.";
 };
 SETPROCESSED(missionNamespace);
 
 SLX_XEH_DisableLogging = uiNamespace getVariable ["SLX_XEH_DisableLogging", false]; // get from preStart
 
-XEH_LOG("XEH: PreInit started. v" + getText (configFile >> "CfgPatches" >> "cba_common" >> "versionStr"));
+XEH_LOG("PreInit started. v" + getText (configFile >> "CfgPatches" >> "cba_common" >> "versionStr"));
 
 SLX_XEH_STR = ""; // does nothing, never changes, backwards compatibility
 SLX_XEH_COMPILE = compileFinal "compile preprocessFileLineNumbers _this"; //backwards comps
@@ -90,7 +90,7 @@ GVAR(incompatible) = [] call CBA_fnc_createNamespace;
 
 // always recompile extended event handlers
 #ifdef DEBUG_MODE_FULL
-    XEH_LOG("XEH: Compiling XEH START");
+    XEH_LOG("Compiling XEH START");
 #endif
 
 //Get configFile eventhandlers from cache that was generated at preStart
@@ -101,7 +101,7 @@ GVAR(allEventHandlers) = call (uiNamespace getVariable [QGVAR(configFileEventHan
 } forEach [campaignConfigFile, missionConfigFile];
 
 #ifdef DEBUG_MODE_FULL
-    XEH_LOG("XEH: Compiling XEH END");
+    XEH_LOG("Compiling XEH END");
 #endif
 
 // add extended event handlers to classes
@@ -192,4 +192,4 @@ if (!isServer) then { // only on client
     }] call CBA_fnc_addEventHandler;
 #endif
 
-XEH_LOG("XEH: PreInit finished.");
+XEH_LOG("PreInit finished.");

--- a/addons/xeh/fnc_preStart.sqf
+++ b/addons/xeh/fnc_preStart.sqf
@@ -60,9 +60,9 @@ with uiNamespace do {
         _x params ["_classname", "_addon"];
 
         if (_addon == "") then {
-            LOG_SYS("WARNING",FORMAT_1("%1 does not support Extended Event Handlers!", _classname));
+            WARNING_1("%1 does not support Extended Event Handlers!", _classname);
         } else {
-            LOG_SYS("WARNING",FORMAT_2("%1 does not support Extended Event Handlers! Addon: %2", _classname, _addon));
+            WARNING_2("%1 does not support Extended Event Handlers! Addon: %2", _classname, _addon);
         };
     } forEach (true call CBA_fnc_supportMonitor);
 

--- a/addons/xeh/fnc_preStart.sqf
+++ b/addons/xeh/fnc_preStart.sqf
@@ -60,9 +60,9 @@ with uiNamespace do {
         _x params ["_classname", "_addon"];
 
         if (_addon == "") then {
-            WARNING_1("%1 does not support Extended Event Handlers!", _classname);
+            LOG_SYS("WARNING",FORMAT_1("%1 does not support Extended Event Handlers!", _classname));
         } else {
-            WARNING_2("%1 does not support Extended Event Handlers! Addon: %2", _classname, _addon);
+            LOG_SYS("WARNING",FORMAT_2("%1 does not support Extended Event Handlers! Addon: %2", _classname, _addon));
         };
     } forEach (true call CBA_fnc_supportMonitor);
 

--- a/addons/xeh/fnc_preStart.sqf
+++ b/addons/xeh/fnc_preStart.sqf
@@ -21,7 +21,7 @@ Author:
 with uiNamespace do {
     SLX_XEH_DisableLogging = isClass (configFile >> "CfgPatches" >> "Disable_XEH_Logging");
 
-    XEH_LOG("XEH: PreStart started.");
+    XEH_LOG("PreStart started.");
 
     SLX_XEH_COMPILE = compileFinal "compile preprocessFileLineNumbers _this"; //backwards comps
     SLX_XEH_COMPILE_NEW = CBA_fnc_compileFunction; //backwards comp
@@ -53,16 +53,16 @@ with uiNamespace do {
         diag_log text format ["isScheduled = %1", call CBA_fnc_isScheduled];
     #endif
 
-    XEH_LOG("XEH: PreStart finished.");
+    XEH_LOG("PreStart finished.");
 
     // check extended event handlers compatibility
     {
         _x params ["_classname", "_addon"];
 
         if (_addon == "") then {
-            diag_log text format ["[XEH]: %1 does not support Extended Event Handlers!", _classname];
+            diag_log text format ["[CBA] (XEH): %1 does not support Extended Event Handlers!", _classname];
         } else {
-            diag_log text format ["[XEH]: %1 does not support Extended Event Handlers! Addon: %2", _classname, _addon];
+            diag_log text format ["[CBA] (XEH): %1 does not support Extended Event Handlers! Addon: %2", _classname, _addon];
         };
     } forEach (true call CBA_fnc_supportMonitor);
 

--- a/addons/xeh/fnc_preStart.sqf
+++ b/addons/xeh/fnc_preStart.sqf
@@ -60,9 +60,9 @@ with uiNamespace do {
         _x params ["_classname", "_addon"];
 
         if (_addon == "") then {
-            diag_log text format ["[CBA] (XEH): %1 does not support Extended Event Handlers!", _classname];
+            WARNING_1("%1 does not support Extended Event Handlers!", _classname);
         } else {
-            diag_log text format ["[CBA] (XEH): %1 does not support Extended Event Handlers! Addon: %2", _classname, _addon];
+            WARNING_2("%1 does not support Extended Event Handlers! Addon: %2", _classname, _addon);
         };
     } forEach (true call CBA_fnc_supportMonitor);
 

--- a/addons/xeh/script_component.hpp
+++ b/addons/xeh/script_component.hpp
@@ -14,7 +14,7 @@
 
 #include "\x\cba\addons\main\script_macros.hpp"
 
-#define XEH_LOG(msg) if (!SLX_XEH_DisableLogging) then { diag_log [diag_frameNo, diag_tickTime, time, msg] }
+#define XEH_LOG(msg) if (!SLX_XEH_DisableLogging) then { diag_log text format ['[CBA] (XEH) [%1,%2,%3] %4', diag_frameNo, diag_tickTime, time, msg] }
 
 #define SYS_EVENTHANDLERS(type,class) format [QGVAR(%1:%2), type, class]
 #define EVENTHANDLERS(type,class) (missionNamespace getVariable [SYS_EVENTHANDLERS(type,class), []])

--- a/addons/xeh/script_component.hpp
+++ b/addons/xeh/script_component.hpp
@@ -1,5 +1,4 @@
 #define COMPONENT xeh
-
 #include "\x\cba\addons\main\script_mod.hpp"
 
 //#define DEBUG_ENABLED_XEH

--- a/addons/xeh/script_component.hpp
+++ b/addons/xeh/script_component.hpp
@@ -12,9 +12,10 @@
     #define DEBUG_SETTINGS DEBUG_SETTINGS_XEH
 #endif
 
+#define DEBUG_SYNCHRONOUS
 #include "\x\cba\addons\main\script_macros.hpp"
 
-#define XEH_LOG(msg) if (!SLX_XEH_DisableLogging) then { diag_log text format ['[CBA] (XEH) [%1,%2,%3] %4', diag_frameNo, diag_tickTime, time, msg] }
+#define XEH_LOG(msg) if (!SLX_XEH_DisableLogging) then { INFO_2("%1 %2",[ARR_3(diag_frameNo, diag_tickTime, time)], msg); }
 
 #define SYS_EVENTHANDLERS(type,class) format [QGVAR(%1:%2), type, class]
 #define EVENTHANDLERS(type,class) (missionNamespace getVariable [SYS_EVENTHANDLERS(type,class), []])


### PR DESCRIPTION
before
```
XEH: missionNamespace processed [false]
[CBA] (settings) INFO: Checking mission settings file ...
[3876,80.609,0,"XEH: PreInit started. v3.13.0.191116"]
[CBA] (settings) INFO: Reading settings from settings file.
[3878,81.513,0,"XEH: PostInit started. MISSIONINIT: missionName=tempMissionSP, missionVersion=53, worldName=Stratis, isMultiplayer=false, isServer=true, isDedicated=false, CBA_isHeadlessClient=false, hasInterface=true, didJIP=false"]
[3878,81.528,0,"CBA_VERSIONING: cba=3.13.0.191116, ace=3.12.6.43, acex=3.4.2.13, "]
[3878,81.919,0,"XEH: PostInit finished."]
[CBA] (optics) INFO: Scripted camera restarted.
```
after
```
[CBA] (XEH): missionNamespace processed [false]
[CBA] (XEH) [1998,49.636,0] PreInit started. v3.13.0.191116
[CBA] (settings) INFO: Reading settings from settings file.
[CBA] (settings) INFO: Finished reading settings from settings file.
[CBA] (XEH) [1998,50.153,0] PreInit finished.
[CBA] (XEH) [2000,50.587,0] PostInit started. MISSIONINIT: missionName=tempMissionSP, missionVersion=53, worldName=Stratis, isMultiplayer=false, isServer=true, isDedicated=false, CBA_isHeadlessClient=false, hasInterface=true, didJIP=false
[CBA] (versioning) [2000,50.602,0] cba=3.13.0.191116, ace=3.12.6.43, acex=3.4.2.13
[CBA] (XEH) [2000,50.996,0] PostInit finished.
[CBA] (optics) INFO: Scripted camera restarted.
```
Makes logging consistent with other CBA
Some people may not know that XEH means CBA 
(although most who know how to open a RPT probably do)