### PR TITLE
optimize default value for radius in CBA_fnc_addWaypoint etc.

### DIFF
--- a/addons/ai/fnc_addWaypoint.sqf
+++ b/addons/ai/fnc_addWaypoint.sqf
@@ -35,7 +35,7 @@ Author:
 params [
     "_group",
     "_position",
-    ["_radius", 0, [0]],
+    ["_radius", -1, [0]],
     ["_type", "MOVE", [""]],
     ["_behaviour", "UNCHANGED", [""]],
     ["_combat", "NO CHANGE", [""]],

--- a/addons/ai/fnc_clearWaypoints.sqf
+++ b/addons/ai/fnc_clearWaypoints.sqf
@@ -30,5 +30,5 @@ private _waypoints = waypoints _group;
 } forEach _waypoints;
 
 // Create a self-deleting waypoint at the leader position to halt all planned movement (based on old waypoints)
-private _wp = _group addWaypoint [getPosATL (leader _group), 0];
+private _wp = _group addWaypoint [getPosATL (leader _group), -1];
 _wp setWaypointStatements ["true", "deleteWaypoint [group this,currentWaypoint (group this)]"];

--- a/addons/ai/fnc_searchNearby.sqf
+++ b/addons/ai/fnc_searchNearby.sqf
@@ -34,7 +34,7 @@ if ((leader _group) distanceSqr _building > 250e3) exitwith {};
 
     // Add a waypoint to regroup after the search
     _group lockWP true;
-    private _wp = _group addWaypoint [getPos _leader, 0, currentWaypoint _group];
+    private _wp = _group addWaypoint [getPos _leader, -1, currentWaypoint _group];
     private _cond = "({unitReady _x || !(alive _x)} count thisList) == count thisList";
     private _comp = format ["this setFormation '%1'; this setBehaviour '%2'; deleteWaypoint [group this, currentWaypoint (group this)];", formation _group, behaviour _leader];
     _wp setWaypointStatements [_cond, _comp];

--- a/addons/ai/fnc_taskAttack.sqf
+++ b/addons/ai/fnc_taskAttack.sqf
@@ -26,7 +26,7 @@ Author:
 
 ---------------------------------------------------------------------------- */
 
-params ["_group", "_position", ["_radius", 0], ["_override", false]];
+params ["_group", "_position", ["_radius", -1], ["_override", false]];
 
 _group = _group call CBA_fnc_getGroup;
 if !(local _group) exitWith {}; // Don't create waypoints on each machine

--- a/addons/ai/fnc_taskPatrol.sqf
+++ b/addons/ai/fnc_taskPatrol.sqf
@@ -55,7 +55,7 @@ _position = _position call CBA_fnc_getPos;
 
 // Can pass parameters straight through to addWaypoint
 _this =+ _this;
-_this set [2,0];
+_this set [2,-1];
 if (count _this > 3) then {
     _this deleteAt 3;
 };

--- a/addons/ai/fnc_taskSearchArea.sqf
+++ b/addons/ai/fnc_taskSearchArea.sqf
@@ -89,7 +89,7 @@ _onComplete = _statements joinString ";";
 [
     _group,
     _pos,
-    0,
+    -1,
     "MOVE",
     _behaviour,
     _combat,

--- a/addons/ai/fnc_waypointGarrison.sqf
+++ b/addons/ai/fnc_waypointGarrison.sqf
@@ -14,7 +14,7 @@ Returns:
 
 Examples:
    (begin example)
-   _group addWaypoint [_position, 0] setWaypointScript "\x\cba\addons\ai\fnc_waypointGarrison.sqf []";
+   _group addWaypoint [_position, -1] setWaypointScript "\x\cba\addons\ai\fnc_waypointGarrison.sqf []";
 
    [_group, _position] execVM "\x\cba\addons\ai\fnc_waypointGarrison.sqf";
    (end)


### PR DESCRIPTION
**When merged this pull request will:**
- `addWaypoint` does "find waypoint position", which is somewhat like find safe pos _dedmen_
- that safe pos check is only done if radius is > 0 _dedmen_
- -1 disables the check, but always leads to the same result as 0, therefore use -1 as default instead