### PR TITLE
skip attachment switch inside vehicles

### DIFF
--- a/addons/accessory/XEH_preInit.sqf
+++ b/addons/accessory/XEH_preInit.sqf
@@ -1,0 +1,21 @@
+#include "script_component.hpp"
+
+if (!hasInterface) exitWith {};
+
+#include "XEH_PREP.sqf"
+
+[ELSTRING(common,WeaponsCategory), "MRT_SwitchItemNextClass_R", [LSTRING(railNext), LSTRING(railNext_tooltip)], {
+    [1, "next"] call FUNC(switchAttachment) // return
+}, {}, [DIK_L, [false, true, false]]] call CBA_fnc_addKeybind;
+
+[ELSTRING(common,WeaponsCategory), "MRT_SwitchItemPrevClass_R", [LSTRING(railPrev), LSTRING(railPrev_tooltip)], {
+    [1, "prev"] call FUNC(switchAttachment) // return
+}, {}, [DIK_L, [true, false, false]]] call CBA_fnc_addKeybind;
+
+[ELSTRING(common,WeaponsCategory), "MRT_SwitchItemNextClass_O", [LSTRING(opticNext), LSTRING(opticNext_tooltip)], {
+    [2, "next"] call FUNC(switchAttachment) // return
+}, {}, [DIK_SUBTRACT, [false, true, false]]] call CBA_fnc_addKeybind;
+
+[ELSTRING(common,WeaponsCategory), "MRT_SwitchItemPrevClass_O", [LSTRING(opticPrev), LSTRING(opticPrev_tooltip)], {
+    [2, "prev"] call FUNC(switchAttachment) // return
+}, {}, [DIK_SUBTRACT, [true, false, false]]] call CBA_fnc_addKeybind;

--- a/addons/accessory/XEH_preInitClient.sqf
+++ b/addons/accessory/XEH_preInitClient.sqf
@@ -1,8 +1,0 @@
-#include "script_component.hpp"
-
-#include "XEH_PREP.sqf"
-
-[ELSTRING(common,WeaponsCategory), "MRT_SwitchItemNextClass_R", [LSTRING(railNext), LSTRING(railNext_tooltip)], {[1, "next"] call FUNC(switchAttachment)}, {}, [38, [false, true, false]]] call CBA_fnc_addKeybind; //default ctrl + L
-[ELSTRING(common,WeaponsCategory), "MRT_SwitchItemPrevClass_R", [LSTRING(railPrev), LSTRING(railPrev_tooltip)], {[1, "prev"] call FUNC(switchAttachment)}, {}, [38, [true, false, false]]] call CBA_fnc_addKeybind; //default shift + L
-[ELSTRING(common,WeaponsCategory), "MRT_SwitchItemNextClass_O", [LSTRING(opticNext), LSTRING(opticNext_tooltip)], {[2, "next"] call FUNC(switchAttachment)}, {}, [181, [false, true, false]]] call CBA_fnc_addKeybind; //default ctlr + NUM-/
-[ELSTRING(common,WeaponsCategory), "MRT_SwitchItemPrevClass_O", [LSTRING(opticPrev), LSTRING(opticPrev_tooltip)], {[2, "prev"] call FUNC(switchAttachment)}, {}, [181, [true, false, false]]] call CBA_fnc_addKeybind; //default shift + NUM-/

--- a/addons/accessory/config.cpp
+++ b/addons/accessory/config.cpp
@@ -22,6 +22,6 @@ class Extended_PreStart_EventHandlers {
 
 class Extended_PreInit_EventHandlers {
     class ADDON {
-        clientInit = QUOTE(call COMPILE_FILE(XEH_preInitClient));
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
     };
 };

--- a/addons/accessory/fnc_switchAttachment.sqf
+++ b/addons/accessory/fnc_switchAttachment.sqf
@@ -28,6 +28,8 @@ private ["_currItem", "_switchItem"];
 private _unit = call CBA_fnc_currentUnit;
 private _cw = currentWeapon _unit;
 
+if !(_unit call CBA_fnc_canUseWeapon) exitWith {false};
+
 private _currWeaponType = call {
     if (_cw == "") exitWith {_currItem = ""; -1};
     if (_cw == primaryWeapon _unit) exitWith {_currItem = (primaryWeaponItems _unit) select _itemType; 0};
@@ -36,7 +38,7 @@ private _currWeaponType = call {
     _currItem = "";
     -1
 };
-if (_currWeaponType < 0) exitWith { false };
+if (_currWeaponType < 0) exitWith {false};
 
 #define __cfgWeapons configfile >> "CfgWeapons"
 #define __currItem __cfgWeapons >> _currItem

--- a/addons/accessory/script_component.hpp
+++ b/addons/accessory/script_component.hpp
@@ -10,3 +10,5 @@
 #endif
 
 #include "\x\cba\addons\main\script_macros.hpp"
+
+#include "\a3\ui_f\hpp\defineDIKCodes.inc"


### PR DESCRIPTION
**When merged this pull request will:**
- exit attachment switch functions early to free up the key combo for vehicle control (see: https://github.com/acemod/ACE3/issues/7498)
- changes accessory preInitClient to preInit with hasInterface check to optimize on HCs
- DIK codes = self documenting code for they default keys, also formatting
