### PR TITLE
createPerFrameHandlerObject - remove pfeh if location deleted

### DIFF
--- a/addons/common/fnc_createPerFrameHandlerObject.sqf
+++ b/addons/common/fnc_createPerFrameHandlerObject.sqf
@@ -102,7 +102,7 @@ private _handle = [{
     params ["_logic"];
 
     if (isNil "_logic" || {isNull _logic}) exitWith {
-        (_logic getVariable "handle") call CBA_fnc_removePerFrameHandler;
+        [_this # 1] call CBA_fnc_removePerFrameHandler;
     };
 
     // deserialize

--- a/addons/common/fnc_createPerFrameHandlerObject.sqf
+++ b/addons/common/fnc_createPerFrameHandlerObject.sqf
@@ -102,7 +102,7 @@ private _handle = [{
     params ["_logic"];
 
     if (isNil "_logic" || {isNull _logic}) exitWith {
-        [_this # 1] call CBA_fnc_removePerFrameHandler;
+        (_this select 1) call CBA_fnc_removePerFrameHandler;
     };
 
     // deserialize


### PR DESCRIPTION
If location doesn't exist, then you won't get a valid getVar from it

```
x = [{systemChat str time}, 1] call CBA_fnc_createPerFrameHandlerObject
```
```
deleteLocation x
```


`count cba_common_perFrameHandlerArray` does not decrease

Edit: This would be a rare bug, `CBA_fnc_deletePerFrameHandlerObject` was safe