### PR TITLE
CBA_fnc_sortNestedArray - Preserve order of elements with same sorting value

### DIFF
--- a/addons/arrays/fnc_sortNestedArray.sqf
+++ b/addons/arrays/fnc_sortNestedArray.sqf
@@ -3,15 +3,19 @@
 Function: CBA_fnc_sortNestedArray
 
 Description:
-    Used to sort a nested array from lowest to highest using quick sort.
+    Sorts the given nested array in either ascending or descending order based on the
+    numerical value at specified index of sub arrays.
 
-    Sorting is based on the specified column, which must have numerical data.
+    Optionally, the current ordering (relative to each other) of array elements with
+    the same numerical sorting value can be preserved.
+
     Original array is modified.
 
 Parameters:
     _array - Nested array to be sorted <ARRAY>
     _index - Sub array item index to be sorted on <NUMBER>
     _order - true: ascending, false: descending (optional, default: true) <BOOLEAN>
+    _preserve - Preserve current order of items with the same sorting value (optional, default: false) <BOOLEAN>
 
 Example:
     (begin example)
@@ -22,20 +26,28 @@ Returns:
     Sorted array <ARRAY>
 
 Author:
-    commy2
+    commy2, mharis001
 ---------------------------------------------------------------------------- */
 SCRIPT(sortNestedArray);
 
-params [["_array", [], [[]]], ["_index", 0, [0]], ["_order", true, [false]]];
+params [["_array", [], [[]]], ["_index", 0, [0]], ["_order", true, [false]], ["_preserve", false, [false]]];
 
 private _helperArray = _array apply {
-    [_x select _index, _x]
+    [_x select _index, 0, _x]
+};
+
+if (_preserve) then {
+    private _coefficient = [-1, 1] select _order;
+
+    {
+        _x set [1, _coefficient * _forEachIndex];
+    } forEach _helperArray;
 };
 
 _helperArray sort _order;
 
 {
-    _array set [_forEachIndex, _x select 1];
+    _array set [_forEachIndex, _x select 2];
 } forEach _helperArray;
 
 _array

--- a/addons/arrays/fnc_sortNestedArray.sqf
+++ b/addons/arrays/fnc_sortNestedArray.sqf
@@ -6,16 +6,12 @@ Description:
     Sorts the given nested array in either ascending or descending order based on the
     numerical value at specified index of sub arrays.
 
-    Optionally, the current ordering (relative to each other) of array elements with
-    the same numerical sorting value can be preserved.
-
     Original array is modified.
 
 Parameters:
     _array - Nested array to be sorted <ARRAY>
     _index - Sub array item index to be sorted on <NUMBER>
     _order - true: ascending, false: descending (optional, default: true) <BOOLEAN>
-    _preserve - Preserve current order of items with the same sorting value (optional, default: false) <BOOLEAN>
 
 Example:
     (begin example)
@@ -30,19 +26,14 @@ Author:
 ---------------------------------------------------------------------------- */
 SCRIPT(sortNestedArray);
 
-params [["_array", [], [[]]], ["_index", 0, [0]], ["_order", true, [false]], ["_preserve", false, [false]]];
+params [["_array", [], [[]]], ["_index", 0, [0]], ["_order", true, [false]]];
 
-private _helperArray = _array apply {
-    [_x select _index, 0, _x]
-};
+private _helperArray = [];
+private _coefficient = [-1, 1] select _order;
 
-if (_preserve) then {
-    private _coefficient = [-1, 1] select _order;
-
-    {
-        _x set [1, _coefficient * _forEachIndex];
-    } forEach _helperArray;
-};
+{
+    _helperArray pushBack [_x select _index, _coefficient * _forEachIndex, _x];
+} forEach _array;
 
 _helperArray sort _order;
 


### PR DESCRIPTION
**When merged this pull request will:**
- title

Example (before changing to default behaviour):

```sqf
_a = [
    ["a", 100],
    ["b", 200],
    ["e", 100],
    ["d", 150],
    ["c", 100],
    ["abc", 200]
];

[_a, 1, true, true] call CBA_fnc_sortNestedArray;
// [["a",100],["e",100],["c",100],["d",150],["b",200],["abc",200]]

_a pushBack ["x", 100];
// [["a",100],["e",100],["c",100],["d",150],["b",200],["abc",200],["x",100]]

[_a, 1, true, true] call CBA_fnc_sortNestedArray;
// [["a",100],["e",100],["c",100],["x",100],["d",150],["b",200],["abc",200]]

// above, ["x", 100] is sorted after all the elements that appeared before it
// however, if preserve is false, the ordering of elements relative to each other is not preserved
[_a, 1, true, false] call CBA_fnc_sortNestedArray;
// [["e",100],["c",100],["x",100],["a",100],["d",150],["abc",200],["b",200]]
```
