### PR TITLE
Settings - Fix localized category duplicating

### DIFF
--- a/addons/settings/fnc_export.sqf
+++ b/addons/settings/fnc_export.sqf
@@ -38,10 +38,6 @@ private _temp = [];
 
     (GVAR(default) getVariable _setting) params ["_defaultValue", "", "", "", "_category"];
 
-    if (isLocalized _category) then {
-        _category = localize _category;
-    };
-
     if (_exportDefault || {
         !(_value isEqualTo _defaultValue) ||
         SANITIZE_PRIORITY(_setting,_priority,_source) > SANITIZE_PRIORITY(_setting,0,_source)

--- a/addons/settings/fnc_init.sqf
+++ b/addons/settings/fnc_init.sqf
@@ -74,6 +74,9 @@ if (_category isEqualTo "") exitWith {
     WARNING_1("Empty menu category for setting %1",_setting);
     1
 };
+if (isLocalized _category) then {
+    _category = localize _category;
+};
 
 // --- setting title and tooltip
 _title params [["_displayName", "", [""]], ["_tooltip", "", [""]]];

--- a/addons/settings/fnc_initDisplayGameOptions.sqf
+++ b/addons/settings/fnc_initDisplayGameOptions.sqf
@@ -82,12 +82,7 @@ private _categories = [];
     (GVAR(default) getVariable _x) params ["", "", "", "", "_category"];
 
     if !(_category in _categories) then {
-        private _categoryLocalized = _category;
-        if (isLocalized _category) then {
-            _categoryLocalized = localize _category;
-        };
-
-        private _index = _ctrlAddonList lbAdd _categoryLocalized;
+        private _index = _ctrlAddonList lbAdd _category;
         _ctrlAddonList lbSetData [_index, str _index];
         _display setVariable [str _index, _category];
 


### PR DESCRIPTION
**When merged this pull request will:**
- title.

Settings support both localized and non-localized category. If add one setting with localized string and other with non-localized (but same when both are localized), there will be 2 same categories in addon list. This PR fixes it.