### PR TITLE
Settings - Add support for percentage sliders

### DIFF
--- a/addons/settings/XEH_preInit.sqf
+++ b/addons/settings/XEH_preInit.sqf
@@ -24,6 +24,7 @@ if (isNil QFUNC(init)) then {
     ["Test_Setting_4", "COLOR",    ["-test color-",    "-tooltip-"], "My Category", [1, 1 ,0], false, {diag_log text format ["Color Setting Changed: %1", _this];}] call CBA_fnc_addSetting;
     ["Test_Setting_5", "COLOR",    ["-test alpha-",    "-tooltip-"], "My Category", [1, 0, 0, 0.5], false] call CBA_fnc_addSetting;
     ["Test_Setting_6", "TIME",     ["-test time-",     "-tooltip-"], "My Category", [0, 3600, 60], false] call CBA_fnc_addSetting;
+    ["Test_Setting_7", "SLIDER",   ["-test slider (percentage)- ",   "-tooltip-"], "My Category", [0, 1, 0.5, 0, true]] call CBA_fnc_addSetting;
     ["Test_Padding", "LIST", "Padding test", "My Category", [[0,1,2,3,4,5,6,7,8,9,10], []]] call CBA_fnc_addSetting;
 
     ["Test_1", "EDITBOX", "setting 1", "Test Category", "null", nil, {systemChat str [1, _this]}] call CBA_fnc_addSetting;

--- a/addons/settings/fnc_addSetting.sqf
+++ b/addons/settings/fnc_addSetting.sqf
@@ -28,7 +28,7 @@ Examples:
         // LIST --- extra arguments: [_values, _valueTitles, _defaultIndex]
         ["Test_Setting_2", "LIST",     ["-test list-",     "-tooltip-"], "My Category", [[1, 0], ["enabled","disabled"], 1]] call CBA_fnc_addSetting;
 
-        // SLIDER --- extra arguments: [_min, _max, _default, _trailingDecimals]
+        // SLIDER --- extra arguments: [_min, _max, _default, _trailingDecimals, _isPercentage]
         ["Test_Setting_3", "SLIDER",   ["-test slider-",   "-tooltip-"], "My Category", [0, 10, 5, 0]] call CBA_fnc_addSetting;
 
         // COLOR PICKER --- extra argument: _color

--- a/addons/settings/fnc_gui_settingSlider.sqf
+++ b/addons/settings/fnc_gui_settingSlider.sqf
@@ -1,27 +1,33 @@
 #include "script_component.hpp"
 
 params ["_controlsGroup", "_setting", "_source", "_currentValue", "_settingData"];
-_settingData params ["_min", "_max", "_trailingDecimals"];
+_settingData params ["_min", "_max", "_trailingDecimals", "_isPercentage"];
+
+private _range = _max - _min;
 
 private _ctrlSlider = _controlsGroup controlsGroupCtrl IDC_SETTING_SLIDER;
-
 _ctrlSlider sliderSetRange [_min, _max];
 _ctrlSlider sliderSetPosition _currentValue;
-private _range = _max - _min;
 _ctrlSlider sliderSetSpeed [0.05 * _range, 0.1 * _range];
 
-_ctrlSlider setVariable [QGVAR(params), [_setting, _source, _trailingDecimals]];
+_ctrlSlider setVariable [QGVAR(params), [_setting, _source, _trailingDecimals, _isPercentage]];
 _ctrlSlider ctrlAddEventHandler ["SliderPosChanged", {
     params ["_ctrlSlider", "_value"];
-    (_ctrlSlider getVariable QGVAR(params)) params ["_setting", "_source", "_trailingDecimals"];
+    (_ctrlSlider getVariable QGVAR(params)) params ["_setting", "_source", "_trailingDecimals", "_isPercentage"];
 
-    if (_trailingDecimals < 0) then {
-        _value = round _value;
+    private _editText = if (_isPercentage) then {
+        format [localize "STR_3DEN_percentageUnit", round (_value * 100), "%"]
+    } else {
+        if (_trailingDecimals < 0) then {
+            _value = round _value;
+        };
+
+        [_value, 1, _trailingDecimals max 0] call CBA_fnc_formatNumber
     };
 
     private _controlsGroup = ctrlParentControlsGroup _ctrlSlider;
     private _ctrlSliderEdit = _controlsGroup controlsGroupCtrl IDC_SETTING_SLIDER_EDIT;
-    _ctrlSliderEdit ctrlSetText ([_value, 1, _trailingDecimals max 0] call CBA_fnc_formatNumber);
+    _ctrlSliderEdit ctrlSetText _editText;
 
     SET_TEMP_NAMESPACE_VALUE(_setting,_value,_source);
 
@@ -34,18 +40,28 @@ _ctrlSlider ctrlAddEventHandler ["SliderPosChanged", {
     [_controlsGroup, _source] call (_controlsGroup getVariable QFUNC(auto_check_overwrite));
 }];
 
-private _ctrlSliderEdit = _controlsGroup controlsGroupCtrl IDC_SETTING_SLIDER_EDIT;
-_ctrlSliderEdit ctrlSetText ([_currentValue, 1, _trailingDecimals max 0] call CBA_fnc_formatNumber);
+private _editText = if (_isPercentage) then {
+    format [localize "STR_3DEN_percentageUnit", round (_currentValue * 100), "%"]
+} else {
+    [_currentValue, 1, _trailingDecimals max 0] call CBA_fnc_formatNumber
+};
 
-_ctrlSliderEdit setVariable [QGVAR(params), [_setting, _source, _trailingDecimals]];
+private _ctrlSliderEdit = _controlsGroup controlsGroupCtrl IDC_SETTING_SLIDER_EDIT;
+_ctrlSliderEdit ctrlSetText _editText;
+
+_ctrlSliderEdit setVariable [QGVAR(params), [_setting, _source, _trailingDecimals, _isPercentage]];
 _ctrlSliderEdit ctrlAddEventHandler ["KeyUp", {
     params ["_ctrlSliderEdit"];
-    (_ctrlSliderEdit getVariable QGVAR(params)) params ["_setting", "_source", "_trailingDecimals"];
+    (_ctrlSliderEdit getVariable QGVAR(params)) params ["_setting", "_source", "_trailingDecimals", "_isPercentage"];
 
     private _value = parseNumber ctrlText _ctrlSliderEdit;
 
-    if (_trailingDecimals < 0) then {
-        _value = round _value;
+    if (_isPercentage) then {
+        _value = _value / 100;
+    } else {
+        if (_trailingDecimals < 0) then {
+            _value = round _value;
+        };
     };
 
     private _controlsGroup = ctrlParentControlsGroup _ctrlSliderEdit;
@@ -67,18 +83,24 @@ _ctrlSliderEdit ctrlAddEventHandler ["KeyUp", {
 
 _ctrlSliderEdit ctrlAddEventHandler ["KillFocus", {
     params ["_ctrlSliderEdit"];
-    (_ctrlSliderEdit getVariable QGVAR(params)) params ["_setting", "_source", "_trailingDecimals"];
+    (_ctrlSliderEdit getVariable QGVAR(params)) params ["_setting", "_source", "_trailingDecimals", "_isPercentage"];
 
     private _controlsGroup = ctrlParentControlsGroup _ctrlSliderEdit;
     private _ctrlSlider = _controlsGroup controlsGroupCtrl IDC_SETTING_SLIDER;
 
     private _value = sliderPosition _ctrlSlider;
 
-    if (_trailingDecimals < 0) then {
-        _value = round _value;
+    private _editText = if (_isPercentage) then {
+        format [localize "STR_3DEN_percentageUnit", round (_value * 100), "%"]
+    } else {
+        if (_trailingDecimals < 0) then {
+            _value = round _value;
+        };
+
+        [_value, 1, _trailingDecimals max 0] call CBA_fnc_formatNumber
     };
 
-    _ctrlSliderEdit ctrlSetText ([_value, 1, _trailingDecimals max 0] call CBA_fnc_formatNumber);
+    _ctrlSliderEdit ctrlSetText _editText;
 
     // if new value is same as default value, grey out the default button
     private _ctrlDefault = _controlsGroup controlsGroupCtrl IDC_SETTING_DEFAULT;
@@ -89,13 +111,20 @@ _ctrlSliderEdit ctrlAddEventHandler ["KillFocus", {
 // set setting ui manually to new value
 _controlsGroup setVariable [QFUNC(updateUI), {
     params ["_controlsGroup", "_value"];
-    (_controlsGroup getVariable QGVAR(params)) params ["_min", "_max", "_trailingDecimals"];
+    (_controlsGroup getVariable QGVAR(params)) params ["_min", "_max", "_trailingDecimals", "_isPercentage"];
 
     private _ctrlSlider = _controlsGroup controlsGroupCtrl IDC_SETTING_SLIDER;
     private _ctrlSliderEdit = _controlsGroup controlsGroupCtrl IDC_SETTING_SLIDER_EDIT;
 
     _ctrlSlider sliderSetPosition _value;
-    _ctrlSliderEdit ctrlSetText ([_value, 1, _trailingDecimals max 0] call CBA_fnc_formatNumber);
+
+    private _editText = if (_isPercentage) then {
+        format [localize "STR_3DEN_percentageUnit", round (_value * 100), "%"]
+    } else {
+        [_value, 1, _trailingDecimals max 0] call CBA_fnc_formatNumber
+    };
+
+    _ctrlSliderEdit ctrlSetText _editText;
 
     // if new value is same as default value, grey out the default button
     private _ctrlDefault = _controlsGroup controlsGroupCtrl IDC_SETTING_DEFAULT;

--- a/addons/settings/fnc_init.sqf
+++ b/addons/settings/fnc_init.sqf
@@ -28,7 +28,7 @@ Examples:
         // LIST --- extra arguments: [_values, _valueTitles, _defaultIndex]
         ["Test_Setting_2", "LIST",     ["-test list-",     "-tooltip-"], "My Category", [[1, 0], ["enabled","disabled"], 1]] call cba_settings_fnc_init;
 
-        // SLIDER --- extra arguments: [_min, _max, _default, _trailingDecimals]
+        // SLIDER --- extra arguments: [_min, _max, _default, _trailingDecimals, _isPercentage]
         ["Test_Setting_3", "SLIDER",   ["-test slider-",   "-tooltip-"], "My Category", [0, 10, 5, 0]] call cba_settings_fnc_init;
 
         // COLOR PICKER --- extra argument: _color
@@ -133,10 +133,10 @@ switch (toUpper _settingType) do {
         _settingData append [_values, _labels, _tooltips];
     };
     case "SLIDER": {
-        _valueInfo params [["_min", 0, [0]], ["_max", 1, [0]], ["_default", 0, [0]], ["_trailingDecimals", 2, [0]]];
+        _valueInfo params [["_min", 0, [0]], ["_max", 1, [0]], ["_default", 0, [0]], ["_trailingDecimals", 2, [0]], ["_isPercentage", false, [false]]];
 
         _defaultValue = _default;
-        _settingData append [_min, _max, _trailingDecimals];
+        _settingData append [_min, _max, _trailingDecimals, _isPercentage];
     };
     case "COLOR": {
         _defaultValue = [_valueInfo] param [0, [1, 1, 1], [[]], [3, 4]];

--- a/addons/settings/gui.hpp
+++ b/addons/settings/gui.hpp
@@ -247,14 +247,14 @@ class GVAR(Row_Base): RscControlsGroupNoScrollbars {
             idc = IDC_SETTING_DEFAULT;
             style = ST_PICTURE;
             text = ICON_DEFAULT;
-            x = POS_W(26.5);
+            x = POS_W(27);
             y = POS_H(0) + TABLE_LINE_SPACING/2;
             w = POS_W(1);
             h = POS_H(1);
         };
         class Locked: RscPicture {
             idc = IDC_SETTING_LOCKED;
-            x = POS_W(28);
+            x = POS_W(28.5);
             y = POS_H(0) + TABLE_LINE_SPACING/2;
             w = POS_W(1);
             h = POS_H(1);
@@ -303,7 +303,7 @@ class GVAR(Row_Editbox): GVAR(Row_Base) {
             idc = IDC_SETTING_EDITBOX;
             x = POS_W(16);
             y = POS_H(0) + TABLE_LINE_SPACING/2;
-            w = POS_W(10);
+            w = POS_W(10.5);
             h = POS_H(1);
         };
         class Default: Default {};
@@ -322,7 +322,7 @@ class GVAR(Row_List): GVAR(Row_Base) {
             idc = IDC_SETTING_LIST;
             x = POS_W(16);
             y = POS_H(0) + TABLE_LINE_SPACING/2;
-            w = POS_W(10);
+            w = POS_W(10.5);
             h = POS_H(1);
         };
         class Default: Default {};
@@ -343,14 +343,14 @@ class GVAR(Row_Slider): GVAR(Row_Base) {
             idc = IDC_SETTING_SLIDER;
             x = POS_W(16);
             y = POS_H(0) + TABLE_LINE_SPACING/2;
-            w = POS_W(7.9);
+            w = POS_W(8.2);
             h = POS_H(1);
         };
         class Edit: RscEdit {
             idc = IDC_SETTING_SLIDER_EDIT;
-            x = POS_W(24);
+            x = POS_W(24.3);
             y = POS_H(0) + TABLE_LINE_SPACING/2;
-            w = POS_W(2);
+            w = POS_W(2.2);
             h = POS_H(1);
         };
         class Default: Default {};
@@ -382,14 +382,14 @@ class GVAR(Row_Color): GVAR(Row_Base) {
             colorDisable[] = {1,0,0,0.4};
             x = POS_W(16);
             y = POS_H(0) + TABLE_LINE_SPACING/2;
-            w = POS_W(7.9);
+            w = POS_W(8.2);
             h = POS_H(1);
         };
         class Red_Edit: RscEdit {
             idc = IDC_SETTING_COLOR_RED_EDIT;
-            x = POS_W(24);
+            x = POS_W(24.3);
             y = POS_H(0) + TABLE_LINE_SPACING/2;
-            w = POS_W(2);
+            w = POS_W(2.2);
             h = POS_H(1);
         };
         class Green: Red {
@@ -449,14 +449,14 @@ class GVAR(Row_ColorAlpha): GVAR(Row_Color) {
             idc = IDC_SETTING_COLOR_ALPHA;
             x = POS_W(16);
             y = POS_H(3) + TABLE_LINE_SPACING/2;
-            w = POS_W(7.9);
+            w = POS_W(8.2);
             h = POS_H(1);
         };
         class Alpha_Edit: RscEdit {
             idc = IDC_SETTING_COLOR_ALPHA_EDIT;
-            x = POS_W(24);
+            x = POS_W(24.3);
             y = POS_H(3) + TABLE_LINE_SPACING/2;
-            w = POS_W(2);
+            w = POS_W(2.2);
             h = POS_H(1);
         };
         class Default: Default {
@@ -488,11 +488,11 @@ class GVAR(Row_Time): GVAR(Row_Base) {
             idc = IDC_SETTING_TIME_SLIDER;
             x = POS_W(16);
             y = POS_H(0) + TABLE_LINE_SPACING / 2;
-            w = POS_W(10);
+            w = POS_W(10.5);
             h = POS_H(1);
         };
         class Frame: RscFrame {
-            x = POS_W(18);
+            x = POS_W(18.25);
             y = POS_H(1.1) + TABLE_LINE_SPACING / 2;
             w = POS_W(6);
             h = POS_H(0.9);
@@ -501,7 +501,7 @@ class GVAR(Row_Time): GVAR(Row_Base) {
             style = ST_CENTER;
             text = ":   :";
             font = "EtelkaMonospaceProBold";
-            x = POS_W(18);
+            x = POS_W(18.25);
             y = POS_H(1.1) + TABLE_LINE_SPACING / 2;
             w = POS_W(6);
             h = POS_H(0.9);
@@ -513,7 +513,7 @@ class GVAR(Row_Time): GVAR(Row_Base) {
             style = ST_CENTER + ST_NO_RECT;
             tooltip = "$STR_3DEN_Attributes_SliderTime_Hour_tooltip";
             font = "EtelkaMonospaceProBold";
-            x = POS_W(18);
+            x = POS_W(18.25);
             y = POS_H(1.1) + TABLE_LINE_SPACING / 2;
             w = POS_W(2);
             h = POS_H(0.9);
@@ -523,12 +523,12 @@ class GVAR(Row_Time): GVAR(Row_Base) {
         class Minutes: Hours {
             idc = IDC_SETTING_TIME_MINUTES;
             tooltip = "$STR_3DEN_Attributes_SliderTime_Minute_tooltip";
-            x = POS_W(20);
+            x = POS_W(20.25);
         };
         class Seconds: Hours {
             idc = IDC_SETTING_TIME_SECONDS;
             tooltip = "$STR_3DEN_Attributes_SliderTime_Second_tooltip";
-            x = POS_W(22);
+            x = POS_W(22.25);
         };
         class Default: Default {
             y = POS_H(0.5) + TABLE_LINE_SPACING / 2;

--- a/addons/settings/gui_createCategory.sqf
+++ b/addons/settings/gui_createCategory.sqf
@@ -137,8 +137,19 @@ private _lastSubCategory = "$START";
         private _defaultValueToolTip = switch (toUpper _settingType) do {
             case "LIST": {
                 private _label = (_settingData param [1, []]) param [_defaultValue, ""];
-                if (isLocalized _label) then { _label = localize _label; };
+
+                if (isLocalized _label) then {
+                    _label = localize _label;
+                };
+
                 _label
+            };
+            case "SLIDER": {
+                if (_settingData param [3, false]) then {
+                    format [localize "STR_3DEN_percentageUnit", round (_defaultValue * 100), "%"]
+                } else {
+                    _defaultValue
+                };
             };
             case "COLOR": {
                 private _template = (["R: %1","%G: %2", "B: %3", "A: %4"] select [0, count _defaultValue]) joinString "\n";
@@ -151,7 +162,8 @@ private _lastSubCategory = "$START";
         };
 
         // ----- set tooltip on "Reset to default" button
-        (_ctrlSettingGroup controlsGroupCtrl IDC_SETTING_DEFAULT) ctrlSetTooltip (format ["%1\n%2", localize LSTRING(default_tooltip), _defaultValueToolTip]);
+        private _ctrlDefault = _ctrlSettingGroup controlsGroupCtrl IDC_SETTING_DEFAULT;
+        _ctrlDefault ctrlSetTooltip (format ["%1\n%2", localize LSTRING(default_tooltip), _defaultValueToolTip]);
 
         _ctrlSettingGroup setVariable [QGVAR(setting), _setting];
         _ctrlSettingGroup setVariable [QGVAR(source), _source];


### PR DESCRIPTION
**When merged this pull request will:**
- Allow sliders to be specified as "percentage sliders"
    - For example, if the range is 0 to 1, displayed value will be formatted to 0 to 100 and have a percent sign - users will also input edit box values between 0 and 100
- Increase width of controls to allow for all of "100%" to fit in the edit box