### PR TITLE
Update make.py for changes to pboProject

### DIFF
--- a/tools/make.py
+++ b/tools/make.py
@@ -1274,9 +1274,9 @@ See the make.cfg file for additional build options.
 
                     else:
                         if check_external:
-                            cmd = [pboproject, "-P", os.path.join(work_drive, prefix, module), "+Engine=Arma3", "-S","+Noisy", "+X", "+Clean", "+Mod="+os.path.join(module_root, release_dir, project), "-Key"]
+                            cmd = [pboproject, "-P", os.path.join(work_drive, prefix, module), "+Engine=Arma3", "-S","+Noisy", "+G", "+Clean", "+Mod="+os.path.join(module_root, release_dir, project), "-Key"]
                         else:
-                            cmd = [pboproject, "-P", os.path.join(work_drive, prefix, module), "+Engine=Arma3", "-S","+Noisy", "-X", "+Clean", "+Mod="+os.path.join(module_root, release_dir, project), "-Key"]
+                            cmd = [pboproject, "-P", os.path.join(work_drive, prefix, module), "+Engine=Arma3", "-S","+Noisy", "-G", "+Clean", "+Mod="+os.path.join(module_root, release_dir, project), "-Key"]
 
                     color("grey")
                     if quiet:


### PR DESCRIPTION
ref https://github.com/acemod/ACE3/pull/7351

2.45
+|-X	deprecated external references	 
+|-G	external references	same as makepbo

2.63
+|-X	no such thing you CANNOT affect exlusion of pbo files
+|-G	enable/disable file reference checks