### PR TITLE
Events - Player events will report driver seat as turret [-1]

### DIFF
--- a/addons/events/fnc_addPlayerEventHandler.sqf
+++ b/addons/events/fnc_addPlayerEventHandler.sqf
@@ -65,7 +65,7 @@ private _id = switch (_type) do {
     };
     case "turretweapon": {
         if (_applyRetroactively) then {
-            [GVAR(oldUnit), GVAR(oldUnit) currentWeaponTurret (GVAR(oldUnit) call CBA_fnc_turretPath), ""] call _function;
+            [GVAR(oldUnit), GVAR(oldTurretWeapon), ""] call _function;
         };
         [QGVAR(turretWeaponEvent), _function] call CBA_fnc_addEventHandler // return id
     };
@@ -95,7 +95,7 @@ private _id = switch (_type) do {
     };
     case "turret": {
         if (_applyRetroactively) then {
-            [GVAR(oldUnit), GVAR(oldUnit) call CBA_fnc_turretPath, []] call _function;
+            [GVAR(oldUnit), GVAR(oldTurret), []] call _function;
         };
         [QGVAR(turretEvent), _function] call CBA_fnc_addEventHandler // return id
     };

--- a/addons/events/fnc_addPlayerEventHandler.sqf
+++ b/addons/events/fnc_addPlayerEventHandler.sqf
@@ -65,7 +65,12 @@ private _id = switch (_type) do {
     };
     case "turretweapon": {
         if (_applyRetroactively) then {
-            [GVAR(oldUnit), GVAR(oldTurretWeapon), ""] call _function;
+            private _vehicle = vehicle GVAR(oldUnit);
+            private _turret = [];
+            if (GVAR(oldUnit) != _vehicle) then {
+                _turret = ([[-1]] + allTurrets [_vehicle, true]) select {_vehicle turretUnit _x == GVAR(oldUnit)} param [0, []];
+            };
+            [GVAR(oldUnit), _vehicle currentWeaponTurret _turret, ""] call _function;
         };
         [QGVAR(turretWeaponEvent), _function] call CBA_fnc_addEventHandler // return id
     };
@@ -95,7 +100,12 @@ private _id = switch (_type) do {
     };
     case "turret": {
         if (_applyRetroactively) then {
-            [GVAR(oldUnit), GVAR(oldTurret), []] call _function;
+            private _vehicle = vehicle GVAR(oldUnit);
+            private _turret = [];
+            if (GVAR(oldUnit) != _vehicle) then {
+                _turret = ([[-1]] + allTurrets [_vehicle, true]) select {_vehicle turretUnit _x == GVAR(oldUnit)} param [0, []];
+            };
+            [GVAR(oldUnit), _turret, []] call _function;
         };
         [QGVAR(turretEvent), _function] call CBA_fnc_addEventHandler // return id
     };

--- a/addons/events/fnc_playerEvent.sqf
+++ b/addons/events/fnc_playerEvent.sqf
@@ -39,7 +39,8 @@ if (!isNull getConnectedUAV _unit) then {
 
 private _turret = [];
 if (_unit != _vehicle) then {
-    _turret = allTurrets [_vehicle, true] select {_vehicle turretUnit _x == _unit} param [0, []];
+    // Unlike CBA_fnc_turretPath, this will return [-1] when player is driver
+    _turret = ([[-1]] + allTurrets [_vehicle, true]) select {_vehicle turretUnit _x == _unit} param [0, []];
 };
 
 private _state = [


### PR DESCRIPTION
Replace #1312 
Reports driver/pilot as turret `[-1]`
This is mainly so it will also report pilot's weapon on "turretweapon" event

e.g. `["turretweapon", {x1 = +_this}, true] call CBA_fnc_addPlayerEventHandler;`
for AH-6 Littlebird will report `[player, "M134_minigun","missiles_DAR"]`

**This could cause problems for code that is not expecting driver's seat turret**
And many cars will report a weapon like `"TruckHorn2"` which might not be expected