### PR TITLE
optimize player events

### DIFF
--- a/addons/events/XEH_preInit.sqf
+++ b/addons/events/XEH_preInit.sqf
@@ -33,6 +33,7 @@ if (isServer) then {
 ADDON = true;
 
 if (!hasInterface) exitWith {};
+PREP(playerEvent);
 
 GVAR(skipCheckingUserActions) = true;
 

--- a/addons/events/XEH_preStart.sqf
+++ b/addons/events/XEH_preStart.sqf
@@ -1,6 +1,8 @@
 #include "script_component.hpp"
 
 if (hasInterface) then {
+    PREP(playerEvent);
+
     PREP(initDisplayMission);
     PREP(initDisplayMainMap);
     PREP(initDisplayCurator);

--- a/addons/events/fnc_addPlayerEventHandler.sqf
+++ b/addons/events/fnc_addPlayerEventHandler.sqf
@@ -152,134 +152,16 @@ if (_id != -1) then {
         GVAR(oldVisibleMap) = false;
         GVAR(oldState) = [];
 
-        GVAR(playerEHInfo) pushBack addMissionEventHandler ["EachFrame", {call FUNC(playerEH_EachFrame)}];
-        [QFUNC(playerEH_EachFrame), {
-            SCRIPT(playerEH_EachFrame);
-            private _unit = missionNamespace getVariable ["bis_fnc_moduleRemoteControl_unit", player];
-            private _vehicle = vehicle _unit;
+        GVAR(playerEHInfo) pushBack addMissionEventHandler ["EachFrame", {call FUNC(playerEvent)}];
+        GVAR(playerEHInfo) pushBack addMissionEventHandler ["Map", {
+            SCRIPT(playerEvent_Map);
 
-            private _controlledEntity = _unit;
-            if (!isNull getConnectedUAV _unit) then {
-                private _uavControl = UAVControl getConnectedUAV _unit;
-                _uavControl = _uavControl param [(_uavControl find _unit) + 1, ""]; // will be position string if actively controlling, or object if not
-                if (_uavControl isEqualTo "DRIVER") exitWith {
-                    _controlledEntity = driver getConnectedUAV _unit;
-                };
-
-                if (_uavControl isEqualTo "GUNNER") exitWith {
-                    _controlledEntity = gunner getConnectedUAV _unit;
-                };
-            };
-
-            private _turret = [];
-            if (_unit != _vehicle) then {
-                _turret = allTurrets [_vehicle, true] select {_vehicle turretUnit _x == _unit} param [0, []];
-            };
-
-            private _state = [
-                _unit, group _unit, leader _unit,
-                currentWeapon _unit, currentMuzzle _unit, currentWeaponMode _unit,
-                getUnitLoadout _unit, _vehicle, _turret,
-                currentVisionMode _controlledEntity, cameraView
-            ];
-
-            if !(_state isEqualTo GVAR(oldState)) then {
-                GVAR(oldState) = _state;
-
-                _state params [
-                    "", "_newGroup", "_newLeader",
-                    "_newWeapon", "_newMuzzle", "_newWeaponMode",
-                    "_newLoadout", "", "",
-                    "_newVisionMode", "_newCameraView"
-                ];
-
-                // These events should fire if the context of the state has changed.
-                // I.e. switching to a different weapon with "Single" fire mode is an implicit weapon mode switch
-                // The modes just happen to share the same name.
-                _newMuzzle = [_unit, _newWeapon, _newMuzzle];
-                _newWeaponMode = [_unit, _newMuzzle, _newWeaponMode];
-
-                if !(_unit isEqualTo GVAR(oldUnit)) then {
-                    [QGVAR(unitEvent), [_unit, GVAR(oldUnit)]] call CBA_fnc_localEvent;
-                    GVAR(oldUnit) = _unit;
-                };
-
-                if !(_newGroup isEqualTo GVAR(oldGroup)) then {
-                    [QGVAR(groupEvent), [_unit, GVAR(oldGroup), _newGroup]] call CBA_fnc_localEvent;
-                    GVAR(oldGroup) = _newGroup;
-                };
-
-                if !(_newLeader isEqualTo GVAR(oldLeader)) then {
-                    [QGVAR(leaderEvent), [_unit, GVAR(oldLeader), _newLeader]] call CBA_fnc_localEvent;
-                    GVAR(oldLeader) = _newLeader;
-                };
-
-                if !(_newWeapon isEqualTo GVAR(oldWeapon)) then {
-                    [QGVAR(weaponEvent), [_unit, _newWeapon, GVAR(oldWeapon)]] call CBA_fnc_localEvent;
-                    GVAR(oldWeapon) = _newWeapon;
-                };
-
-                if !(_newMuzzle isEqualTo GVAR(oldMuzzle)) then {
-                    [QGVAR(muzzleEvent), [_newMuzzle select 2, GVAR(oldMuzzle) select 2]] call CBA_fnc_localEvent;
-                    GVAR(oldMuzzle) = _newMuzzle;
-                };
-
-                if !(_newWeaponMode isEqualTo GVAR(oldWeaponMode)) then {
-                    [QGVAR(weaponModeEvent), [_unit, _newWeaponMode select 2, GVAR(oldWeaponMode) select 2]] call CBA_fnc_localEvent;
-                    GVAR(oldWeaponMode) = _newWeaponMode;
-                };
-
-                if !(_newLoadout isEqualTo GVAR(oldLoadout)) then {
-                    // We don't want to trigger this just because your ammo counter decreased.
-                    private _newLoadoutNoAmmo = + _newLoadout;
-
-                    {
-                        private _weaponInfo = _newLoadoutNoAmmo param [_forEachIndex, []];
-                        if !(_weaponInfo isEqualTo []) then {
-                            _weaponInfo set [4, _x];
-                            _weaponInfo deleteAt 5;
-                        };
-                    } forEach [primaryWeaponMagazine _unit, secondaryWeaponMagazine _unit, handgunMagazine _unit];
-
-                    if !(_newLoadoutNoAmmo isEqualTo GVAR(oldLoadoutNoAmmo)) then {
-                        [QGVAR(loadoutEvent), [_unit, GVAR(oldLoadout), _newLoadout]] call CBA_fnc_localEvent;
-                        GVAR(oldLoadoutNoAmmo) = _newLoadoutNoAmmo;
-                    };
-
-                    GVAR(oldLoadout) = _newLoadout;
-                };
-
-                if !(_vehicle isEqualTo GVAR(oldVehicle)) then {
-                    [QGVAR(vehicleEvent), [_unit, _vehicle, GVAR(oldVehicle)]] call CBA_fnc_localEvent;
-                    GVAR(oldVehicle) = _vehicle;
-                };
-
-                if !(_turret isEqualTo GVAR(oldTurret)) then {
-                    [QGVAR(turretEvent), [_unit, _turret, GVAR(oldTurret)]] call CBA_fnc_localEvent;
-                    GVAR(oldTurret) = _turret;
-                };
-
-                if !(_newVisionMode isEqualTo GVAR(oldVisionMode)) then {
-                    [QGVAR(visionModeEvent), [_unit, _newVisionMode, GVAR(oldVisionMode)]] call CBA_fnc_localEvent;
-                    GVAR(oldVisionMode) = _newVisionMode;
-                };
-
-                if !(_newCameraView isEqualTo GVAR(oldCameraView)) then {
-                    [QGVAR(cameraViewEvent), [_unit, _newCameraView, GVAR(oldCameraView)]] call CBA_fnc_localEvent;
-                    GVAR(oldCameraView) = _newCameraView;
-                };
-            };
-        }] call CBA_fnc_compileFinal;
-
-        GVAR(playerEHInfo) pushBack addMissionEventHandler ["Map", {call FUNC(playerEH_Map)}];
-        [QFUNC(playerEH_Map), {
-            SCRIPT(playerEH_Map);
             params ["_data"]; // visibleMap is updated one frame later
             if !(_data isEqualTo GVAR(oldVisibleMap)) then {
                 GVAR(oldVisibleMap) = _data;
                 [QGVAR(visibleMapEvent), [call CBA_fnc_currentUnit, _data]] call CBA_fnc_localEvent;
             };
-        }] call CBA_fnc_compileFinal;
+        }];
 
         // emulate change to first value from default one frame later
         // using spawn-dc to not having to wait for postInit to complete
@@ -295,6 +177,7 @@ if (_id != -1) then {
 
         GVAR(playerEHInfo) pushBack ([{
             SCRIPT(playerEH_featureCamera);
+
             private _data = call CBA_fnc_getActiveFeatureCamera;
             if !(_data isEqualTo GVAR(oldFeatureCamera)) then {
                 GVAR(oldFeatureCamera) = _data;

--- a/addons/events/fnc_addPlayerEventHandler.sqf
+++ b/addons/events/fnc_addPlayerEventHandler.sqf
@@ -151,23 +151,31 @@ if (_id != -1) then {
         [QFUNC(playerEH_EachFrame), {
             SCRIPT(playerEH_EachFrame);
             private _unit = missionNamespace getVariable ["bis_fnc_moduleRemoteControl_unit", player];
-            private _controlledEntity = _unit;
+            private _vehicle = vehicle _unit;
 
-            private _uavControl = UAVControl getConnectedUAV _unit;
-            _uavControl = _uavControl param [(_uavControl find _unit) + 1, ""];
-            if (_uavControl isEqualTo "DRIVER") then {
-                _controlledEntity = driver getConnectedUAV _unit;
+            private _controlledEntity = _unit;
+            if (!isNull getConnectedUAV _unit) then {
+                private _uavControl = UAVControl getConnectedUAV _unit;
+                _uavControl = _uavControl param [(_uavControl find _unit) + 1, ""];
+                if (_uavControl isEqualTo "DRIVER") exitWith {
+                    _controlledEntity = driver getConnectedUAV _unit;
+                };
+
+                if (_uavControl isEqualTo "GUNNER") exitWith {
+                    _controlledEntity = gunner getConnectedUAV _unit;
+                };
             };
 
-            if (_uavControl isEqualTo "GUNNER") then {
-                _controlledEntity = gunner getConnectedUAV _unit;
+            private _turret = [];
+            if (_unit != _vehicle) then {
+                _turret = allTurrets [_vehicle, true] select {_vehicle turretUnit _x == _unit} param [0, []];
             };
 
             private _state = [
                 _unit, group _unit, leader _unit,
                 currentWeapon _unit, currentMuzzle _unit, currentWeaponMode _unit,
                 getUnitLoadout _unit,
-                vehicle _unit, _unit call CBA_fnc_turretPath,
+                _vehicle, _turret,
                 currentVisionMode _controlledEntity, cameraView
             ];
 

--- a/addons/events/fnc_addPlayerEventHandler.sqf
+++ b/addons/events/fnc_addPlayerEventHandler.sqf
@@ -174,8 +174,7 @@ if (_id != -1) then {
             private _state = [
                 _unit, group _unit, leader _unit,
                 currentWeapon _unit, currentMuzzle _unit, currentWeaponMode _unit,
-                getUnitLoadout _unit,
-                _vehicle, _turret,
+                getUnitLoadout _unit, _vehicle, _turret,
                 currentVisionMode _controlledEntity, cameraView
             ];
 
@@ -183,13 +182,13 @@ if (_id != -1) then {
                 GVAR(oldState) = _state;
 
                 _state params [
-                    "_newunit", "_newGroup", "_newLeader",
+                    "", "_newGroup", "_newLeader",
                     "_newWeapon", "_newMuzzle", "_newWeaponMode",
-                    "_newLoadout", "_newVehicle", "_newTurret",
+                    "_newLoadout", "", "",
                     "_newVisionMode", "_newCameraView"
                 ];
 
-                if !(_newunit isEqualTo GVAR(oldUnit)) then {
+                if !(_unit isEqualTo GVAR(oldUnit)) then {
                     [QGVAR(unitEvent), [_unit, GVAR(oldUnit)]] call CBA_fnc_localEvent;
                     GVAR(oldUnit) = _unit;
                 };
@@ -221,7 +220,7 @@ if (_id != -1) then {
 
                 if !(_newLoadout isEqualTo GVAR(oldLoadout)) then {
                     // We don't want to trigger this just because your ammo counter decreased.
-                    _newLoadoutNoAmmo = + _newLoadout;
+                    private _newLoadoutNoAmmo = + _newLoadout;
 
                     {
                         private _weaponInfo = _newLoadoutNoAmmo param [_forEachIndex, []];
@@ -239,14 +238,14 @@ if (_id != -1) then {
                     GVAR(oldLoadout) = _newLoadout;
                 };
 
-                if !(_newVehicle isEqualTo GVAR(oldVehicle)) then {
-                    [QGVAR(vehicleEvent), [_unit, _newVehicle]] call CBA_fnc_localEvent;
-                    GVAR(oldVehicle) = _newVehicle;
+                if !(_vehicle isEqualTo GVAR(oldVehicle)) then {
+                    [QGVAR(vehicleEvent), [_unit, _vehicle]] call CBA_fnc_localEvent;
+                    GVAR(oldVehicle) = _vehicle;
                 };
 
-                if !(_newTurret isEqualTo GVAR(oldTurret)) then {
-                    [QGVAR(turretEvent), [_unit, _newTurret]] call CBA_fnc_localEvent;
-                    GVAR(oldTurret) = _newTurret;
+                if !(_turret isEqualTo GVAR(oldTurret)) then {
+                    [QGVAR(turretEvent), [_unit, _turret]] call CBA_fnc_localEvent;
+                    GVAR(oldTurret) = _turret;
                 };
 
                 if !(_newVisionMode isEqualTo GVAR(oldVisionMode)) then {

--- a/addons/events/fnc_addPlayerEventHandler.sqf
+++ b/addons/events/fnc_addPlayerEventHandler.sqf
@@ -8,6 +8,7 @@ Description:
     Possible events:
         "unit"          - player controlled unit changed
         "weapon"        - currently selected weapon change
+        "turretweapon"  - currently selected turret weapon change
         "muzzle"        - currently selected muzzle change
         "weaponMode"    - currently selected weapon mode change
         "loadout"       - players loadout changed
@@ -58,49 +59,55 @@ private _id = switch (_type) do {
     };
     case "weapon": {
         if (_applyRetroactively) then {
-            [GVAR(oldUnit), currentWeapon GVAR(oldUnit)] call _function;
+            [GVAR(oldUnit), currentWeapon GVAR(oldUnit), ""] call _function;
         };
         [QGVAR(weaponEvent), _function] call CBA_fnc_addEventHandler // return id
     };
+    case "turretweapon": {
+        if (_applyRetroactively) then {
+            [GVAR(oldUnit), GVAR(oldUnit) currentWeaponTurret (GVAR(oldUnit) call CBA_fnc_turretPath), ""] call _function;
+        };
+        [QGVAR(turretWeaponEvent), _function] call CBA_fnc_addEventHandler // return id
+    };
     case "muzzle": {
         if (_applyRetroactively) then {
-            [GVAR(oldUnit), currentMuzzle GVAR(oldUnit)] call _function;
+            [GVAR(oldUnit), currentMuzzle GVAR(oldUnit), ""] call _function;
         };
         [QGVAR(muzzleEvent), _function] call CBA_fnc_addEventHandler // return id
     };
     case "weaponmode": {
         if (_applyRetroactively) then {
-            [GVAR(oldUnit), currentWeaponMode GVAR(oldUnit)] call _function;
+            [GVAR(oldUnit), currentWeaponMode GVAR(oldUnit), ""] call _function;
         };
         [QGVAR(weaponModeEvent), _function] call CBA_fnc_addEventHandler // return id
     };
     case "loadout": {
         if (_applyRetroactively) then {
-            [GVAR(oldUnit), getUnitLoadout GVAR(oldUnit)] call _function;
+            [GVAR(oldUnit), getUnitLoadout GVAR(oldUnit), []] call _function;
         };
         [QGVAR(loadoutEvent), _function] call CBA_fnc_addEventHandler // return id
     };
     case "vehicle": {
         if (_applyRetroactively) then {
-            [GVAR(oldUnit), vehicle GVAR(oldUnit)] call _function;
+            [GVAR(oldUnit), vehicle GVAR(oldUnit), objNull] call _function;
         };
         [QGVAR(vehicleEvent), _function] call CBA_fnc_addEventHandler // return id
     };
     case "turret": {
         if (_applyRetroactively) then {
-            [GVAR(oldUnit), GVAR(oldUnit) call CBA_fnc_turretPath] call _function;
+            [GVAR(oldUnit), GVAR(oldUnit) call CBA_fnc_turretPath, []] call _function;
         };
         [QGVAR(turretEvent), _function] call CBA_fnc_addEventHandler // return id
     };
     case "visionmode": {
         if (_applyRetroactively) then {
-            [GVAR(oldUnit), currentVisionMode GVAR(oldUnit)] call _function;
+            [GVAR(oldUnit), currentVisionMode GVAR(oldUnit), -1] call _function;
         };
         [QGVAR(visionModeEvent), _function] call CBA_fnc_addEventHandler // return id
     };
     case "cameraview": {
         if (_applyRetroactively) then {
-            [GVAR(oldUnit), cameraView] call _function;
+            [GVAR(oldUnit), cameraView, ""] call _function;
         };
         [QGVAR(cameraViewEvent), _function] call CBA_fnc_addEventHandler // return id
     };
@@ -118,13 +125,13 @@ private _id = switch (_type) do {
     };
     case "group": {
         if (_applyRetroactively) then {
-            [GVAR(oldUnit), group GVAR(oldUnit)] call _function;
+            [GVAR(oldUnit), group GVAR(oldUnit), grpNull] call _function;
         };
         [QGVAR(groupEvent), _function] call CBA_fnc_addEventHandler // return id
     };
     case "leader": {
         if (_applyRetroactively) then {
-            [GVAR(oldUnit), group GVAR(oldUnit)] call _function;
+            [GVAR(oldUnit), leader GVAR(oldUnit), objNull] call _function;
         };
         [QGVAR(leaderEvent), _function] call CBA_fnc_addEventHandler // return id
     };
@@ -140,6 +147,7 @@ if (_id != -1) then {
         GVAR(oldGroup) = grpNull;
         GVAR(oldLeader) = objNull;
         GVAR(oldWeapon) = "";
+        GVAR(oldTurretWeapon) = "";
         GVAR(oldMuzzle) = [objNull, "", ""];
         GVAR(oldWeaponMode) = [objNull, GVAR(oldMuzzle), ""];
         GVAR(oldLoadout) = [];

--- a/addons/events/fnc_addPlayerEventHandler.sqf
+++ b/addons/events/fnc_addPlayerEventHandler.sqf
@@ -44,81 +44,86 @@ params [["_type", "", [""]], ["_function", {}, [{}]], ["_applyRetroactively", fa
 
 _type = toLower _type;
 
+// Skip retroactive execution if no current unit.
+if (!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])) then {
+    _applyRetroactively = false;
+};
+
 private _id = switch (_type) do {
     case "unit": {
-        if (_applyRetroactively && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
+        if (_applyRetroactively) then {
             [GVAR(oldUnit), objNull] call _function;
         };
         [QGVAR(unitEvent), _function] call CBA_fnc_addEventHandler // return id
     };
     case "weapon": {
-        if (_applyRetroactively && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
+        if (_applyRetroactively) then {
             [GVAR(oldUnit), currentWeapon GVAR(oldUnit)] call _function;
         };
         [QGVAR(weaponEvent), _function] call CBA_fnc_addEventHandler // return id
     };
     case "muzzle": {
-        if (_applyRetroactively && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
+        if (_applyRetroactively) then {
             [GVAR(oldUnit), currentMuzzle GVAR(oldUnit)] call _function;
         };
         [QGVAR(muzzleEvent), _function] call CBA_fnc_addEventHandler // return id
     };
     case "weaponmode": {
-        if (_applyRetroactively && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
+        if (_applyRetroactively) then {
             [GVAR(oldUnit), currentWeaponMode GVAR(oldUnit)] call _function;
         };
         [QGVAR(weaponModeEvent), _function] call CBA_fnc_addEventHandler // return id
     };
     case "loadout": {
-        if (_applyRetroactively && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
+        if (_applyRetroactively) then {
             [GVAR(oldUnit), getUnitLoadout GVAR(oldUnit)] call _function;
         };
         [QGVAR(loadoutEvent), _function] call CBA_fnc_addEventHandler // return id
     };
     case "vehicle": {
-        if (_applyRetroactively && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
+        if (_applyRetroactively) then {
             [GVAR(oldUnit), vehicle GVAR(oldUnit)] call _function;
         };
         [QGVAR(vehicleEvent), _function] call CBA_fnc_addEventHandler // return id
     };
     case "turret": {
-        if (_applyRetroactively && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
+        if (_applyRetroactively) then {
             [GVAR(oldUnit), GVAR(oldUnit) call CBA_fnc_turretPath] call _function;
         };
         [QGVAR(turretEvent), _function] call CBA_fnc_addEventHandler // return id
     };
     case "visionmode": {
-        if (_applyRetroactively && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
+        if (_applyRetroactively) then {
             [GVAR(oldUnit), currentVisionMode GVAR(oldUnit)] call _function;
         };
         [QGVAR(visionModeEvent), _function] call CBA_fnc_addEventHandler // return id
     };
     case "cameraview": {
-        if (_applyRetroactively && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
+        if (_applyRetroactively) then {
             [GVAR(oldUnit), cameraView] call _function;
         };
         [QGVAR(cameraViewEvent), _function] call CBA_fnc_addEventHandler // return id
     };
     case "featurecamera": {
-        if (_applyRetroactively && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
+        if (_applyRetroactively) then {
             [GVAR(oldUnit), call CBA_fnc_getActiveFeatureCamera] call _function;
         };
         [QGVAR(featureCameraEvent), _function] call CBA_fnc_addEventHandler // return id
     };
     case "visiblemap": {
-        if (_applyRetroactively && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
+        if (_applyRetroactively) then {
             [GVAR(oldUnit), visibleMap] call _function;
         };
         [QGVAR(visibleMapEvent), _function] call CBA_fnc_addEventHandler // return id
     };
     case "group": {
-        if (_applyRetroactively && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
+        if (_applyRetroactively) then {
             [GVAR(oldUnit), group GVAR(oldUnit)] call _function;
         };
         [QGVAR(groupEvent), _function] call CBA_fnc_addEventHandler // return id
     };
     case "leader": {
-        if (_applyRetroactively && {!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
+        if (_applyRetroactively) then {
             [GVAR(oldUnit), group GVAR(oldUnit)] call _function;
         };
         [QGVAR(leaderEvent), _function] call CBA_fnc_addEventHandler // return id

--- a/addons/events/fnc_addPlayerEventHandler.sqf
+++ b/addons/events/fnc_addPlayerEventHandler.sqf
@@ -140,8 +140,8 @@ if (_id != -1) then {
         GVAR(oldGroup) = grpNull;
         GVAR(oldLeader) = objNull;
         GVAR(oldWeapon) = "";
-        GVAR(oldMuzzle) = "";
-        GVAR(oldWeaponMode) = "";
+        GVAR(oldMuzzle) = [objNull, "", ""];
+        GVAR(oldWeaponMode) = [objNull, GVAR(oldMuzzle), ""];
         GVAR(oldLoadout) = [];
         GVAR(oldLoadoutNoAmmo) = [];
         GVAR(oldVehicle) = objNull;
@@ -193,6 +193,12 @@ if (_id != -1) then {
                     "_newVisionMode", "_newCameraView"
                 ];
 
+                // These events should fire if the context of the state has changed.
+                // I.e. switching to a different weapon with "Single" fire mode is an implicit weapon mode switch
+                // The modes just happen to share the same name.
+                _newMuzzle = [_unit, _newWeapon, _newMuzzle];
+                _newWeaponMode = [_unit, _newMuzzle, _newWeaponMode];
+
                 if !(_unit isEqualTo GVAR(oldUnit)) then {
                     [QGVAR(unitEvent), [_unit, GVAR(oldUnit)]] call CBA_fnc_localEvent;
                     GVAR(oldUnit) = _unit;
@@ -214,12 +220,12 @@ if (_id != -1) then {
                 };
 
                 if !(_newMuzzle isEqualTo GVAR(oldMuzzle)) then {
-                    [QGVAR(muzzleEvent), [_unit, _newMuzzle, GVAR(oldMuzzle)]] call CBA_fnc_localEvent;
+                    [QGVAR(muzzleEvent), [_newMuzzle select 2, GVAR(oldMuzzle) select 2]] call CBA_fnc_localEvent;
                     GVAR(oldMuzzle) = _newMuzzle;
                 };
 
                 if !(_newWeaponMode isEqualTo GVAR(oldWeaponMode)) then {
-                    [QGVAR(weaponModeEvent), [_unit, _newWeaponMode, GVAR(oldWeaponMode)]] call CBA_fnc_localEvent;
+                    [QGVAR(weaponModeEvent), [_unit, _newWeaponMode select 2, GVAR(oldWeaponMode) select 2]] call CBA_fnc_localEvent;
                     GVAR(oldWeaponMode) = _newWeaponMode;
                 };
 

--- a/addons/events/fnc_addPlayerEventHandler.sqf
+++ b/addons/events/fnc_addPlayerEventHandler.sqf
@@ -45,7 +45,7 @@ params [["_type", "", [""]], ["_function", {}, [{}]], ["_applyRetroactively", fa
 _type = toLower _type;
 
 // Skip retroactive execution if no current unit.
-if (isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])) then {
+if (_applyRetroactively && {isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])}) then {
     _applyRetroactively = false;
 };
 

--- a/addons/events/fnc_addPlayerEventHandler.sqf
+++ b/addons/events/fnc_addPlayerEventHandler.sqf
@@ -45,7 +45,7 @@ params [["_type", "", [""]], ["_function", {}, [{}]], ["_applyRetroactively", fa
 _type = toLower _type;
 
 // Skip retroactive execution if no current unit.
-if (!isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])) then {
+if (isNull (missionNamespace getVariable [QGVAR(oldUnit), objNull])) then {
     _applyRetroactively = false;
 };
 

--- a/addons/events/fnc_addPlayerEventHandler.sqf
+++ b/addons/events/fnc_addPlayerEventHandler.sqf
@@ -161,7 +161,7 @@ if (_id != -1) then {
             private _controlledEntity = _unit;
             if (!isNull getConnectedUAV _unit) then {
                 private _uavControl = UAVControl getConnectedUAV _unit;
-                _uavControl = _uavControl param [(_uavControl find _unit) + 1, ""];
+                _uavControl = _uavControl param [(_uavControl find _unit) + 1, ""]; // will be position string if actively controlling, or object if not
                 if (_uavControl isEqualTo "DRIVER") exitWith {
                     _controlledEntity = driver getConnectedUAV _unit;
                 };

--- a/addons/events/fnc_addPlayerEventHandler.sqf
+++ b/addons/events/fnc_addPlayerEventHandler.sqf
@@ -199,27 +199,27 @@ if (_id != -1) then {
                 };
 
                 if !(_newGroup isEqualTo GVAR(oldGroup)) then {
-                    [QGVAR(groupEvent), [_unit, GVAR(oldGroup)]] call CBA_fnc_localEvent;
+                    [QGVAR(groupEvent), [_unit, GVAR(oldGroup), _newGroup]] call CBA_fnc_localEvent;
                     GVAR(oldGroup) = _newGroup;
                 };
 
                 if !(_newLeader isEqualTo GVAR(oldLeader)) then {
-                    [QGVAR(leaderEvent), [_unit, GVAR(oldLeader)]] call CBA_fnc_localEvent;
+                    [QGVAR(leaderEvent), [_unit, GVAR(oldLeader), _newLeader]] call CBA_fnc_localEvent;
                     GVAR(oldLeader) = _newLeader;
                 };
 
                 if !(_newWeapon isEqualTo GVAR(oldWeapon)) then {
-                    [QGVAR(weaponEvent), [_unit, _newWeapon]] call CBA_fnc_localEvent;
+                    [QGVAR(weaponEvent), [_unit, _newWeapon, GVAR(oldWeapon)]] call CBA_fnc_localEvent;
                     GVAR(oldWeapon) = _newWeapon;
                 };
 
                 if !(_newMuzzle isEqualTo GVAR(oldMuzzle)) then {
-                    [QGVAR(muzzleEvent), [_unit, _newMuzzle]] call CBA_fnc_localEvent;
+                    [QGVAR(muzzleEvent), [_unit, _newMuzzle, GVAR(oldMuzzle)]] call CBA_fnc_localEvent;
                     GVAR(oldMuzzle) = _newMuzzle;
                 };
 
                 if !(_newWeaponMode isEqualTo GVAR(oldWeaponMode)) then {
-                    [QGVAR(weaponModeEvent), [_unit, _newWeaponMode]] call CBA_fnc_localEvent;
+                    [QGVAR(weaponModeEvent), [_unit, _newWeaponMode, GVAR(oldWeaponMode)]] call CBA_fnc_localEvent;
                     GVAR(oldWeaponMode) = _newWeaponMode;
                 };
 
@@ -236,7 +236,7 @@ if (_id != -1) then {
                     } forEach [primaryWeaponMagazine _unit, secondaryWeaponMagazine _unit, handgunMagazine _unit];
 
                     if !(_newLoadoutNoAmmo isEqualTo GVAR(oldLoadoutNoAmmo)) then {
-                        [QGVAR(loadoutEvent), [_unit, GVAR(oldLoadout)]] call CBA_fnc_localEvent;
+                        [QGVAR(loadoutEvent), [_unit, GVAR(oldLoadout), _newLoadout]] call CBA_fnc_localEvent;
                         GVAR(oldLoadoutNoAmmo) = _newLoadoutNoAmmo;
                     };
 
@@ -244,22 +244,22 @@ if (_id != -1) then {
                 };
 
                 if !(_vehicle isEqualTo GVAR(oldVehicle)) then {
-                    [QGVAR(vehicleEvent), [_unit, _vehicle]] call CBA_fnc_localEvent;
+                    [QGVAR(vehicleEvent), [_unit, _vehicle, GVAR(oldVehicle)]] call CBA_fnc_localEvent;
                     GVAR(oldVehicle) = _vehicle;
                 };
 
                 if !(_turret isEqualTo GVAR(oldTurret)) then {
-                    [QGVAR(turretEvent), [_unit, _turret]] call CBA_fnc_localEvent;
+                    [QGVAR(turretEvent), [_unit, _turret, GVAR(oldTurret)]] call CBA_fnc_localEvent;
                     GVAR(oldTurret) = _turret;
                 };
 
                 if !(_newVisionMode isEqualTo GVAR(oldVisionMode)) then {
-                    [QGVAR(visionModeEvent), [_unit, _newVisionMode]] call CBA_fnc_localEvent;
+                    [QGVAR(visionModeEvent), [_unit, _newVisionMode, GVAR(oldVisionMode)]] call CBA_fnc_localEvent;
                     GVAR(oldVisionMode) = _newVisionMode;
                 };
 
                 if !(_newCameraView isEqualTo GVAR(oldCameraView)) then {
-                    [QGVAR(cameraViewEvent), [_unit, _newCameraView]] call CBA_fnc_localEvent;
+                    [QGVAR(cameraViewEvent), [_unit, _newCameraView, GVAR(oldCameraView)]] call CBA_fnc_localEvent;
                     GVAR(oldCameraView) = _newCameraView;
                 };
             };

--- a/addons/events/fnc_playerEvent.sqf
+++ b/addons/events/fnc_playerEvent.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 /* ----------------------------------------------------------------------------
-Function: CBA_fnc_playerEvent
+Function: CBA_events_fnc_playerEvent
 
 Description:
     Poll player event states and possibly raise events on state change.
@@ -13,7 +13,7 @@ Returns:
 
 Examples:
     (begin example)
-        call CBA_fnc_playerEvent;
+        call CBA_events_fnc_playerEvent;
     (end)
 
 Author:

--- a/addons/events/fnc_playerEvent.sqf
+++ b/addons/events/fnc_playerEvent.sqf
@@ -1,0 +1,137 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_playerEvent
+
+Description:
+    Poll player event states and possibly raise events on state change.
+
+Parameters:
+    None.
+
+Returns:
+    Nothing. (May return assignment.)
+
+Examples:
+    (begin example)
+        call CBA_fnc_playerEvent;
+    (end)
+
+Author:
+    commy2
+---------------------------------------------------------------------------- */
+SCRIPT(playerEvent);
+
+private _unit = missionNamespace getVariable ["bis_fnc_moduleRemoteControl_unit", player];
+private _vehicle = vehicle _unit;
+
+private _controlledEntity = _unit;
+if (!isNull getConnectedUAV _unit) then {
+    private _uavControl = UAVControl getConnectedUAV _unit;
+    _uavControl = _uavControl param [(_uavControl find _unit) + 1, ""]; // Will be position STRING if actively controlling, or OBJECT if not.
+    if (_uavControl isEqualTo "DRIVER") exitWith {
+        _controlledEntity = driver getConnectedUAV _unit;
+    };
+
+    if (_uavControl isEqualTo "GUNNER") exitWith {
+        _controlledEntity = gunner getConnectedUAV _unit;
+    };
+};
+
+private _turret = [];
+if (_unit != _vehicle) then {
+    _turret = allTurrets [_vehicle, true] select {_vehicle turretUnit _x == _unit} param [0, []];
+};
+
+private _state = [
+    _unit, group _unit, leader _unit,
+    currentWeapon _unit, currentMuzzle _unit, currentWeaponMode _unit,
+    getUnitLoadout _unit, _vehicle, _turret,
+    currentVisionMode _controlledEntity, cameraView
+];
+
+if !(_state isEqualTo GVAR(oldState)) then {
+    GVAR(oldState) = _state;
+
+    _state params [
+        "", "_newGroup", "_newLeader",
+        "_newWeapon", "_newMuzzle", "_newWeaponMode",
+        "_newLoadout", "", "",
+        "_newVisionMode", "_newCameraView"
+    ];
+
+    // These events should fire if the context of the state has changed.
+    // I.e. switching to a different weapon with "Single" fire mode is an implicit weapon mode switch.
+    // The modes just happen to share the same name.
+    _newMuzzle = [_unit, _newWeapon, _newMuzzle];
+    _newWeaponMode = [_unit, _newMuzzle, _newWeaponMode];
+
+    if !(_unit isEqualTo GVAR(oldUnit)) then {
+        [QGVAR(unitEvent), [_unit, GVAR(oldUnit)]] call CBA_fnc_localEvent;
+        GVAR(oldUnit) = _unit;
+    };
+
+    if !(_newGroup isEqualTo GVAR(oldGroup)) then {
+        [QGVAR(groupEvent), [_unit, GVAR(oldGroup), _newGroup]] call CBA_fnc_localEvent;
+        GVAR(oldGroup) = _newGroup;
+    };
+
+    if !(_newLeader isEqualTo GVAR(oldLeader)) then {
+        [QGVAR(leaderEvent), [_unit, GVAR(oldLeader), _newLeader]] call CBA_fnc_localEvent;
+        GVAR(oldLeader) = _newLeader;
+    };
+
+    if !(_newWeapon isEqualTo GVAR(oldWeapon)) then {
+        [QGVAR(weaponEvent), [_unit, _newWeapon, GVAR(oldWeapon)]] call CBA_fnc_localEvent;
+        GVAR(oldWeapon) = _newWeapon;
+    };
+
+    if !(_newMuzzle isEqualTo GVAR(oldMuzzle)) then {
+        [QGVAR(muzzleEvent), [_newMuzzle select 2, GVAR(oldMuzzle) select 2]] call CBA_fnc_localEvent;
+        GVAR(oldMuzzle) = _newMuzzle;
+    };
+
+    if !(_newWeaponMode isEqualTo GVAR(oldWeaponMode)) then {
+        [QGVAR(weaponModeEvent), [_unit, _newWeaponMode select 2, GVAR(oldWeaponMode) select 2]] call CBA_fnc_localEvent;
+        GVAR(oldWeaponMode) = _newWeaponMode;
+    };
+
+    if !(_newLoadout isEqualTo GVAR(oldLoadout)) then {
+        // We don't want to trigger this just because your ammo counter decreased.
+        private _newLoadoutNoAmmo = + _newLoadout;
+
+        {
+            private _weaponInfo = _newLoadoutNoAmmo param [_forEachIndex, []];
+            if !(_weaponInfo isEqualTo []) then {
+                _weaponInfo set [4, _x];
+                _weaponInfo deleteAt 5;
+            };
+        } forEach [primaryWeaponMagazine _unit, secondaryWeaponMagazine _unit, handgunMagazine _unit];
+
+        if !(_newLoadoutNoAmmo isEqualTo GVAR(oldLoadoutNoAmmo)) then {
+            [QGVAR(loadoutEvent), [_unit, GVAR(oldLoadout), _newLoadout]] call CBA_fnc_localEvent;
+            GVAR(oldLoadoutNoAmmo) = _newLoadoutNoAmmo;
+        };
+
+        GVAR(oldLoadout) = _newLoadout;
+    };
+
+    if !(_vehicle isEqualTo GVAR(oldVehicle)) then {
+        [QGVAR(vehicleEvent), [_unit, _vehicle, GVAR(oldVehicle)]] call CBA_fnc_localEvent;
+        GVAR(oldVehicle) = _vehicle;
+    };
+
+    if !(_turret isEqualTo GVAR(oldTurret)) then {
+        [QGVAR(turretEvent), [_unit, _turret, GVAR(oldTurret)]] call CBA_fnc_localEvent;
+        GVAR(oldTurret) = _turret;
+    };
+
+    if !(_newVisionMode isEqualTo GVAR(oldVisionMode)) then {
+        [QGVAR(visionModeEvent), [_unit, _newVisionMode, GVAR(oldVisionMode)]] call CBA_fnc_localEvent;
+        GVAR(oldVisionMode) = _newVisionMode;
+    };
+
+    if !(_newCameraView isEqualTo GVAR(oldCameraView)) then {
+        [QGVAR(cameraViewEvent), [_unit, _newCameraView, GVAR(oldCameraView)]] call CBA_fnc_localEvent;
+        GVAR(oldCameraView) = _newCameraView; // This assignment may be returned.
+    };
+};

--- a/addons/events/fnc_playerEvent.sqf
+++ b/addons/events/fnc_playerEvent.sqf
@@ -45,7 +45,7 @@ if (_unit != _vehicle) then {
 private _state = [
     _unit, group _unit, leader _unit,
     currentWeapon _unit, currentMuzzle _unit, currentWeaponMode _unit,
-    getUnitLoadout _unit, _vehicle, _turret,
+    getUnitLoadout _unit, _vehicle, _turret, _vehicle currentWeaponTurret _turret,
     currentVisionMode _controlledEntity, cameraView
 ];
 
@@ -55,7 +55,7 @@ if !(_state isEqualTo GVAR(oldState)) then {
     _state params [
         "", "_newGroup", "_newLeader",
         "_newWeapon", "_newMuzzle", "_newWeaponMode",
-        "_newLoadout", "", "",
+        "_newLoadout", "", "", "_newTurretWeapon",
         "_newVisionMode", "_newCameraView"
     ];
 
@@ -83,6 +83,11 @@ if !(_state isEqualTo GVAR(oldState)) then {
     if !(_newWeapon isEqualTo GVAR(oldWeapon)) then {
         [QGVAR(weaponEvent), [_unit, _newWeapon, GVAR(oldWeapon)]] call CBA_fnc_localEvent;
         GVAR(oldWeapon) = _newWeapon;
+    };
+
+    if !(_newTurretWeapon isEqualTo GVAR(oldTurretWeapon)) then {
+        [QGVAR(turretWeaponEvent), [_unit, _newTurretWeapon, GVAR(oldTurretWeapon)]] call CBA_fnc_localEvent;
+        GVAR(oldTurretWeapon) = _newTurretWeapon;
     };
 
     if !(_newMuzzle isEqualTo GVAR(oldMuzzle)) then {

--- a/addons/events/fnc_removePlayerEventHandler.sqf
+++ b/addons/events/fnc_removePlayerEventHandler.sqf
@@ -33,7 +33,7 @@ switch (_type) do {
     case "weapon": {
         [QGVAR(weaponEvent), _id] call CBA_fnc_removeEventHandler;
     };
-    case "weapon": {
+    case "turretweapon": {
         [QGVAR(turretWeaponEvent), _id] call CBA_fnc_removeEventHandler;
     };
     case "muzzle": {

--- a/addons/events/fnc_removePlayerEventHandler.sqf
+++ b/addons/events/fnc_removePlayerEventHandler.sqf
@@ -33,6 +33,9 @@ switch (_type) do {
     case "weapon": {
         [QGVAR(weaponEvent), _id] call CBA_fnc_removeEventHandler;
     };
+    case "weapon": {
+        [QGVAR(turretWeaponEvent), _id] call CBA_fnc_removeEventHandler;
+    };
     case "muzzle": {
         [QGVAR(muzzleEvent), _id] call CBA_fnc_removeEventHandler;
     };

--- a/addons/events/fnc_removePlayerEventHandler.sqf
+++ b/addons/events/fnc_removePlayerEventHandler.sqf
@@ -33,6 +33,12 @@ switch (_type) do {
     case "weapon": {
         [QGVAR(weaponEvent), _id] call CBA_fnc_removeEventHandler;
     };
+    case "muzzle": {
+        [QGVAR(muzzleEvent), _id] call CBA_fnc_removeEventHandler;
+    };
+    case "weaponmode": {
+        [QGVAR(weaponModeEvent), _id] call CBA_fnc_removeEventHandler;
+    };
     case "loadout": {
         [QGVAR(loadoutEvent), _id] call CBA_fnc_removeEventHandler;
     };


### PR DESCRIPTION
**When merged this pull request will:**
- A single state check to exit all frames without change immediately / replace all the assignments with a single params
- `muzzle`, `weaponMode` and `turretWeapon` player events
- [x] pass old/new state as argument as well
