### PR TITLE
Fix for CBA_fnc_isMusicPlaying not handling music stop properly

### DIFF
--- a/addons/music/CfgEventHandlers.hpp
+++ b/addons/music/CfgEventHandlers.hpp
@@ -1,0 +1,5 @@
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};

--- a/addons/music/XEH_PREP.sqf
+++ b/addons/music/XEH_PREP.sqf
@@ -1,0 +1,1 @@
+PREP(initMusicHandler);

--- a/addons/music/XEH_preInit.sqf
+++ b/addons/music/XEH_preInit.sqf
@@ -1,0 +1,5 @@
+#include "script_component.hpp"
+
+#include "XEH_PREP.sqf"
+
+[] call FUNC(initMusicHandler)

--- a/addons/music/config.cpp
+++ b/addons/music/config.cpp
@@ -14,5 +14,6 @@ class CfgPatches {
     };
 };
 
+#include "CfgEventHandlers.hpp"
 #include "CfgFunctions.hpp"
 #include "CfgMusic.hpp"

--- a/addons/music/fnc_getMusicPlaying.sqf
+++ b/addons/music/fnc_getMusicPlaying.sqf
@@ -20,18 +20,11 @@ Author:
     Fishy, Dedmen
 ---------------------------------------------------------------------------- */
 
-if (isNil QGVAR(track)) exitWith {["", 0, 0]};
+if !(call CBA_fnc_isMusicPlaying) exitWith {["", 0, 0]};
 
 GVAR(track) params ["_class", "_startTime", "_playPos", "_duration"];
 
-private _trackTime = (CBA_missionTime - _startTime) + _playPos;
+private _trackTime = getMusicPlayedTime;
 private _remainingTime = _duration - _trackTime;
-
-if (_remainingTime <= 0) then {
-    _remainingTime = 0;
-    _trackTime = 0;
-    _class = "";
-    GVAR(track) = nil;
-};
 
 [_class, _trackTime, _remainingTime]

--- a/addons/music/fnc_getMusicPlaying.sqf
+++ b/addons/music/fnc_getMusicPlaying.sqf
@@ -26,5 +26,6 @@ GVAR(track) params ["_class", "_startTime", "_playPos", "_duration"];
 
 private _trackTime = getMusicPlayedTime;
 private _remainingTime = _duration - _trackTime;
+_remainingTime = _remainingTime max 0;
 
 [_class, _trackTime, _remainingTime]

--- a/addons/music/fnc_initMusicHandler.sqf
+++ b/addons/music/fnc_initMusicHandler.sqf
@@ -1,0 +1,16 @@
+#include "script_component.hpp"
+
+addMusicEventHandler ["MusicStart", {
+    params ["_className", "_eventId"];
+
+    private _startTime = getMusicPlayedTime;
+    private _duration = [_className, "duration"] call CBA_fnc_getMusicData;
+
+    GVAR(track) = [_className, CBA_missionTime, _startTime, _duration];
+}];
+
+addMusicEventHandler ["MusicStop", {
+    params ["_className", "_eventId"];
+
+    GVAR(track) = nil;
+}];

--- a/addons/music/fnc_isMusicPlaying.sqf
+++ b/addons/music/fnc_isMusicPlaying.sqf
@@ -20,4 +20,19 @@ Author:
     Dedmen, Commy2, Fishy
 ---------------------------------------------------------------------------- */
 
-!isNil QGVAR(track)
+#define MINIMUM_WAIT 0.1
+
+if (isNil QGVAR(track)) exitWith {false};
+
+GVAR(track) params ["_className", "_startTime", "_playPos", "_duration"];
+
+private _return = true;
+
+// Check if theres a track playing, since `playMusic ""` doesn't trigger an event
+private _trackTime = getMusicPlayedTime;
+if (CBA_missionTime > (_startTime + MINIMUM_WAIT) && {_trackTime == 0}) then {
+    GVAR(track) = nil;
+    _return = false;
+};
+
+_return

--- a/addons/music/fnc_playMusic.sqf
+++ b/addons/music/fnc_playMusic.sqf
@@ -37,7 +37,6 @@ private _duration = [_className, "duration"] call CBA_fnc_getMusicData;
 if (!isNil "_duration") then {
     if (_time < _duration) then {
         playMusic [_className, _time];
-        GVAR(track) = [_className, CBA_missionTime, _time, _duration];
         _return = true;
     } else {
         WARNING("Time is greater than song length");


### PR DESCRIPTION
As you might know the CBA Music module isn't useful in its current state. This is because the function `CBA_fnc_isMusicPlaying` is unable to detect when a song ended and cant handle music that was started without calling `CBA_fnc_playMusic`.

This pull request fixes most of these issues by utilizing the vanilla music event handlers, however this leave's one special case. That being `playMusic ""` since that doesn't trigger any of the currently present music events, this issue is fixed by incorporating an extra check in `CBA_fnc_isMusicPlaying`.

When merged this pull request will:
- Fix `CBA_fnc_isMusicPlaying` incorrect return value ([#1241](https://github.com/CBATeam/CBA_A3/issues/1241), [#1024](https://github.com/CBATeam/CBA_A3/issues/1024))
- Make `CBA_fnc_getMusicPlaying` use `CBA_fnc_isMusicPlaying` instead of a `isNil` check
- Improve the accuracy of the `_trackTime` value returned from `CBA_fnc_getMusicPlaying`