### PR TITLE
restore selected tab in settings ui

### DIFF
--- a/addons/settings/fnc_gui_configure.sqf
+++ b/addons/settings/fnc_gui_configure.sqf
@@ -92,6 +92,18 @@ if !(ctrlShown _ctrlAddonsGroup) then {
         };
     };
 
+    if (_previousSelectedSource == "client" && {!CAN_VIEW_CLIENT_SETTINGS}) then {
+        _previousSelectedSource = "mission";
+    };
+
+    if (_previousSelectedSource == "mission" && {!CAN_VIEW_MISSION_SETTINGS}) then {
+        _previousSelectedSource = "server";
+    };
+
+    if (_previousSelectedSource == "server" && {!CAN_VIEW_SERVER_SETTINGS}) then {
+        _previousSelectedSource = "";
+    };
+
     private _ctrlPreviousButton = [_ctrlServerButton, _ctrlMissionButton, _ctrlClientButton] param [
         ["server", "mission", "client"] find _previousSelectedSource,
         _ctrlServerButton

--- a/addons/settings/fnc_gui_configure.sqf
+++ b/addons/settings/fnc_gui_configure.sqf
@@ -72,18 +72,33 @@ if !(ctrlShown _ctrlAddonsGroup) then {
     //--- change button text
     _ctrlToggleButton ctrlSetText LLSTRING(configureBase);
 
-    //--- emulate default scope selection
-    switch (true) do {
-        case CAN_SET_CLIENT_SETTINGS: {
-            _ctrlClientButton call FUNC(gui_sourceChanged);
-        };
-        case CAN_SET_MISSION_SETTINGS: {
-            _ctrlMissionButton call FUNC(gui_sourceChanged);
-        };
-        case CAN_SET_SERVER_SETTINGS: {
-            _ctrlServerButton call FUNC(gui_sourceChanged);
+    //--- emulate scope selection
+    private _previousSelectedSource = uiNamespace getVariable QGVAR(source);
+
+    if (isNil "_previousSelectedSource") then {
+        switch (true) do {
+            case CAN_SET_CLIENT_SETTINGS: {
+                _previousSelectedSource = "client";
+            };
+            case CAN_SET_MISSION_SETTINGS: {
+                _previousSelectedSource = "mission";
+            };
+            case CAN_SET_SERVER_SETTINGS: {
+                _previousSelectedSource = "server";
+            };
+            default {
+                _previousSelectedSource = "";
+            };
         };
     };
+
+    private _ctrlPreviousButton = [_ctrlServerButton, _ctrlMissionButton, _ctrlClientButton] param [
+        ["server", "mission", "client"] find _previousSelectedSource,
+        _ctrlServerButton
+    ];
+
+    _ctrlPreviousButton call FUNC(gui_sourceChanged);
+    ctrlSetFocus _ctrlPreviousButton;
 } else {
     //--- enable and show default menu
     _ctrlGeneralGroup ctrlEnable true;

--- a/addons/settings/fnc_initDisplayGameOptions.sqf
+++ b/addons/settings/fnc_initDisplayGameOptions.sqf
@@ -173,6 +173,7 @@ _ctrlButtonExport ctrlAddEventHandler ["ButtonClick", {
     _x ctrlAddEventHandler ["ButtonClick", FUNC(gui_sourceChanged)];
 } forEach [_ctrlServerButton, _ctrlMissionButton, _ctrlClientButton];
 
+// ----- configure addons/base button
 (_display displayCtrl IDC_BTN_CONFIGURE_ADDONS) ctrlAddEventHandler ["ButtonClick", {_this call FUNC(gui_configure)}];
 
 // ----- scripted OK button

--- a/addons/settings/fnc_openSettingsMenu.sqf
+++ b/addons/settings/fnc_openSettingsMenu.sqf
@@ -26,12 +26,3 @@ private _ctrlConfirm = _dlgSettings ctrlCreate ["RscButtonMenuOK", IDC_CANCEL];
 _ctrlConfirm ctrlSetPosition ctrlPosition _ctrlScriptedOK;
 _ctrlConfirm ctrlCommit 0;
 _ctrlConfirm ctrlAddEventHandler ["ButtonClick", {call FUNC(gui_saveTempData)}];
-
-// then switch right to missions tab if in 3den
-if (ctrlIDD _display isEqualTo 313) then {
-    private _ctrlMissionButton = _dlgSettings displayCtrl IDC_BTN_MISSION;
-
-    if (ctrlEnabled _ctrlMissionButton) then {
-        _ctrlMissionButton call FUNC(gui_sourceChanged);
-    };
-};


### PR DESCRIPTION
**When merged this pull request will:**
- make the settings UI remember which tab (SERVER/MISSION/CLIENT) you selected previously when reopening the UI.
