### PR TITLE
FIX: CBA_missionTime time leak

### DIFF
--- a/addons/common/fnc_waitAndExecute.sqf
+++ b/addons/common/fnc_waitAndExecute.sqf
@@ -4,7 +4,7 @@ Function: CBA_fnc_waitAndExecute
 
 Description:
     Executes a code once in unscheduled environment with a given game time delay.
-    Note that unlike PFEH, the delay is in CBA_missionTime not diag_tickTime (will be adjusted for time accl).
+    Note that unlike PFEH, the delay is in CBA_missionTimeTriple not diag_tickTime (will be adjusted for time accl).
 
 Parameters:
     _function - The function you wish to execute. <CODE>
@@ -33,7 +33,7 @@ _delay = [
     floor((_delay % 1e6)/1e3),
     _delay % 1e3
 ];
-private _timeOfExec = CBA_missionTime vectorAdd _delay;
+private _timeOfExec = CBA_missionTimeTriple vectorAdd _delay;
 
 GVAR(waitAndExecArray) pushBack (_timeOfExec + [_function, _args]);
 GVAR(waitAndExecArrayIsSorted) = false;

--- a/addons/common/fnc_waitAndExecute.sqf
+++ b/addons/common/fnc_waitAndExecute.sqf
@@ -29,9 +29,9 @@ Author:
 params [["_function", {}, [{}]], ["_args", []], ["_delay", 0, [0]]];
 
 _delay = [
-    floor(_delay/1e6),
-    floor(_delay/1e3) - floor(_delay/1e6) * 1e6,
-    _delay - floor(_delay/1e3) * 1e3 - floor(_delay/1e6) * 1e6
+    floor((_delay % 1e9)/1e6),
+    floor((_delay % 1e6)/1e3),
+    _delay % 1e3
 ];
 private _timeOfExec = CBA_missionTime vectorAdd _delay;
 

--- a/addons/common/fnc_waitAndExecute.sqf
+++ b/addons/common/fnc_waitAndExecute.sqf
@@ -28,5 +28,12 @@ Author:
 
 params [["_function", {}, [{}]], ["_args", []], ["_delay", 0, [0]]];
 
-GVAR(waitAndExecArray) pushBack [CBA_missionTime + _delay, _function, _args];
+_delay = [
+    floor(_delay/1e6),
+    floor(_delay/1e3) - floor(_delay/1e6) * 1e6,
+    _delay - floor(_delay/1e3) * 1e3 - floor(_delay/1e6) * 1e6
+];
+private _timeOfExec = CBA_missionTime vectorAdd _delay;
+
+GVAR(waitAndExecArray) pushBack (_timeOfExec + [_function, _args]);
 GVAR(waitAndExecArrayIsSorted) = false;

--- a/addons/common/fnc_waitUntilAndExecute.sqf
+++ b/addons/common/fnc_waitUntilAndExecute.sqf
@@ -49,11 +49,6 @@ if (_timeout < 0) then {
     GVAR(waitUntilAndExecArray) pushBack [{
         params ["_condition", "_statement", "_args", "_timeout", "_timeoutCode", "_startTime"];
 
-        _startTime = [
-            floor(_startTime/1e6),
-            floor(_startTime/1e3) - floor(_startTime/1e6) * 1e6,
-            _startTime - floor(_startTime/1e3) * 1e3 - floor(_startTime/1e6) * 1e6
-        ];
         private _timeDiff = CBA_missionTime vectorDiff _startTime;
 
         if (_timeDiff#0 * 1e6 + _timeDiff#1 * 1e3 + _timeDiff#2 > _timeout) exitWith {

--- a/addons/common/fnc_waitUntilAndExecute.sqf
+++ b/addons/common/fnc_waitUntilAndExecute.sqf
@@ -50,8 +50,7 @@ if (_timeout < 0) then {
         params ["_condition", "_statement", "_args", "_timeout", "_timeoutCode", "_startTime"];
 
         private _timeDiff = CBA_missionTime vectorDiff _startTime;
-
-        if (_timeDiff#0 * 1e6 + _timeDiff#1 * 1e3 + _timeDiff#2 > _timeout) exitWith {
+        if (_timeDiff vectorDotProduct [1e6 , 1e3, 1]) exitWith {
             _args call _timeoutCode;
             true
         };

--- a/addons/common/fnc_waitUntilAndExecute.sqf
+++ b/addons/common/fnc_waitUntilAndExecute.sqf
@@ -50,7 +50,7 @@ if (_timeout < 0) then {
         params ["_condition", "_statement", "_args", "_timeout", "_timeoutCode", "_startTime"];
 
         private _timeDiff = CBA_missionTime vectorDiff _startTime;
-        if (_timeDiff vectorDotProduct [1e6 , 1e3, 1]) exitWith {
+        if (_timeDiff vectorDotProduct [1e6 , 1e3, 1] > _timeout) exitWith {
             _args call _timeoutCode;
             true
         };

--- a/addons/common/fnc_waitUntilAndExecute.sqf
+++ b/addons/common/fnc_waitUntilAndExecute.sqf
@@ -49,7 +49,7 @@ if (_timeout < 0) then {
     GVAR(waitUntilAndExecArray) pushBack [{
         params ["_condition", "_statement", "_args", "_timeout", "_timeoutCode", "_startTime"];
 
-        private _timeDiff = CBA_missionTime vectorDiff _startTime;
+        private _timeDiff = CBA_missionTimeTriple vectorDiff _startTime;
         if (_timeDiff vectorDotProduct [1e6 , 1e3, 1] > _timeout) exitWith {
             _args call _timeoutCode;
             true
@@ -59,7 +59,7 @@ if (_timeout < 0) then {
             true
         };
         false
-    }, {}, [_condition, _statement, _args, _timeout, _timeoutCode, CBA_missionTime]];
+    }, {}, [_condition, _statement, _args, _timeout, _timeoutCode, CBA_missionTimeTriple]];
 };
 
 nil

--- a/addons/common/fnc_waitUntilAndExecute.sqf
+++ b/addons/common/fnc_waitUntilAndExecute.sqf
@@ -49,7 +49,14 @@ if (_timeout < 0) then {
     GVAR(waitUntilAndExecArray) pushBack [{
         params ["_condition", "_statement", "_args", "_timeout", "_timeoutCode", "_startTime"];
 
-        if (CBA_missionTime - _startTime > _timeout) exitWith {
+        _startTime = [
+            floor(_startTime/1e6),
+            floor(_startTime/1e3) - floor(_startTime/1e6) * 1e6,
+            _startTime - floor(_startTime/1e3) * 1e3 - floor(_startTime/1e6) * 1e6
+        ];
+        private _timeDiff = CBA_missionTime vectorDiff _startTime;
+
+        if (_timeDiff#0 * 1e6 + _timeDiff#1 * 1e3 + _timeDiff#2 > _timeout) exitWith {
             _args call _timeoutCode;
             true
         };

--- a/addons/common/init_perFrameHandler.sqf
+++ b/addons/common/init_perFrameHandler.sqf
@@ -46,8 +46,9 @@ GVAR(waitUntilAndExecArray) = [];
     };
     private _delete = false;
     {
-        private _timeDiff = (_x select [0,3]) vectorDiff CBA_missionTime;
-        if (_timeDiff#0 * 1e6 + _timeDiff#1 * 1e3 + _timeDiff#2 > 0) exitWith {};
+        private _timeDiff = [_x select [0, 3], CBA_missionTime];
+        _timeDiff sort false;
+        if (_timeDiff#0 isEqualTo CBA_missionTime) exitWith {};
 
         (_x select 4) call (_x select 3);
 

--- a/addons/common/init_perFrameHandler.sqf
+++ b/addons/common/init_perFrameHandler.sqf
@@ -108,11 +108,14 @@ if (isMultiplayer) then {
         [QFUNC(missionTimePFH), {
             SCRIPT(missionTimePFH_server);
             if (time != GVAR(lastTime)) then {
-                CBA_missionTime = CBA_missionTime + (_tickTime - GVAR(lastTickTime));
+                private _additionCheckPrecision = CBA_missionTime + (_tickTime - GVAR(lastTickTime));
+                if (CBA_missionTime == _additionCheckPrecision) exitWith {}; // used to detect floating point precision error
+                CBA_missionTime = _additionCheckPrecision;
                 GVAR(lastTime) = time; // used to detect paused game
+                GVAR(lastTickTime) = _tickTime;
+            } else {
+                GVAR(lastTickTime) = _tickTime;
             };
-
-            GVAR(lastTickTime) = _tickTime;
         }] call CBA_fnc_compileFinal;
 
         addMissionEventHandler ["PlayerConnected", {
@@ -132,11 +135,14 @@ if (isMultiplayer) then {
                     [QFUNC(missionTimePFH), {
                         SCRIPT(missionTimePFH_client);
                         if (time != GVAR(lastTime)) then {
-                            CBA_missionTime = CBA_missionTime + (_tickTime - GVAR(lastTickTime));
+                            private _additionCheckPrecision = CBA_missionTime + (_tickTime - GVAR(lastTickTime));
+                            if (CBA_missionTime == _additionCheckPrecision) exitWith {}; // used to detect floating point precision error
+                            CBA_missionTime = _additionCheckPrecision;
                             GVAR(lastTime) = time; // used to detect paused game
+                            GVAR(lastTickTime) = _tickTime;
+                        } else {
+                            GVAR(lastTickTime) = _tickTime;
                         };
-
-                        GVAR(lastTickTime) = _tickTime;
                     }] call CBA_fnc_compileFinal;
 
                 };
@@ -155,10 +161,13 @@ if (isMultiplayer) then {
     [QFUNC(missionTimePFH), {
         SCRIPT(missionTimePFH_sp);
         if (time != GVAR(lastTime)) then {
-            CBA_missionTime = CBA_missionTime + (_tickTime - GVAR(lastTickTime)) * accTime;
+            private _additionCheckPrecision = CBA_missionTime + (_tickTime - GVAR(lastTickTime)) * accTime;
+            if (CBA_missionTime == _additionCheckPrecision) exitWith {}; // used to detect floating point precision error
+            CBA_missionTime = _additionCheckPrecision;
             GVAR(lastTime) = time; // used to detect paused game
+            GVAR(lastTickTime) = _tickTime;
+        } else {
+            GVAR(lastTickTime) = _tickTime;
         };
-
-        GVAR(lastTickTime) = _tickTime;
     }] call CBA_fnc_compileFinal;
 };

--- a/addons/common/init_perFrameHandler.sqf
+++ b/addons/common/init_perFrameHandler.sqf
@@ -47,7 +47,7 @@ GVAR(waitUntilAndExecArray) = [];
     private _delete = false;
     {
         private _timeDiff = [_x select [0, 3], CBA_missionTime];
-        _timeDiff sort false;
+        _timeDiff sort true;
         if (_timeDiff#0 isEqualTo CBA_missionTime) exitWith {};
 
         (_x select 4) call (_x select 3);

--- a/addons/diagnostic/fnc_debug.sqf
+++ b/addons/diagnostic/fnc_debug.sqf
@@ -75,7 +75,7 @@ _message set [0, format [
     "(%3) %1 - %2",
     _title,
     _message select 0,
-    [CBA_missionTime, "H:MM:SS"] call CBA_fnc_formatElapsedTime
+    [CBA_missionTime#0 * 1e6 + CBA_missionTime#1 * 1e3 + CBA_missionTime#2, "H:MM:SS"] call CBA_fnc_formatElapsedTime
 ]];
 
 _message = _message call _fnc_splitLines;

--- a/addons/diagnostic/fnc_debug.sqf
+++ b/addons/diagnostic/fnc_debug.sqf
@@ -75,7 +75,7 @@ _message set [0, format [
     "(%3) %1 - %2",
     _title,
     _message select 0,
-    [CBA_missionTime vectorDotProduct [1e6 , 1e3, 1], "H:MM:SS"] call CBA_fnc_formatElapsedTime
+    [CBA_missionTimeTriple vectorDotProduct [1e6 , 1e3, 1], "H:MM:SS"] call CBA_fnc_formatElapsedTime
 ]];
 
 _message = _message call _fnc_splitLines;

--- a/addons/diagnostic/fnc_debug.sqf
+++ b/addons/diagnostic/fnc_debug.sqf
@@ -75,7 +75,7 @@ _message set [0, format [
     "(%3) %1 - %2",
     _title,
     _message select 0,
-    [CBA_missionTime#0 * 1e6 + CBA_missionTime#1 * 1e3 + CBA_missionTime#2, "H:MM:SS"] call CBA_fnc_formatElapsedTime
+    [CBA_missionTime vectorDotProduct [1e6 , 1e3, 1], "H:MM:SS"] call CBA_fnc_formatElapsedTime
 ]];
 
 _message = _message call _fnc_splitLines;

--- a/addons/events/fnc_weaponEvents.sqf
+++ b/addons/events/fnc_weaponEvents.sqf
@@ -116,7 +116,13 @@ if (!_isEmpty || _onEmpty) then {
         };
 
         // keep waiting until time over
-        if (CBA_missionTime < _time + _delay) exitWith {false};
+        _time = [
+            floor(_time/1e6),
+            floor(_time/1e3) - floor(_time/1e6) * 1e6,
+            _time - floor(_time/1e3) * 1e3 - floor(_time/1e6) * 1e6
+        ];
+        private _timeDiff = CBA_missionTime vectorDiff _time;
+        if (_timeDiff#0 * 1e6 + _timeDiff#1 * 1e3 + _timeDiff#2 < _delay) exitWith {false};
 
         if (local _unit) then {
             _unit playAction _handAction;

--- a/addons/events/fnc_weaponEvents.sqf
+++ b/addons/events/fnc_weaponEvents.sqf
@@ -117,7 +117,7 @@ if (!_isEmpty || _onEmpty) then {
 
         // keep waiting until time over
         private _timeDiff = CBA_missionTime vectorDiff _time;
-        if (_timeDiff#0 * 1e6 + _timeDiff#1 * 1e3 + _timeDiff#2 < _delay) exitWith {false};
+        if (_timeDiff vectorDotProduct [1e6 , 1e3, 1] < _delay) exitWith {false};
 
         if (local _unit) then {
             _unit playAction _handAction;

--- a/addons/events/fnc_weaponEvents.sqf
+++ b/addons/events/fnc_weaponEvents.sqf
@@ -116,11 +116,6 @@ if (!_isEmpty || _onEmpty) then {
         };
 
         // keep waiting until time over
-        _time = [
-            floor(_time/1e6),
-            floor(_time/1e3) - floor(_time/1e6) * 1e6,
-            _time - floor(_time/1e3) * 1e3 - floor(_time/1e6) * 1e6
-        ];
         private _timeDiff = CBA_missionTime vectorDiff _time;
         if (_timeDiff#0 * 1e6 + _timeDiff#1 * 1e3 + _timeDiff#2 < _delay) exitWith {false};
 

--- a/addons/events/fnc_weaponEvents.sqf
+++ b/addons/events/fnc_weaponEvents.sqf
@@ -110,13 +110,13 @@ if (!_isEmpty || _onEmpty) then {
                 _this set [10, true];
             };
 
-            _this set [8, CBA_missionTime];
+            _this set [8, CBA_missionTimeTriple];
             _unit setWeaponReloadingTime [_unit, _muzzle, 1];
             false
         };
 
         // keep waiting until time over
-        private _timeDiff = CBA_missionTime vectorDiff _time;
+        private _timeDiff = CBA_missionTimeTriple vectorDiff _time;
         if (_timeDiff vectorDotProduct [1e6 , 1e3, 1] < _delay) exitWith {false};
 
         if (local _unit) then {
@@ -186,7 +186,7 @@ if (!_isEmpty || _onEmpty) then {
     }, {}, [
         _unit, _weapon, _muzzle, _optic,
         _handAction, _sound, call _fnc_soundSource,
-        _expectedMagazineCount, CBA_missionTime, _delay,
+        _expectedMagazineCount, CBA_missionTimeTriple, _delay,
         _triggerReleased, _config
     ]] call CBA_fnc_waitUntilAndExecute;
 };

--- a/addons/music/fnc_getMusicPlaying.sqf
+++ b/addons/music/fnc_getMusicPlaying.sqf
@@ -24,7 +24,13 @@ if (isNil QGVAR(track)) exitWith {["", 0, 0]};
 
 GVAR(track) params ["_class", "_startTime", "_playPos", "_duration"];
 
-private _trackTime = (CBA_missionTime - _startTime) + _playPos;
+_startTime = [
+    floor(_startTime/1e6),
+    floor(_startTime/1e3) - floor(_startTime/1e6) * 1e6,
+    _startTime - floor(_startTime/1e3) * 1e3 - floor(_startTime/1e6) * 1e6
+];
+private _timeDiff = CBA_missionTime vectorDiff _startTime;
+private _trackTime = _timeDiff#0 * 1e6 + _timeDiff#1 * 1e3 + _timeDiff#2 + _playPos;
 private _remainingTime = _duration - _trackTime;
 
 if (_remainingTime <= 0) then {

--- a/addons/music/fnc_getMusicPlaying.sqf
+++ b/addons/music/fnc_getMusicPlaying.sqf
@@ -24,7 +24,7 @@ if (isNil QGVAR(track)) exitWith {["", 0, 0]};
 
 GVAR(track) params ["_class", "_startTime", "_playPos", "_duration"];
 
-private _timeDiff = CBA_missionTime vectorDiff _startTime;
+private _timeDiff = CBA_missionTimeTriple vectorDiff _startTime;
 private _trackTime = (_timeDiff vectorDotProduct [1e6 , 1e3, 1]) + _playPos;
 private _remainingTime = _duration - _trackTime;
 

--- a/addons/music/fnc_getMusicPlaying.sqf
+++ b/addons/music/fnc_getMusicPlaying.sqf
@@ -24,11 +24,6 @@ if (isNil QGVAR(track)) exitWith {["", 0, 0]};
 
 GVAR(track) params ["_class", "_startTime", "_playPos", "_duration"];
 
-_startTime = [
-    floor(_startTime/1e6),
-    floor(_startTime/1e3) - floor(_startTime/1e6) * 1e6,
-    _startTime - floor(_startTime/1e3) * 1e3 - floor(_startTime/1e6) * 1e6
-];
 private _timeDiff = CBA_missionTime vectorDiff _startTime;
 private _trackTime = _timeDiff#0 * 1e6 + _timeDiff#1 * 1e3 + _timeDiff#2 + _playPos;
 private _remainingTime = _duration - _trackTime;

--- a/addons/music/fnc_getMusicPlaying.sqf
+++ b/addons/music/fnc_getMusicPlaying.sqf
@@ -25,7 +25,7 @@ if (isNil QGVAR(track)) exitWith {["", 0, 0]};
 GVAR(track) params ["_class", "_startTime", "_playPos", "_duration"];
 
 private _timeDiff = CBA_missionTime vectorDiff _startTime;
-private _trackTime = _timeDiff#0 * 1e6 + _timeDiff#1 * 1e3 + _timeDiff#2 + _playPos;
+private _trackTime = (_timeDiff vectorDotProduct [1e6 , 1e3, 1]) + _playPos;
 private _remainingTime = _duration - _trackTime;
 
 if (_remainingTime <= 0) then {

--- a/addons/music/fnc_playMusic.sqf
+++ b/addons/music/fnc_playMusic.sqf
@@ -37,7 +37,7 @@ private _duration = [_className, "duration"] call CBA_fnc_getMusicData;
 if (!isNil "_duration") then {
     if (_time < _duration) then {
         playMusic [_className, _time];
-        GVAR(track) = [_className, CBA_missionTime, _time, _duration];
+        GVAR(track) = [_className, CBA_missionTimeTriple, _time, _duration];
         _return = true;
     } else {
         WARNING("Time is greater than song length");

--- a/addons/statemachine/fnc_dumpPerformanceCounters.sqf
+++ b/addons/statemachine/fnc_dumpPerformanceCounters.sqf
@@ -27,7 +27,7 @@ if (true) exitWith {WARNING("Requires `STATEMACHINE_PERFORMANCE_COUNTERS` in scr
 #endif
 
 diag_log text format ["CBA State Machine Results:"];
-diag_log text format ["------------------ [Time: %1] -------------------------", (CBA_missionTime#0 * 1e6 + CBA_missionTime#1 * 1e3 + CBA_missionTime#2) toFixed 1];
+diag_log text format ["------------------ [Time: %1] -------------------------", (CBA_missionTime vectorDotProduct [1e6 , 1e3, 1]) toFixed 1];
 
 {
     // _x is an array of small individual run times from FUNC(clockwork)

--- a/addons/statemachine/fnc_dumpPerformanceCounters.sqf
+++ b/addons/statemachine/fnc_dumpPerformanceCounters.sqf
@@ -27,7 +27,7 @@ if (true) exitWith {WARNING("Requires `STATEMACHINE_PERFORMANCE_COUNTERS` in scr
 #endif
 
 diag_log text format ["CBA State Machine Results:"];
-diag_log text format ["------------------ [Time: %1] -------------------------", (CBA_missionTime vectorDotProduct [1e6 , 1e3, 1]) toFixed 1];
+diag_log text format ["------------------ [Time: %1] -------------------------", (CBA_missionTimeTriple vectorDotProduct [1e6 , 1e3, 1]) toFixed 1];
 
 {
     // _x is an array of small individual run times from FUNC(clockwork)

--- a/addons/statemachine/fnc_dumpPerformanceCounters.sqf
+++ b/addons/statemachine/fnc_dumpPerformanceCounters.sqf
@@ -27,7 +27,7 @@ if (true) exitWith {WARNING("Requires `STATEMACHINE_PERFORMANCE_COUNTERS` in scr
 #endif
 
 diag_log text format ["CBA State Machine Results:"];
-diag_log text format ["------------------ [Time: %1] -------------------------", CBA_missionTime toFixed 1];
+diag_log text format ["------------------ [Time: %1] -------------------------", (CBA_missionTime#0 * 1e6 + CBA_missionTime#1 * 1e3 + CBA_missionTime#2) toFixed 1];
 
 {
     // _x is an array of small individual run times from FUNC(clockwork)

--- a/addons/ui/fnc_progressBar.sqf
+++ b/addons/ui/fnc_progressBar.sqf
@@ -78,7 +78,13 @@ _ctrlTitle ctrlSetText _title;
 // run failure code on previous progress bar
 if (!isNil QGVAR(ProgressBarParams)) then {
     GVAR(ProgressBarParams) params ["_arguments", "", "", "_onFailure", "_startTime", "_totalTime"];
-    private _elapsedTime = (CBA_missionTime - _startTime) min _totalTime;
+    _startTime = [
+        floor(_startTime/1e6),
+        floor(_startTime/1e3) - floor(_startTime/1e6) * 1e6,
+        _startTime - floor(_startTime/1e3) * 1e3 - floor(_startTime/1e6) * 1e6
+    ];
+    private _timeDiff = CBA_missionTime vectorDiff _startTime;
+    private _elapsedTime = (_timeDiff#0 * 1e6 + _timeDiff#1 * 1e3 + _timeDiff#2) min _totalTime;
 
     [_onFailure, [_arguments, false, _elapsedTime, _totalTime, 3]] call CBA_fnc_execNextFrame;
 };
@@ -92,7 +98,13 @@ _ctrlScript ctrlAddEventHandler ["Draw", {
     private _display = ctrlParent _ctrlScript;
 
     GVAR(ProgressBarParams) params ["_arguments", "_condition", "_onSuccess", "_onFailure", "_startTime", "_totalTime"];
-    private _elapsedTime = (CBA_missionTime - _startTime) min _totalTime;
+    _startTime = [
+        floor(_startTime/1e6),
+        floor(_startTime/1e3) - floor(_startTime/1e6) * 1e6,
+        _startTime - floor(_startTime/1e3) * 1e3 - floor(_startTime/1e6) * 1e6
+    ];
+    private _timeDiff = CBA_missionTime vectorDiff _startTime;
+    private _elapsedTime = (_timeDiff#0 * 1e6 + _timeDiff#1 * 1e3 + _timeDiff#2) min _totalTime;
 
     private _continue = [[_arguments, true, _elapsedTime, _totalTime], _condition] call {
         // prevent these variables from being overwritten
@@ -133,7 +145,13 @@ if (_blockMouse) then {
         params ["_blockInputDisplay", "_key", "_shift", "_control", "_alt"];
 
         GVAR(ProgressBarParams) params ["_arguments", "", "", "_onFailure", "_startTime", "_totalTime", "_blockMouse", "_blockKeys", "_allowClose"];
-        private _elapsedTime = (CBA_missionTime - _startTime) min _totalTime;
+        _startTime = [
+            floor(_startTime/1e6),
+            floor(_startTime/1e3) - floor(_startTime/1e6) * 1e6,
+            _startTime - floor(_startTime/1e3) * 1e3 - floor(_startTime/1e6) * 1e6
+        ];
+        private _timeDiff = CBA_missionTime vectorDiff _startTime;
+        private _elapsedTime = (_timeDiff#0 * 1e6 + _timeDiff#1 * 1e3 + _timeDiff#2) min _totalTime;
 
         if (_key isEqualTo DIK_ESCAPE) then {
             if (_allowClose) then {

--- a/addons/ui/fnc_progressBar.sqf
+++ b/addons/ui/fnc_progressBar.sqf
@@ -79,7 +79,7 @@ _ctrlTitle ctrlSetText _title;
 if (!isNil QGVAR(ProgressBarParams)) then {
     GVAR(ProgressBarParams) params ["_arguments", "", "", "_onFailure", "_startTime", "_totalTime"];
     private _timeDiff = CBA_missionTime vectorDiff _startTime;
-    private _elapsedTime = (_timeDiff#0 * 1e6 + _timeDiff#1 * 1e3 + _timeDiff#2) min _totalTime;
+    private _elapsedTime = (_timeDiff vectorDotProduct [1e6 , 1e3, 1]) min _totalTime;
 
     [_onFailure, [_arguments, false, _elapsedTime, _totalTime, 3]] call CBA_fnc_execNextFrame;
 };
@@ -94,7 +94,7 @@ _ctrlScript ctrlAddEventHandler ["Draw", {
 
     GVAR(ProgressBarParams) params ["_arguments", "_condition", "_onSuccess", "_onFailure", "_startTime", "_totalTime"];
     private _timeDiff = CBA_missionTime vectorDiff _startTime;
-    private _elapsedTime = (_timeDiff#0 * 1e6 + _timeDiff#1 * 1e3 + _timeDiff#2) min _totalTime;
+    private _elapsedTime = (_timeDiff vectorDotProduct [1e6 , 1e3, 1]) min _totalTime;
 
     private _continue = [[_arguments, true, _elapsedTime, _totalTime], _condition] call {
         // prevent these variables from being overwritten
@@ -136,7 +136,7 @@ if (_blockMouse) then {
 
         GVAR(ProgressBarParams) params ["_arguments", "", "", "_onFailure", "_startTime", "_totalTime", "_blockMouse", "_blockKeys", "_allowClose"];
         private _timeDiff = CBA_missionTime vectorDiff _startTime;
-        private _elapsedTime = (_timeDiff#0 * 1e6 + _timeDiff#1 * 1e3 + _timeDiff#2) min _totalTime;
+        private _elapsedTime = (_timeDiff vectorDotProduct [1e6 , 1e3, 1]) min _totalTime;
 
         if (_key isEqualTo DIK_ESCAPE) then {
             if (_allowClose) then {

--- a/addons/ui/fnc_progressBar.sqf
+++ b/addons/ui/fnc_progressBar.sqf
@@ -78,11 +78,6 @@ _ctrlTitle ctrlSetText _title;
 // run failure code on previous progress bar
 if (!isNil QGVAR(ProgressBarParams)) then {
     GVAR(ProgressBarParams) params ["_arguments", "", "", "_onFailure", "_startTime", "_totalTime"];
-    _startTime = [
-        floor(_startTime/1e6),
-        floor(_startTime/1e3) - floor(_startTime/1e6) * 1e6,
-        _startTime - floor(_startTime/1e3) * 1e3 - floor(_startTime/1e6) * 1e6
-    ];
     private _timeDiff = CBA_missionTime vectorDiff _startTime;
     private _elapsedTime = (_timeDiff#0 * 1e6 + _timeDiff#1 * 1e3 + _timeDiff#2) min _totalTime;
 
@@ -98,11 +93,6 @@ _ctrlScript ctrlAddEventHandler ["Draw", {
     private _display = ctrlParent _ctrlScript;
 
     GVAR(ProgressBarParams) params ["_arguments", "_condition", "_onSuccess", "_onFailure", "_startTime", "_totalTime"];
-    _startTime = [
-        floor(_startTime/1e6),
-        floor(_startTime/1e3) - floor(_startTime/1e6) * 1e6,
-        _startTime - floor(_startTime/1e3) * 1e3 - floor(_startTime/1e6) * 1e6
-    ];
     private _timeDiff = CBA_missionTime vectorDiff _startTime;
     private _elapsedTime = (_timeDiff#0 * 1e6 + _timeDiff#1 * 1e3 + _timeDiff#2) min _totalTime;
 
@@ -145,11 +135,6 @@ if (_blockMouse) then {
         params ["_blockInputDisplay", "_key", "_shift", "_control", "_alt"];
 
         GVAR(ProgressBarParams) params ["_arguments", "", "", "_onFailure", "_startTime", "_totalTime", "_blockMouse", "_blockKeys", "_allowClose"];
-        _startTime = [
-            floor(_startTime/1e6),
-            floor(_startTime/1e3) - floor(_startTime/1e6) * 1e6,
-            _startTime - floor(_startTime/1e3) * 1e3 - floor(_startTime/1e6) * 1e6
-        ];
         private _timeDiff = CBA_missionTime vectorDiff _startTime;
         private _elapsedTime = (_timeDiff#0 * 1e6 + _timeDiff#1 * 1e3 + _timeDiff#2) min _totalTime;
 

--- a/addons/ui/fnc_progressBar.sqf
+++ b/addons/ui/fnc_progressBar.sqf
@@ -78,13 +78,13 @@ _ctrlTitle ctrlSetText _title;
 // run failure code on previous progress bar
 if (!isNil QGVAR(ProgressBarParams)) then {
     GVAR(ProgressBarParams) params ["_arguments", "", "", "_onFailure", "_startTime", "_totalTime"];
-    private _timeDiff = CBA_missionTime vectorDiff _startTime;
+    private _timeDiff = CBA_missionTimeTriple vectorDiff _startTime;
     private _elapsedTime = (_timeDiff vectorDotProduct [1e6 , 1e3, 1]) min _totalTime;
 
     [_onFailure, [_arguments, false, _elapsedTime, _totalTime, 3]] call CBA_fnc_execNextFrame;
 };
 
-GVAR(ProgressBarParams) = [_arguments, _condition, _onSuccess, _onFailure, CBA_missionTime, _totalTime, _blockMouse, _blockKeys, _allowClose];
+GVAR(ProgressBarParams) = [_arguments, _condition, _onSuccess, _onFailure, CBA_missionTimeTriple, _totalTime, _blockMouse, _blockKeys, _allowClose];
 
 // update bar, check condition, execute success or failure scripts
 private _ctrlScript = _display displayCtrl IDC_PROGRESSBAR_SCRIPT;
@@ -93,7 +93,7 @@ _ctrlScript ctrlAddEventHandler ["Draw", {
     private _display = ctrlParent _ctrlScript;
 
     GVAR(ProgressBarParams) params ["_arguments", "_condition", "_onSuccess", "_onFailure", "_startTime", "_totalTime"];
-    private _timeDiff = CBA_missionTime vectorDiff _startTime;
+    private _timeDiff = CBA_missionTimeTriple vectorDiff _startTime;
     private _elapsedTime = (_timeDiff vectorDotProduct [1e6 , 1e3, 1]) min _totalTime;
 
     private _continue = [[_arguments, true, _elapsedTime, _totalTime], _condition] call {
@@ -135,7 +135,7 @@ if (_blockMouse) then {
         params ["_blockInputDisplay", "_key", "_shift", "_control", "_alt"];
 
         GVAR(ProgressBarParams) params ["_arguments", "", "", "_onFailure", "_startTime", "_totalTime", "_blockMouse", "_blockKeys", "_allowClose"];
-        private _timeDiff = CBA_missionTime vectorDiff _startTime;
+        private _timeDiff = CBA_missionTimeTriple vectorDiff _startTime;
         private _elapsedTime = (_timeDiff vectorDotProduct [1e6 , 1e3, 1]) min _totalTime;
 
         if (_key isEqualTo DIK_ESCAPE) then {

--- a/addons/xeh/fnc_postInit.sqf
+++ b/addons/xeh/fnc_postInit.sqf
@@ -20,8 +20,8 @@ isNil {
     XEH_LOG("PostInit started. " + PFORMAT_9("MISSIONINIT",missionName,missionVersion,worldName,isMultiplayer,isServer,isDedicated,CBA_isHeadlessClient,hasInterface,didJIP));
 
     // fix CBA_missionTime being -1 on (non-JIP) clients at mission start.
-    if (CBA_missionTime == -1) then {
-        CBA_missionTime = 0;
+    if (CBA_missionTime isEqualTo []) then {
+        CBA_missionTime = [0, 0, 0];
     };
 
     // call PostInit events

--- a/addons/xeh/fnc_postInit.sqf
+++ b/addons/xeh/fnc_postInit.sqf
@@ -19,9 +19,9 @@ Author:
 isNil {
     XEH_LOG("PostInit started. " + PFORMAT_9("MISSIONINIT",missionName,missionVersion,worldName,isMultiplayer,isServer,isDedicated,CBA_isHeadlessClient,hasInterface,didJIP));
 
-    // fix CBA_missionTime being -1 on (non-JIP) clients at mission start.
-    if (CBA_missionTime isEqualTo []) then {
-        CBA_missionTime = [0, 0, 0];
+    // fix CBA_missionTimeTriple being -1 on (non-JIP) clients at mission start.
+    if (CBA_missionTimeTriple isEqualTo []) then {
+        CBA_missionTimeTriple = [0, 0, 0];
     };
 
     // call PostInit events


### PR DESCRIPTION
For `CBA_missionTime` above to 6e5s (7 days):
Addition with `CBA_missionTime` has some floating point precision error appearing randomly. This can be see thanks to this code mimicking the actual CBA behaviour:
```sqf
Vdofin_somme = 0;
Vdofin_start = 6e5;

Vdofin_missionTime = Vdofin_start;
Vdofin_lastTickTime = diag_tickTime;
v = addMissionEventHandler ["EachFrame", {
    private _tickTime = diag_tickTime;
    private _additionCheckPrecision = _tickTime - Vdofin_lastTickTime;

    Vdofin_somme = Vdofin_somme + _additionCheckPrecision;

    Vdofin_missionTime = Vdofin_missionTime + _additionCheckPrecision;
    Vdofin_lastTickTime = _tickTime;
}];
```
Check in debug console the leak happening after a few second:
`Vdofin_somme + Vdofin_start - Vdofin_missionTime`

This leak is due to the problem that `_tickTime - GVAR(lastTickTime)` is around 0.01 to 0.1 which is between 1e6 to 1e7 power of magnitude smaller than `CBA_missionTime`. So when `_tickTime - GVAR(lastTickTime)` is added to 6e5 the result is the same as before the addition.
The idea is to wait until `_tickTime - GVAR(lastTickTime)` is higher. To do so, first we need to check if a floating point error occur and don't update `CBA_missionTime` AND `GVAR(lastTickTime)`. So the `_tickTime - GVAR(lastTickTime)` will get higher and higher until the floating point error do not occur any more.

For the previous code this mean this:
```sqf
Vdofin_somme = 0;
Vdofin_start = 6e5;

Vdofin_lastTickTime = diag_tickTime;
Vdofin_missionTime = Vdofin_start;
a = addMissionEventHandler ["EachFrame", {
    private _tickTime = diag_tickTime;
    private _additionCheckPrecision = _tickTime - Vdofin_lastTickTime;
    Vdofin_somme = Vdofin_somme + _additionCheckPrecision;

    private _storeAddition = Vdofin_missionTime + _additionCheckPrecision;
    if (Vdofin_missionTime == _storeAddition) exitWith{};
    Vdofin_missionTime = _storeAddition;
    Vdofin_lastTickTime = _tickTime;
}];
```

For CBA, see commits.

This allow dedicated server with CBA work longer than 5e5s and lower than 1e6s without significant time leak.

**When merged this pull request will:**
- This PR avoid time leak when  `CBA_missionTime` above to 6e5s (7 days) and lower than 1e6s (11.5 days).
- Each time the CBA_missionTime is updated
  - Now checking if the addition : `CBA_missionTime + (_tickTime - GVAR(lastTickTime))` is equal to than `CBA_missionTime`
  - If is, this mean there is a floating point precision error
    - Skip the addition and the update of `GVAR(lastTickTime)`
  - If not, update the `CBA_missionTime` and `GVAR(lastTickTime)`
