### PR TITLE
Add CBA_fnc_canAddItem

### DIFF
--- a/addons/common/CfgFunctions.hpp
+++ b/addons/common/CfgFunctions.hpp
@@ -78,6 +78,7 @@ class CfgFunctions {
             PATHTO_FNC(addBinocularMagazine);
             PATHTO_FNC(removeBinocularMagazine);
             PATHTO_FNC(randomizeFacewear);
+            PATHTO_FNC(unitHasSpace);
         };
 
         class Cargo {

--- a/addons/common/CfgFunctions.hpp
+++ b/addons/common/CfgFunctions.hpp
@@ -78,7 +78,7 @@ class CfgFunctions {
             PATHTO_FNC(addBinocularMagazine);
             PATHTO_FNC(removeBinocularMagazine);
             PATHTO_FNC(randomizeFacewear);
-            PATHTO_FNC(unitHasSpace);
+            PATHTO_FNC(canAddItem);
         };
 
         class Cargo {

--- a/addons/common/fnc_canAddItem.sqf
+++ b/addons/common/fnc_canAddItem.sqf
@@ -38,7 +38,7 @@ params [
     ["_checkBackpack", true, [false]]
 ];
 
-if (_unit isEqualTo objNull || {_item isEqualTo ""}) exitWith {false};
+if (isNull _unit || {_item isEqualTo ""}) exitWith {false};
 
 #define TYPE_VEST 701
 #define TYPE_UNIFORM 801

--- a/addons/common/fnc_canAddItem.sqf
+++ b/addons/common/fnc_canAddItem.sqf
@@ -100,9 +100,12 @@ if (
     _checkUniform
     && {TYPE_UNIFORM in _allowedSlots}
     && {
-        // each time subtract whole number of items which can be put in container
-        _count = _count - floor (getContainerMaxLoad uniform _unit * (1 - loadUniform _unit) / _mass);
-        _count <= 0
+        _mass == 0
+        || {
+            // each time subtract whole number of items which can be put in container
+            _count = _count - floor (getContainerMaxLoad uniform _unit * (1 - loadUniform _unit) / _mass);
+            _count <= 0
+        }
     }
 ) exitWith {true};
 
@@ -110,8 +113,11 @@ if (
     _checkVest
     && {TYPE_VEST in _allowedSlots}
     && {
-        _count = _count - floor (getContainerMaxLoad vest _unit * (1 - loadVest _unit) / _mass);
-        _count <= 0
+        _mass == 0
+        || {
+            _count = _count - floor (getContainerMaxLoad vest _unit * (1 - loadVest _unit) / _mass);
+            _count <= 0
+        }
     }
 ) exitWith {true};
 
@@ -119,8 +125,11 @@ if (
     _checkBackpack
     && {TYPE_BACKPACK in _allowedSlots}
     && {
-        _count = _count - floor (getContainerMaxLoad backpack _unit * (1 - loadBackpack _unit) / _mass);
-        _count <= 0
+        _mass == 0
+        || {
+            _count = _count - floor (getContainerMaxLoad backpack _unit * (1 - loadBackpack _unit) / _mass);
+            _count <= 0
+        }
     }
 ) exitWith {true};
 

--- a/addons/common/fnc_canAddItem.sqf
+++ b/addons/common/fnc_canAddItem.sqf
@@ -100,8 +100,9 @@ if (
     _checkUniform
     && {TYPE_UNIFORM in _allowedSlots}
     && {
-        private _maxLoad = getContainerMaxLoad uniform _unit;
-        _maxLoad >= _mass * _count + _maxLoad * loadUniform _unit
+        // each time subtract whole number of items which can be put in container
+        _count = _count - floor (getContainerMaxLoad uniform _unit * (1 - loadUniform _unit) / _mass);
+        _count <= 0
     }
 ) exitWith {true};
 
@@ -109,8 +110,8 @@ if (
     _checkVest
     && {TYPE_VEST in _allowedSlots}
     && {
-        private _maxLoad = getContainerMaxLoad vest _unit;
-        _maxLoad >= _mass * _count + _maxLoad * loadVest _unit
+        _count = _count - floor (getContainerMaxLoad vest _unit * (1 - loadVest _unit) / _mass);
+        _count <= 0
     }
 ) exitWith {true};
 
@@ -118,8 +119,8 @@ if (
     _checkBackpack
     && {TYPE_BACKPACK in _allowedSlots}
     && {
-        private _maxLoad = getContainerMaxLoad backpack _unit;
-        _maxLoad >= _mass * _count + _maxLoad * loadBackpack _unit
+        _count = _count - floor (getContainerMaxLoad backpack _unit * (1 - loadBackpack _unit) / _mass);
+        _count <= 0
     }
 ) exitWith {true};
 

--- a/addons/common/fnc_canAddItem.sqf
+++ b/addons/common/fnc_canAddItem.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 /* ----------------------------------------------------------------------------
-Function: CBA_fnc_unitHasSpace
+Function: CBA_fnc_canAddItem
 
 Description:
     Checks if unit has enough free space in inventory to store item.
@@ -20,14 +20,14 @@ Returns:
 
 Examples:
     (begin example)
-        [player, "acc_flashlight"] call CBA_fnc_unitHasSpace
-        [player, "30Rnd_556x45_Stanag", 7, false, true, false] call CBA_fnc_unitHasSpace
+        [player, "acc_flashlight"] call CBA_fnc_canAddItem
+        [player, "30Rnd_556x45_Stanag", 7, false, true, false] call CBA_fnc_canAddItem
     (end)
 
 Author:
     Dystopian
 ---------------------------------------------------------------------------- */
-SCRIPT(unitHasSpace);
+SCRIPT(canAddItem);
 
 params [
     ["_unit", objNull, [objNull]],

--- a/addons/common/fnc_unitHasSpace.sqf
+++ b/addons/common/fnc_unitHasSpace.sqf
@@ -47,14 +47,9 @@ if (isNil QGVAR(itemMassAllowedSlots)) then {
     GVAR(itemMassAllowedSlots) = [] call CBA_fnc_createNamespace;
 };
 
-private ["_mass", "_allowedSlots"];
-private _itemMassAllowedSlots = GVAR(itemMassAllowedSlots) getVariable _item;
+(GVAR(itemMassAllowedSlots) getVariable [_item, []]) params ["_mass", "_allowedSlots"];
 
-if (!isNil "_itemMassAllowedSlots") then {
-    _mass = _itemMassAllowedSlots # 0;
-    _allowedSlots = _itemMassAllowedSlots # 1;
-    TRACE_3("cache found",_item,_mass,_allowedSlots);
-} else {
+if (isNil "_mass") then {
     _allowedSlots = [TYPE_UNIFORM, TYPE_VEST, TYPE_BACKPACK];
     private _cfgWeaponsItem = configFile >> "CfgWeapons" >> _item;
     if (isClass _cfgWeaponsItem) then {
@@ -90,14 +85,14 @@ if (!isNil "_itemMassAllowedSlots") then {
             } else {
                 _mass = -1;
                 _allowedSlots = [];
-            }
+            };
         };
     };
     TRACE_3("caching",_item,_mass,_allowedSlots);
     GVAR(itemMassAllowedSlots) setVariable [_item, [_mass, _allowedSlots]];
 };
 
-if (_mass == -1) exitWith {false};
+if (_mass == -1) exitWith {false}; // item doesn't exist
 
 if (
     _checkUniform

--- a/addons/common/fnc_unitHasSpace.sqf
+++ b/addons/common/fnc_unitHasSpace.sqf
@@ -96,29 +96,29 @@ if (_mass == -1) exitWith {false}; // item doesn't exist
 
 if (
     _checkUniform
+    && {TYPE_UNIFORM in _allowedSlots}
     && {
         private _maxLoad = getContainerMaxLoad uniform _unit;
         _maxLoad >= _mass * _count + _maxLoad * loadUniform _unit
     }
-    && {TYPE_UNIFORM in _allowedSlots}
 ) exitWith {true};
 
 if (
     _checkVest
+    && {TYPE_VEST in _allowedSlots}
     && {
         private _maxLoad = getContainerMaxLoad vest _unit;
         _maxLoad >= _mass * _count + _maxLoad * loadVest _unit
     }
-    && {TYPE_VEST in _allowedSlots}
 ) exitWith {true};
 
 if (
     _checkBackpack
+    && {TYPE_BACKPACK in _allowedSlots}
     && {
         private _maxLoad = getContainerMaxLoad backpack _unit;
         _maxLoad >= _mass * _count + _maxLoad * loadBackpack _unit
     }
-    && {TYPE_BACKPACK in _allowedSlots}
 ) exitWith {true};
 
 false

--- a/addons/common/fnc_unitHasSpace.sqf
+++ b/addons/common/fnc_unitHasSpace.sqf
@@ -1,0 +1,129 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_unitHasSpace
+
+Description:
+    Checks if unit has enough free space in inventory to store item.
+
+    Doesn't take current unit load into account unlike canAdd command.
+
+Parameters:
+    _unit          - Unit <OBJECT>
+    _item          - Item to store <STRING>
+    _count         - Item count <NUMBER> (Default: 1)
+    _checkUniform  - Check space in uniform <BOOLEAN> (Default: true)
+    _checkVest     - Check space in vest <BOOLEAN> (Default: true)
+    _checkBackpack - Check space in backpack <BOOLEAN> (Default: true)
+
+Returns:
+    True if unit has free space, false otherwise <BOOLEAN>
+
+Examples:
+    (begin example)
+        [player, "acc_flashlight"] call CBA_fnc_unitHasSpace
+        [player, "30Rnd_556x45_Stanag", 7, false, true, false] call CBA_fnc_unitHasSpace
+    (end)
+
+Author:
+    Dystopian
+---------------------------------------------------------------------------- */
+SCRIPT(unitHasSpace);
+
+params [
+    "_unit",
+    "_item",
+    ["_count", 1],
+    ["_checkUniform", true],
+    ["_checkVest", true],
+    ["_checkBackpack", true]
+];
+
+#define TYPE_VEST 701
+#define TYPE_UNIFORM 801
+#define TYPE_BACKPACK 901
+
+if (isNil QGVAR(itemMassAllowedSlots)) then {
+    LOG("create ns");
+    GVAR(itemMassAllowedSlots) = [] call CBA_fnc_createNamespace;
+};
+
+private ["_mass", "_allowedSlots"];
+private _itemMassAllowedSlots = GVAR(itemMassAllowedSlots) getVariable _item;
+
+if (!isNil "_itemMassAllowedSlots") then {
+    _mass = _itemMassAllowedSlots # 0;
+    _allowedSlots = _itemMassAllowedSlots # 1;
+    TRACE_3("cache found",_item,_mass,_allowedSlots);
+} else {
+    _allowedSlots = [TYPE_UNIFORM, TYPE_VEST, TYPE_BACKPACK];
+    private _cfgWeaponsItem = configFile >> "CfgWeapons" >> _item;
+    if (isClass _cfgWeaponsItem) then {
+        private _cfgItemInfo = _cfgWeaponsItem >> "ItemInfo";
+        private _cfgWeaponSlotsInfo = _cfgWeaponsItem >> "WeaponSlotsInfo";
+        if (isNumber (_cfgItemInfo >> "mass")) then {
+            _mass = getNumber (_cfgItemInfo >> "mass");
+        } else {
+            _mass = getNumber (_cfgWeaponSlotsInfo >> "mass");
+        };
+
+        {
+            if (isArray _x) exitWith {
+                _allowedSlots = getArray _x;
+            };
+        } forEach [
+            _cfgWeaponsItem >> "allowedSlots",
+            _cfgItemInfo >> "allowedSlots",
+            _cfgWeaponSlotsInfo >> "allowedSlots"
+        ];
+    } else {
+        private _cfgMagazinesItem = configFile >> "CfgMagazines" >> _item;
+        if (isClass _cfgMagazinesItem) then {
+            _mass = getNumber (_cfgMagazinesItem >> "mass");
+            private _cfgAllowedSlots = _cfgMagazinesItem >> "allowedSlots";
+            if (isArray _cfgAllowedSlots) then {
+                _allowedSlots = getArray _cfgAllowedSlots;
+            };
+        } else {
+            private _cfgGlassesItem = configFile >> "CfgGlasses" >> _item;
+            if (isClass _cfgGlassesItem) then {
+                _mass = getNumber (_cfgGlassesItem >> "mass");
+            } else {
+                _mass = -1;
+                _allowedSlots = [];
+            }
+        };
+    };
+    TRACE_3("caching",_item,_mass,_allowedSlots);
+    GVAR(itemMassAllowedSlots) setVariable [_item, [_mass, _allowedSlots]];
+};
+
+if (_mass == -1) exitWith {false};
+
+if (
+    _checkUniform
+    && {
+        private _maxLoad = getContainerMaxLoad uniform _unit;
+        _maxLoad >= _mass * _count + _maxLoad * loadUniform _unit
+    }
+    && {TYPE_UNIFORM in _allowedSlots}
+) exitWith {true};
+
+if (
+    _checkVest
+    && {
+        private _maxLoad = getContainerMaxLoad vest _unit;
+        _maxLoad >= _mass * _count + _maxLoad * loadVest _unit
+    }
+    && {TYPE_VEST in _allowedSlots}
+) exitWith {true};
+
+if (
+    _checkBackpack
+    && {
+        private _maxLoad = getContainerMaxLoad backpack _unit;
+        _maxLoad >= _mass * _count + _maxLoad * loadBackpack _unit
+    }
+    && {TYPE_BACKPACK in _allowedSlots}
+) exitWith {true};
+
+false

--- a/addons/common/fnc_unitHasSpace.sqf
+++ b/addons/common/fnc_unitHasSpace.sqf
@@ -43,7 +43,6 @@ params [
 #define TYPE_BACKPACK 901
 
 if (isNil QGVAR(itemMassAllowedSlots)) then {
-    LOG("create ns");
     GVAR(itemMassAllowedSlots) = [] call CBA_fnc_createNamespace;
 };
 
@@ -52,40 +51,41 @@ if (isNil QGVAR(itemMassAllowedSlots)) then {
 if (isNil "_mass") then {
     _allowedSlots = [TYPE_UNIFORM, TYPE_VEST, TYPE_BACKPACK];
     private _cfgWeaponsItem = configFile >> "CfgWeapons" >> _item;
-    if (isClass _cfgWeaponsItem) then {
-        private _cfgItemInfo = _cfgWeaponsItem >> "ItemInfo";
-        private _cfgWeaponSlotsInfo = _cfgWeaponsItem >> "WeaponSlotsInfo";
-        if (isNumber (_cfgItemInfo >> "mass")) then {
-            _mass = getNumber (_cfgItemInfo >> "mass");
-        } else {
-            _mass = getNumber (_cfgWeaponSlotsInfo >> "mass");
-        };
-
-        {
-            if (isArray _x) exitWith {
-                _allowedSlots = getArray _x;
+    private _cfgMagazinesItem = configFile >> "CfgMagazines" >> _item;
+    private _cfgGlassesItem = configFile >> "CfgGlasses" >> _item;
+    switch true do {
+        case (isClass _cfgWeaponsItem): {
+            private _cfgItemInfo = _cfgWeaponsItem >> "ItemInfo";
+            private _cfgWeaponSlotsInfo = _cfgWeaponsItem >> "WeaponSlotsInfo";
+            if (isNumber (_cfgItemInfo >> "mass")) then {
+                _mass = getNumber (_cfgItemInfo >> "mass");
+            } else {
+                _mass = getNumber (_cfgWeaponSlotsInfo >> "mass");
             };
-        } forEach [
-            _cfgWeaponsItem >> "allowedSlots",
-            _cfgItemInfo >> "allowedSlots",
-            _cfgWeaponSlotsInfo >> "allowedSlots"
-        ];
-    } else {
-        private _cfgMagazinesItem = configFile >> "CfgMagazines" >> _item;
-        if (isClass _cfgMagazinesItem) then {
+
+            {
+                if (isArray _x) exitWith {
+                    _allowedSlots = getArray _x;
+                };
+            } forEach [
+                _cfgWeaponsItem >> "allowedSlots",
+                _cfgItemInfo >> "allowedSlots",
+                _cfgWeaponSlotsInfo >> "allowedSlots"
+            ];
+        };
+        case (isClass _cfgMagazinesItem): {
             _mass = getNumber (_cfgMagazinesItem >> "mass");
             private _cfgAllowedSlots = _cfgMagazinesItem >> "allowedSlots";
             if (isArray _cfgAllowedSlots) then {
                 _allowedSlots = getArray _cfgAllowedSlots;
             };
-        } else {
-            private _cfgGlassesItem = configFile >> "CfgGlasses" >> _item;
-            if (isClass _cfgGlassesItem) then {
-                _mass = getNumber (_cfgGlassesItem >> "mass");
-            } else {
-                _mass = -1;
-                _allowedSlots = [];
-            };
+        };
+        case (isClass _cfgGlassesItem): {
+            _mass = getNumber (_cfgGlassesItem >> "mass");
+        };
+        default {
+            _mass = -1;
+            _allowedSlots = [];
         };
     };
     TRACE_3("caching",_item,_mass,_allowedSlots);

--- a/addons/common/fnc_unitHasSpace.sqf
+++ b/addons/common/fnc_unitHasSpace.sqf
@@ -30,13 +30,15 @@ Author:
 SCRIPT(unitHasSpace);
 
 params [
-    "_unit",
-    "_item",
-    ["_count", 1],
-    ["_checkUniform", true],
-    ["_checkVest", true],
-    ["_checkBackpack", true]
+    ["_unit", objNull, [objNull]],
+    ["_item", "", [""]],
+    ["_count", 1, [0]],
+    ["_checkUniform", true, [false]],
+    ["_checkVest", true, [false]],
+    ["_checkBackpack", true, [false]]
 ];
+
+if (_unit isEqualTo objNull || {_item isEqualTo ""}) exitWith {false};
 
 #define TYPE_VEST 701
 #define TYPE_UNIFORM 801


### PR DESCRIPTION
**When merged this pull request will:**
- add function for checking if unit has enough free space in inventory to store item.

`canAdd*` commands can return `false` even if there is free space in unit inventory (see [this ticket](https://feedback.bistudio.com/T120627) and other about `canAdd`). These commands take current unit load into account. Sometimes we don't need to check unit load e.g. when taking out ACE Earplugs or weapon accessories.

As usually function and variables names are subject to discuss.