### PR TITLE
Common - Add option to use vanilla game time (mission config)

### DIFF
--- a/addons/common/init_perFrameHandler.sqf
+++ b/addons/common/init_perFrameHandler.sqf
@@ -98,8 +98,16 @@ addMissionEventHandler ["Loaded", {
 }];
 
 CBA_missionTime = 0;
-GVAR(lastTime) = time;
+if ((getNumber (missionConfigFile >> "CBA_useVanillaMissionTime")) == 1) exitWith {
+    INFO("Using basic time for CBA_MissionTime [max compatiblity]");
+    [QFUNC(missionTimePFH), {
+        SCRIPT(missionTimePFH_vanilla);
+        CBA_missionTime = time;
+        GVAR(lastTickTime) = _tickTime;
+    }] call CBA_fnc_compileFinal;
+};
 
+GVAR(lastTime) = time;
 // increase CBA_missionTime variable every frame
 if (isMultiplayer) then {
     // multiplayer - no accTime in MP


### PR DESCRIPTION
ref #1320
simpler fix
just add option to use vanilla `time`
might not be perfectly synced, but should handle extended plays much better