### PR TITLE
AI: Don't halt planned movement for empty group

### DIFF
--- a/addons/ai/fnc_clearWaypoints.sqf
+++ b/addons/ai/fnc_clearWaypoints.sqf
@@ -29,6 +29,8 @@ private _waypoints = waypoints _group;
     deleteWaypoint [_group, 0];
 } forEach _waypoints;
 
-// Create a self-deleting waypoint at the leader position to halt all planned movement (based on old waypoints)
-private _wp = _group addWaypoint [getPosATL (leader _group), 0];
-_wp setWaypointStatements ["true", "deleteWaypoint [group this,currentWaypoint (group this)]"];
+if !(units _group isEqualTo []) then {
+    // Create a self-deleting waypoint at the leader position to halt all planned movement (based on old waypoints)
+    private _wp = _group addWaypoint [getPosATL (leader _group), 0];
+    _wp setWaypointStatements ["true", "deleteWaypoint [group this,currentWaypoint (group this)]"];
+};


### PR DESCRIPTION
`CBA_fnc_clearWaypoints` can be call for empty group. In this case, a waypoint is created at [0,0,0] because `getPosATL (leader _group)`. This waypoint is unnecessary in case of empty group because there is no reason to "halt all planned movement".

**When merged this pull request will:**
- This pull request avoid the creation of a waypoint for empty group.
- Each change in a separate line
  - Check if group is not empty
  - Create the waypoint if there is at least a unit in the group
