### PR TITLE
fix missing default value for cba_optics_OpticBodyTextureSize

### DIFF
--- a/addons/optics/XEH_preInit.sqf
+++ b/addons/optics/XEH_preInit.sqf
@@ -23,6 +23,7 @@ GVAR(camera) = objNull;
 GVAR(currentOptic) = "";
 GVAR(IsUsingOptic) = false;
 GVAR(magnificationCache) = -1;
+GVAR(OpticBodyTextureSize) = 0;
 GVAR(ReticleAdjust) = [1,1,nil,1,1];
 GVAR(HideRedDotMagnification) = 1e+11;
 GVAR(FadeReticleInterval) = [0,0,nil,0,0];


### PR DESCRIPTION
**When merged this pull request will:**
- title
- It's a race condition in restarted hosted games.
- fix  #1297
