### PR TITLE
Fix CBA_fnc_formatNumber for small negative numbers

### DIFF
--- a/addons/strings/fnc_formatNumber.sqf
+++ b/addons/strings/fnc_formatNumber.sqf
@@ -86,6 +86,9 @@ if (_separateThousands) then { // add localized thousands seperator "1,000"
     };
 };
 
-if (_isNegative) then {_return = "-" + _return;}; // re-add negative sign
+// re-add negative sign if there is at least one decimal place != 0.
+if (_isNegative && {!(toArray _return arrayIntersect toArray "123456789" isEqualTo [])}) then {
+    _return = "-" + _return;
+};
 
 _return

--- a/addons/strings/fnc_formatNumber.sqf
+++ b/addons/strings/fnc_formatNumber.sqf
@@ -86,7 +86,7 @@ if (_separateThousands) then { // add localized thousands seperator "1,000"
     };
 };
 
-// re-add negative sign if there is at least one decimal place != 0.
+// Re-add negative sign if there is at least one decimal place != 0.
 if (_isNegative && {!(toArray _return arrayIntersect toArray "123456789" isEqualTo [])}) then {
     _return = "-" + _return;
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Before:
```sqf
[-0.001, 1, 2] call CBA_fnc_formatNumber // "-0.00"
```
- After:
```sqf
[-0.001, 1, 2] call CBA_fnc_formatNumber // "0.00"
```
Doesn't make sense to have it report a negative number if all decimal places are zeros.