### PR TITLE
Add CBA_Init attribute to editor

### DIFF
--- a/addons/common/Cfg3DEN.hpp
+++ b/addons/common/Cfg3DEN.hpp
@@ -142,7 +142,7 @@ class Cfg3DEN {
                     // the usage of local variables and return values.
                     onKillFocus = QUOTE(\
                         private _code = ctrlText (_this select 0);\
-                        (uiNamespace getVariable [ARR_2('GVAR(InitAttributeValue)', controlNull)]) ctrlSetText _code;\
+                        (ctrlParent (_this select 0) getVariable [ARR_2('GVAR(InitAttributeValue)', controlNull)]) ctrlSetText _code;\
                         if (_code != '') then {\
                             _code = 'call{' + _code + '}';\
                         };\
@@ -158,7 +158,7 @@ class Cfg3DEN {
                 class Title: Title {};
                 class Value: Value {
                     onLoad = QUOTE(\
-                        uiNamespace setVariable [ARR_2('GVAR(InitAttributeValue'), _this select 0)];\
+                        ctrlParent (_this select 0) setVariable [ARR_2('GVAR(InitAttributeValue)', _this select 0)];\
                         (_this select 0) ctrlEnable false;\
                     );
                     h = 0;
@@ -190,7 +190,7 @@ class Cfg3DEN {
             class Init {
                 class Attributes {
                     class Init {
-                        control = QGVAR(EditCodeMulti6);
+                        control = QGVAR(EditCodeMulti6_Init);
                     };
                     class Callsign {
                         expression = "[_this, _value] call CBA_fnc_setCallsign";
@@ -238,7 +238,7 @@ class Cfg3DEN {
             class Init {
                 class Attributes {
                     class Init {
-                        control = QGVAR(EditCodeMulti6);
+                        control = QGVAR(EditCodeMulti6_Init);
                     };
                 };
             };

--- a/addons/common/Cfg3DEN.hpp
+++ b/addons/common/Cfg3DEN.hpp
@@ -191,7 +191,7 @@ class Cfg3DEN {
                     };
                     class CBA_Init {
                         control = QGVAR(InitAttribute);
-                        property = "CBA_Init"; // Unique config property name saved in SQM
+                        property = "CBA_Init";
                         expression = "_this setVariable ['%s', _value, true];";
                         defaultValue = "''";
                     };

--- a/addons/common/Cfg3DEN.hpp
+++ b/addons/common/Cfg3DEN.hpp
@@ -130,7 +130,7 @@ class Cfg3DEN {
             };
         };
 
-        class GVAR(EditCodeMulti10_Init): GVAR(EditCodeMulti10) {
+        class GVAR(EditCodeMulti6_Init): GVAR(EditCodeMulti6) {
             class Controls: Controls {
                 class Background: Background {};
                 class Title: Title {};
@@ -149,6 +149,21 @@ class Cfg3DEN {
                         (ctrlParentControlsGroup (_this select 0) controlsGroupCtrl 100) ctrlSetText _code;\
                     );
                 };
+            };
+        };
+
+        class GVAR(EditCodeMulti10_Init): GVAR(EditCodeMulti6_Init) {
+            h = POS_H_GROUP(10);
+
+            class Controls: Controls {
+                class Background: Background {
+                    h = POS_H_BACKGROUND(10);
+                };
+                class Title: Title {
+                    h = POS_H_TITLE(10);
+                };
+                class Value: Value {};
+                class GVAR(ValueInit): GVAR(ValueInit) {};
             };
         };
 

--- a/addons/common/Cfg3DEN.hpp
+++ b/addons/common/Cfg3DEN.hpp
@@ -129,6 +129,42 @@ class Cfg3DEN {
                 };
             };
         };
+
+        class GVAR(EditCodeMulti10_Init): GVAR(EditCodeMulti10) {
+            class Controls: Controls {
+                class Background: Background {};
+                class Title: Title {};
+                class Value: Value {};
+                class GVAR(ValueInit): GVAR(Value) {
+                    // Copies contents of editable init box into the hidden
+                    // variant and into CBA_Init attribute.
+                    // Automatically adds call-block wrapper to enable
+                    // the usage of local variables and return values.
+                    onKillFocus = QUOTE(\
+                        private _code = ctrlText (_this select 0);\
+                        (uiNamespace getVariable [ARR_2('GVAR(InitAttributeValue)', controlNull)]) ctrlSetText _code;\
+                        if (_code != '') then {\
+                            _code = 'call{' + _code + '}';\
+                        };\
+                        (ctrlParentControlsGroup (_this select 0) controlsGroupCtrl 100) ctrlSetText _code;\
+                    );
+                };
+            };
+        };
+
+        class GVAR(InitAttribute): GVAR(EditCodeMulti3) {
+            class Controls: Controls {
+                class Background: Background {};
+                class Title: Title {};
+                class Value: Value {
+                    onLoad = QUOTE(\
+                        uiNamespace setVariable [ARR_2('GVAR(InitAttributeValue'), _this select 0)];\
+                        (_this select 0) ctrlEnable false;\
+                    );
+                    h = 0;
+                };
+            };
+        };
     };
 
     class Object {
@@ -136,7 +172,13 @@ class Cfg3DEN {
             class Init {
                 class Attributes {
                     class Init {
-                        control = QGVAR(EditCodeMulti10);
+                        control = QGVAR(EditCodeMulti10_Init);
+                    };
+                    class CBA_Init {
+                        control = QGVAR(InitAttribute);
+                        property = "CBA_Init"; // Unique config property name saved in SQM
+                        expression = "_this setVariable ['%s', _value, true];";
+                        defaultValue = "''";
                     };
                 };
             };

--- a/addons/common/Cfg3DEN.hpp
+++ b/addons/common/Cfg3DEN.hpp
@@ -257,6 +257,12 @@ class Cfg3DEN {
                     class Init {
                         control = QGVAR(EditCodeMulti6_Init);
                     };
+                    class CBA_Init {
+                        control = QGVAR(InitAttribute);
+                        property = "CBA_Init";
+                        expression = "_this setVariable ['%s', _value, true];";
+                        defaultValue = "''";
+                    };
                 };
             };
         };

--- a/addons/common/Cfg3DEN.hpp
+++ b/addons/common/Cfg3DEN.hpp
@@ -130,7 +130,7 @@ class Cfg3DEN {
             };
         };
 
-        class GVAR(EditCodeMulti6_Init): GVAR(EditCodeMulti6) {
+        class GVAR(EditCodeMulti10_InitObject): GVAR(EditCodeMulti10) {
             class Controls: Controls {
                 class Background: Background {};
                 class Title: Title {};
@@ -142,7 +142,7 @@ class Cfg3DEN {
                     // the usage of local variables and return values.
                     onKillFocus = QUOTE(\
                         private _code = ctrlText (_this select 0);\
-                        (ctrlParent (_this select 0) getVariable [ARR_2('GVAR(InitAttributeValue)', controlNull)]) ctrlSetText _code;\
+                        (ctrlParent (_this select 0) getVariable [ARR_2('GVAR(InitAttributeValue_Object)', controlNull)]) ctrlSetText _code;\
                         if (_code != '') then {\
                             _code = 'call{' + _code + '}';\
                         };\
@@ -152,22 +152,51 @@ class Cfg3DEN {
             };
         };
 
-        class GVAR(EditCodeMulti10_Init): GVAR(EditCodeMulti6_Init) {
-            h = POS_H_GROUP(10);
-
+        class GVAR(EditCodeMulti6_InitGroup): GVAR(EditCodeMulti6) {
             class Controls: Controls {
-                class Background: Background {
-                    h = POS_H_BACKGROUND(10);
-                };
-                class Title: Title {
-                    h = POS_H_TITLE(10);
-                };
+                class Background: Background {};
+                class Title: Title {};
                 class Value: Value {};
-                class GVAR(ValueInit): GVAR(ValueInit) {};
+                class GVAR(ValueInit): GVAR(Value) {
+                    // Copies contents of editable init box into the hidden
+                    // variant and into CBA_Init attribute.
+                    // Automatically adds call-block wrapper to enable
+                    // the usage of local variables and return values.
+                    onKillFocus = QUOTE(\
+                        private _code = ctrlText (_this select 0);\
+                        (ctrlParent (_this select 0) getVariable [ARR_2('GVAR(InitAttributeValue_Group)', controlNull)]) ctrlSetText _code;\
+                        if (_code != '') then {\
+                            _code = 'call{' + _code + '}';\
+                        };\
+                        (ctrlParentControlsGroup (_this select 0) controlsGroupCtrl 100) ctrlSetText _code;\
+                    );
+                };
             };
         };
 
-        class GVAR(InitAttribute): GVAR(EditCodeMulti3) {
+        class GVAR(EditCodeMulti6_InitLogic): GVAR(EditCodeMulti6) {
+            class Controls: Controls {
+                class Background: Background {};
+                class Title: Title {};
+                class Value: Value {};
+                class GVAR(ValueInit): GVAR(Value) {
+                    // Copies contents of editable init box into the hidden
+                    // variant and into CBA_Init attribute.
+                    // Automatically adds call-block wrapper to enable
+                    // the usage of local variables and return values.
+                    onKillFocus = QUOTE(\
+                        private _code = ctrlText (_this select 0);\
+                        (ctrlParent (_this select 0) getVariable [ARR_2('GVAR(InitAttributeValue_Logic)', controlNull)]) ctrlSetText _code;\
+                        if (_code != '') then {\
+                            _code = 'call{' + _code + '}';\
+                        };\
+                        (ctrlParentControlsGroup (_this select 0) controlsGroupCtrl 100) ctrlSetText _code;\
+                    );
+                };
+            };
+        };
+
+        class GVAR(InitAttribute_Object): GVAR(EditCodeMulti3) {
             h = 0;
 
             class Controls: Controls {
@@ -175,10 +204,35 @@ class Cfg3DEN {
                 class Title: Title {};
                 class Value: Value {
                     onLoad = QUOTE(\
-                        ctrlParent (_this select 0) setVariable [ARR_2('GVAR(InitAttributeValue)', _this select 0)];\
+                        ctrlParent (_this select 0) setVariable [ARR_2('GVAR(InitAttributeValue_Object)', _this select 0)];\
                         (_this select 0) ctrlEnable false;\
                     );
-                    h = 0;
+                };
+            };
+        };
+
+        class GVAR(InitAttribute_Group): GVAR(InitAttribute_Object) {
+            class Controls: Controls {
+                class Background: Background {};
+                class Title: Title {};
+                class Value: Value {
+                    onLoad = QUOTE(\
+                        ctrlParent (_this select 0) setVariable [ARR_2('GVAR(InitAttributeValue_Group)', _this select 0)];\
+                        (_this select 0) ctrlEnable false;\
+                    );
+                };
+            };
+        };
+
+        class GVAR(InitAttribute_Logic): GVAR(InitAttribute_Object) {
+            class Controls: Controls {
+                class Background: Background {};
+                class Title: Title {};
+                class Value: Value {
+                    onLoad = QUOTE(\
+                        ctrlParent (_this select 0) setVariable [ARR_2('GVAR(InitAttributeValue_Logic)', _this select 0)];\
+                        (_this select 0) ctrlEnable false;\
+                    );
                 };
             };
         };
@@ -189,10 +243,10 @@ class Cfg3DEN {
             class Init {
                 class Attributes {
                     class Init {
-                        control = QGVAR(EditCodeMulti10_Init);
+                        control = QGVAR(EditCodeMulti10_InitObject);
                     };
                     class CBA_Init {
-                        control = QGVAR(InitAttribute);
+                        control = QGVAR(InitAttribute_Object);
                         property = "CBA_Init";
                         expression = "_this setVariable ['%s', _value, true];";
                         defaultValue = "''";
@@ -207,7 +261,13 @@ class Cfg3DEN {
             class Init {
                 class Attributes {
                     class Init {
-                        control = QGVAR(EditCodeMulti6_Init);
+                        control = QGVAR(EditCodeMulti6_InitGroup);
+                    };
+                    class CBA_Init {
+                        control = QGVAR(InitAttribute_Group);
+                        property = "CBA_Init";
+                        expression = "_this setVariable ['%s', _value, true];";
+                        defaultValue = "''";
                     };
                     class Callsign {
                         expression = "[_this, _value] call CBA_fnc_setCallsign";
@@ -255,10 +315,10 @@ class Cfg3DEN {
             class Init {
                 class Attributes {
                     class Init {
-                        control = QGVAR(EditCodeMulti6_Init);
+                        control = QGVAR(EditCodeMulti6_InitLogic);
                     };
                     class CBA_Init {
-                        control = QGVAR(InitAttribute);
+                        control = QGVAR(InitAttribute_Logic);
                         property = "CBA_Init";
                         expression = "_this setVariable ['%s', _value, true];";
                         defaultValue = "''";

--- a/addons/common/Cfg3DEN.hpp
+++ b/addons/common/Cfg3DEN.hpp
@@ -168,6 +168,8 @@ class Cfg3DEN {
         };
 
         class GVAR(InitAttribute): GVAR(EditCodeMulti3) {
+            h = 0;
+
             class Controls: Controls {
                 class Background: Background {};
                 class Title: Title {};


### PR DESCRIPTION
This attribute holds the code of Init box as an string

**When merged this pull request will:**
- title
- editor attribute with content of `Init` box as string

ToDo:
- [x] Objects
- [x] Groups
- [x] Logics

I was unsure how to name the controls.