### PR TITLE
Tools - Fix HEMTT version set and set version in README.md

### DIFF
--- a/hemtt.toml
+++ b/hemtt.toml
@@ -15,7 +15,7 @@ modname = "{{name}}"
 key_name = "{{prefix}}_{{version}}"
 authority = "{{prefix}}_{{version}}-{{git \"id 8\"}}"
 
-prebuild = [
+check = [
     "!version_set"
 ]
 releasebuild = [
@@ -28,13 +28,13 @@ version = "{{git \"id 8\"}}"
 
 [scripts.version_set]
 steps_linux = [
-    "echo 'Setting version'",
-    "sed -i -r -s 's/[0-9]+\\.[0-9]+\\.[0-9]+/{{semver.major}}.{{semver.minor}}.{{semver.patch}}/g' mod.cpp addons/main_a3/CfgMods.hpp",
+    "echo Setting version",
+    "sed -i -r -s 's/[0-9]+\\.[0-9]+\\.[0-9]+/{{semver.major}}.{{semver.minor}}.{{semver.patch}}/g' mod.cpp README.md addons/main_a3/CfgMods.hpp",
     "sed -i -r -s 's/#define BUILD 000000/#define BUILD {{date \"%y%m%d\"}}/g' addons/main/script_version.hpp"
 ]
 steps_windows = [
-    "echo 'Setting version'",
-    "powershell -Command foreach ($f in 'mod.cpp', 'addons/main_a3/CfgMods.hpp') {(Get-Content $f) -replace '[0-9]+\\.[0-9]+\\.[0-9]+', '{{semver.major}}.{{semver.minor}}.{{semver.patch}}' -join \"`n\" ^| Set-Content -NoNewline $f; Add-Content -NoNewline \"`n\" $f}",
+    "echo Setting version",
+    "powershell -Command foreach ($f in 'mod.cpp', 'README.md', 'addons/main_a3/CfgMods.hpp') {(Get-Content $f) -replace '[0-9]+\\.[0-9]+\\.[0-9]+', '{{semver.major}}.{{semver.minor}}.{{semver.patch}}' -join \"`n\" ^| Set-Content -NoNewline $f; Add-Content -NoNewline \"`n\" $f}",
     "powershell -Command foreach ($f in 'addons/main/script_version.hpp') {(Get-Content $f) -replace '#define BUILD 000000', '#define BUILD {{date \"%y%m%d\"}}' -join \"`n\" ^| Set-Content -NoNewline $f; Add-Content -NoNewline \"`n\" $f}"
 ]
 only_release = true
@@ -44,12 +44,14 @@ show_output = true
 steps_linux = [
     "echo 'Unsetting version'",
     "sed -i -r -s 's/{{semver.major}}.{{semver.minor}}.{{semver.patch}}/0.0.0/g' mod.cpp addons/main_a3/CfgMods.hpp",
-    "sed -i -r -s 's/#define BUILD {{date \"%y%m%d\"}}/#define BUILD 000000/g' addons/main/script_version.hpp"
+    "sed -i -r -s 's/#define BUILD {{date \"%y%m%d\"}}/#define BUILD 000000/g' addons/main/script_version.hpp",
+    "echo '-> README.md version ready for commit (ignore until release)!'"
 ]
 steps_windows = [
-    "echo 'Unsetting version'",
+    "echo Unsetting version",
     "powershell -Command foreach ($f in 'mod.cpp', 'addons/main_a3/CfgMods.hpp') {(Get-Content $f) -replace '{{semver.major}}.{{semver.minor}}.{{semver.patch}}', '0.0.0' -join \"`n\" ^| Set-Content -NoNewline $f; Add-Content -NoNewline \"`n\" $f}",
-    "powershell -Command foreach ($f in 'addons/main/script_version.hpp') {(Get-Content $f) -replace '#define BUILD {{date \"%y%m%d\"}}', '#define BUILD 000000' -join \"`n\" ^| Set-Content -NoNewline $f; Add-Content -NoNewline \"`n\" $f}"
+    "powershell -Command foreach ($f in 'addons/main/script_version.hpp') {(Get-Content $f) -replace '#define BUILD {{date \"%y%m%d\"}}', '#define BUILD 000000' -join \"`n\" ^| Set-Content -NoNewline $f; Add-Content -NoNewline \"`n\" $f}",
+    "echo -^> README.md version ready for commit (ignore until release)!"
 ]
 only_release = true
 show_output = true


### PR DESCRIPTION
**When merged this pull request will:**
- Title - fix 2 points from #1316

Version was set too late, after pre-processing. Woops!

@commy2 do you like this setting of version in README.md? It won't be committed, but is ready to be committed for final builds (or on separate branch until release as we usually do) or would you prefer to do it yourself?