### PR TITLE
Fix waypoint positioning for exact placement

### DIFF
--- a/addons/ai/fnc_addWaypoint.sqf
+++ b/addons/ai/fnc_addWaypoint.sqf
@@ -30,8 +30,8 @@ Returns:
 
 Author:
     Rommel
-
 ---------------------------------------------------------------------------- */
+
 params [
     "_group",
     "_position",
@@ -45,8 +45,15 @@ params [
     ["_timeout", [0,0,0], [[]], 3],
     ["_compRadius", 0, [0]]
 ];
+
 _group = _group call CBA_fnc_getGroup;
 _position = _position call CBA_fnc_getPos;
+
+// addWaypoint expects ASL when a negative radius is provided for exact placement
+// otherwise waypoints will be placed under the ground
+if (_radius < 0) then {
+    _position = AGLtoASL _position;
+};
 
 private _waypoint = _group addWaypoint [_position, _radius];
 

--- a/addons/ai/fnc_clearWaypoints.sqf
+++ b/addons/ai/fnc_clearWaypoints.sqf
@@ -31,6 +31,6 @@ private _waypoints = waypoints _group;
 
 if !(units _group isEqualTo []) then {
     // Create a self-deleting waypoint at the leader position to halt all planned movement (based on old waypoints)
-    private _wp = _group addWaypoint [getPosATL (leader _group), -1];
-    _wp setWaypointStatements ["true", "deleteWaypoint [group this,currentWaypoint (group this)]"];
+    private _wp = _group addWaypoint [getPosASL leader _group, -1];
+    _wp setWaypointStatements ["true", "deleteWaypoint [group this, currentWaypoint (group this)]"];
 };

--- a/addons/ai/fnc_searchNearby.sqf
+++ b/addons/ai/fnc_searchNearby.sqf
@@ -34,7 +34,7 @@ if ((leader _group) distanceSqr _building > 250e3) exitwith {};
 
     // Add a waypoint to regroup after the search
     _group lockWP true;
-    private _wp = _group addWaypoint [getPos _leader, -1, currentWaypoint _group];
+    private _wp = _group addWaypoint [getPosASL _leader, -1, currentWaypoint _group];
     private _cond = "({unitReady _x || !(alive _x)} count thisList) == count thisList";
     private _comp = format ["this setFormation '%1'; this setBehaviour '%2'; deleteWaypoint [group this, currentWaypoint (group this)];", formation _group, behaviour _leader];
     _wp setWaypointStatements [_cond, _comp];


### PR DESCRIPTION
**When merged this pull request will:**
- Fix waypoints being placed under the ground by `CBA_fnc_addWaypoint`, `CBA_fnc_clearWaypoints`, and `CBA_fnc_searchNearby` after changes made in #1277 
- `addWaypoint` expects ASL not AGL when a negative radius is provided for exact placement
- Preserves `CBA_fnc_addWaypoint` expecting position to be in AGL format, converts to ASL if radius is negative