### PR TITLE
Add time getter parameter to fnc_waitAndExecute

### DIFF
--- a/addons/common/CfgFunctions.hpp
+++ b/addons/common/CfgFunctions.hpp
@@ -128,6 +128,7 @@ class CfgFunctions {
             PATHTO_FNC(execNextFrame);
             PATHTO_FNC(waitAndExecute);
             PATHTO_FNC(waitUntilAndExecute);
+            PATHTO_FNC(initWaitAndExecPFH);
             PATHTO_FNC(compileFinal);
         };
 

--- a/addons/common/fnc_initWaitAndExecPFH.sqf
+++ b/addons/common/fnc_initWaitAndExecPFH.sqf
@@ -1,0 +1,49 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Internal Function: CBA_fnc_initWaitAndExecPFH
+
+Description:
+    Initialises a PFH observing a queue of a certain command type
+
+Parameters:
+    _command - Array that defines the action, as used in addAction command [Array]
+    _inverse - Whether to inverse the conditions and sorting order. [Boolean]
+
+Returns:
+    Created PFH handle [Number]
+
+Example:
+    (begin example)
+        _handle = ["diag_tickTime",false] call CBA_fnc_initWaitAndExecPFH;
+    (end)
+
+Author:
+    Freddo
+
+---------------------------------------------------------------------------- */
+
+params [["_command","diag_tickTime",[""]],["_inverse",false,[true]]];
+
+LOG_2("Registering waitAndExecPFH for command", _command, _inverse);
+
+private _handle = [compile format [QUOTE(                                                      \
+    if (!GVAR(TRIPLES(waitAndExec,%1,ArrayIsSorted))) then {                                   \
+        GVAR(TRIPLES(waitAndExec,%1,Array)) sort %3;                                           \
+        GVAR(TRIPLES(waitAndExec,%1,ArrayIsSorted)) = true;                                    \
+    };                                                                                         \
+    private _delete = false;                                                                   \
+    {                                                                                          \
+        if (_x select 0 %2 %1) exitWith {};                                                    \
+                                                                                               \
+        (_x select 2) call (_x select 1);                                                      \
+                                                                                               \
+        GVAR(TRIPLES(waitAndExec,%1,Array)) set [ARR_2(_forEachIndex, objNull)];               \
+        _delete = true;                                                                        \
+    } forEach GVAR(TRIPLES(waitAndExec,%1,Array));                                             \
+    if (_delete) then {                                                                        \
+        GVAR(TRIPLES(waitAndExec,%1,Array)) = GVAR(TRIPLES(waitAndExec,%1,Array)) - [objNull]; \
+        _delete = false;                                                                       \
+    };                                                                                         \
+),_command, [">","<"] select _inverse, !_inverse]] call CBA_fnc_addPerFrameHandler;
+
+_handle

--- a/addons/common/fnc_initWaitAndExecPFH.sqf
+++ b/addons/common/fnc_initWaitAndExecPFH.sqf
@@ -6,7 +6,8 @@ Description:
     Initialises a PFH observing a queue of a certain command type
 
 Parameters:
-    _command - Array that defines the action, as used in addAction command [Array]
+    _queue   - Which queue this function will be assigned to [String]
+    _command - Command evaluated to get the current value [String]
     _inverse - Whether to inverse the conditions and sorting order. [Boolean]
 
 Returns:
@@ -14,7 +15,7 @@ Returns:
 
 Example:
     (begin example)
-        _handle = ["diag_tickTime",false] call CBA_fnc_initWaitAndExecPFH;
+        _handle = ["_queue","diag_tickTime",false] call CBA_fnc_initWaitAndExecPFH;
     (end)
 
 Author:
@@ -22,7 +23,7 @@ Author:
 
 ---------------------------------------------------------------------------- */
 
-params [["_command","diag_tickTime",[""]],["_inverse",false,[true]]];
+params [["_queue","diag_tickTime",[""]]["_command","diag_tickTime",[""]],["_inverse",false,[true]]];
 
 LOG_2("Registering waitAndExecPFH for command", _command, _inverse);
 
@@ -33,7 +34,7 @@ private _handle = [compile format [QUOTE(                                       
     };                                                                                         \
     private _delete = false;                                                                   \
     {                                                                                          \
-        if (_x select 0 %2 %1) exitWith {};                                                    \
+        if (_x select 0 %3 (%2)) exitWith {};                                                    \
                                                                                                \
         (_x select 2) call (_x select 1);                                                      \
                                                                                                \
@@ -44,6 +45,6 @@ private _handle = [compile format [QUOTE(                                       
         GVAR(TRIPLES(waitAndExec,%1,Array)) = GVAR(TRIPLES(waitAndExec,%1,Array)) - [objNull]; \
         _delete = false;                                                                       \
     };                                                                                         \
-),_command, [">","<"] select _inverse, !_inverse]] call CBA_fnc_addPerFrameHandler;
+),_queue,_command, [">","<"] select _inverse, !_inverse]] call CBA_fnc_addPerFrameHandler;
 
 _handle

--- a/addons/common/fnc_initWaitAndExecPFH.sqf
+++ b/addons/common/fnc_initWaitAndExecPFH.sqf
@@ -23,18 +23,18 @@ Author:
 
 ---------------------------------------------------------------------------- */
 
-params [["_queue","diag_tickTime",[""]]["_command","diag_tickTime",[""]],["_inverse",false,[true]]];
+params [["_queue","diag_tickTime",[""]],["_command","diag_tickTime",[""]],["_inverse",false,[true]]];
 
 LOG_2("Registering waitAndExecPFH for command", _command, _inverse);
 
 private _handle = [compile format [QUOTE(                                                      \
     if (!GVAR(TRIPLES(waitAndExec,%1,ArrayIsSorted))) then {                                   \
-        GVAR(TRIPLES(waitAndExec,%1,Array)) sort %3;                                           \
+        GVAR(TRIPLES(waitAndExec,%1,Array)) sort %4;                                           \
         GVAR(TRIPLES(waitAndExec,%1,ArrayIsSorted)) = true;                                    \
     };                                                                                         \
     private _delete = false;                                                                   \
     {                                                                                          \
-        if (_x select 0 %3 (%2)) exitWith {};                                                    \
+        if (_x select 0 %3 (%2)) exitWith {};                                                  \
                                                                                                \
         (_x select 2) call (_x select 1);                                                      \
                                                                                                \

--- a/addons/common/fnc_waitAndExecute.sqf
+++ b/addons/common/fnc_waitAndExecute.sqf
@@ -38,6 +38,9 @@ Examples:
         // Does not take new years into account.
         [{player sideChat "1 month later";}, [], 0.1, "dateToNumber"] call CBA_fnc_waitAndExecute;
     (end)
+    (begin example)
+        [{player sideChat "5 units of time later"}, [], ([] call getMyTime) + 5, {[] call getMyTime}] call CBA_fnc_waitAndExecute
+    (end)
 
 Author:
     esteldunedain and PabstMirror, donated from ACE3
@@ -50,12 +53,12 @@ if !(_getter isEqualType {}) then {
             GVAR(waitAndExecArray) pushBack [CBA_missionTime + _delay, _function, _args];
             GVAR(waitAndExecArrayIsSorted) = false;
         };
-        #define CASE(id,command,inverse) case QUOTE(id): {                                                \
-            GVAR(TRIPLES(waitAndExec,id,Array)) pushBack [command + _delay, _function, _args];            \
-            if (isNil QGVAR(TRIPLES(waitAndExec,id,handle))) then {                                       \
-                GVAR(TRIPLES(waitAndExec,id,handle)) = [_getter,inverse] call CBA_fnc_initWaitAndExecPFH; \
-            };                                                                                            \
-        }
+        #define CASE(id,command,inverse) case QUOTE(id): {                                                                 \
+            GVAR(TRIPLES(waitAndExec,id,Array)) pushBack [command + _delay, _function, _args];                             \
+            if (isNil QGVAR(TRIPLES(waitAndExec,id,handle))) then {                                                        \
+                GVAR(TRIPLES(waitAndExec,id,handle)) = [QUOTE(id),QUOTE(command),inverse] call CBA_fnc_initWaitAndExecPFH; \
+            };                                                                                                             \
+        }//;
         CASE(diag_ticktime,diag_tickTime,false);
         CASE(diag_frameno,diag_frameno,false);
         CASE(time,time,false);

--- a/addons/common/fnc_waitAndExecute.sqf
+++ b/addons/common/fnc_waitAndExecute.sqf
@@ -7,12 +7,22 @@ Description:
     Note that unlike PFEH, the delay is in CBA_missionTime not diag_tickTime (will be adjusted for time accl).
 
 Parameters:
-    _function - The function you wish to execute. <CODE>
-    _args     - Parameters passed to the function executing. (optional) <ANY>
-    _delay    - The amount of time in seconds before the code is executed. (optional, default: 0) <NUMBER>
+    _function - The function you wish to execute. [Code]
+    _args     - Parameters passed to the function executing. [Any, defaults to []]
+    _delay    - The amount of time in seconds before the code is executed. [Number, defaults to 0]
+    _getter   - Command evaluated to get the current "time", available options: [String, Code, defaults to "cba_missiontime"]
+                "cba_missiontime"    - Savegame compatible and JIP synced time (Default)
+                "diag_ticktime"      - Real time in seconds spent from the start of the game
+                "diag_frameno"       - Current number of frame displayed.
+                "time"               - Time elapsed since mission start, different for each client.
+                "servertime"         - Time since last server restart, synced every 5 minutes.
+                "getmusicplayedtime" - Elapsed time on current playing music track.
+                "datetonumber"       - Day number / 365.
+                "playerrespawntime"  - Time remaining before respawn. Condition and sorting is inverted here.
+                {Code}               - Custom function for getting time, passed to CBA_fnc_waitUntilAndExecute
 
 Passed Arguments:
-    _this     - Parameters passed by this function. Same as '_args' above. <ANY>
+    _this     - Parameters passed by this function. Same as '_args' above. [Any]
 
 Returns:
     Nothing
@@ -20,6 +30,13 @@ Returns:
 Examples:
     (begin example)
         [{player sideChat format ["5s later! _this: %1", _this];}, ["some","params",1,2,3], 5] call CBA_fnc_waitAndExecute;
+    (end)
+    (begin example)
+        [{player sideChat "5 frames later";}, [], 5, "diag_frameno"] call CBA_fnc_waitAndExecute;
+    (end)
+    (begin example)
+        // Does not take new years into account.
+        [{player sideChat "1 month later";}, [], 0.1, "dateToNumber"] call CBA_fnc_waitAndExecute;
     (end)
 
 Author:
@@ -33,19 +50,19 @@ if !(_getter isEqualType {}) then {
 			GVAR(waitAndExecArray) pushBack [CBA_missionTime + _delay, _function, _args];
 			GVAR(waitAndExecArrayIsSorted) = false;
 		};
-		#define CASE(command,inverse) case QUOTE(command): {                                                   \
-			GVAR(TRIPLES(waitAndExec,command,Array)) pushBack [command + _delay, _function, _args];            \
-			if (isNil QGVAR(TRIPLES(waitAndExec,command,handle))) then {                                       \
-                GVAR(TRIPLES(waitAndExec,command,handle)) = [_getter,inverse] call CBA_fnc_initWaitAndExecPFH; \
-			};                                                                                                 \
+		#define CASE(id,command,inverse) case QUOTE(id): {                                                \
+			GVAR(TRIPLES(waitAndExec,id,Array)) pushBack [command + _delay, _function, _args];            \
+			if (isNil QGVAR(TRIPLES(waitAndExec,id,handle))) then {                                       \
+                GVAR(TRIPLES(waitAndExec,id,handle)) = [_getter,inverse] call CBA_fnc_initWaitAndExecPFH; \
+			};                                                                                            \
 		}
-		CASE(diag_ticktime,false);
-		CASE(diag_frameno,false);
-		CASE(time,false);
-		CASE(servertime,false);
-		CASE(getmusicplayedtime,false);
-		CASE(datetonumber,false);
-        CASE(playerrespawntime,true);
+		CASE(diag_ticktime,diag_tickTime,false);
+		CASE(diag_frameno,diag_frameno,false);
+		CASE(time,time,false);
+		CASE(servertime,servertime,false);
+		CASE(getmusicplayedtime,getmusicplayedtime,false);
+		CASE(datetonumber,(datetonumber date),false);
+        CASE(playerrespawntime,playerrespawntime,true);
 	};
 } else {
 	// Scripted getter, convert it to waitUntilAndExecute

--- a/addons/common/fnc_waitAndExecute.sqf
+++ b/addons/common/fnc_waitAndExecute.sqf
@@ -26,7 +26,34 @@ Author:
     esteldunedain and PabstMirror, donated from ACE3
 ---------------------------------------------------------------------------- */
 
-params [["_function", {}, [{}]], ["_args", []], ["_delay", 0, [0]]];
+params [["_function", {}, [{}]], ["_args", []], ["_delay", 0, [0]],["_getter","cba_missiontime",["",{}]]];
+if !(_getter isEqualType {}) then {
+	switch (toLower _getter) do {
+		case "cba_missiontime": {
+			GVAR(waitAndExecArray) pushBack [CBA_missionTime + _delay, _function, _args];
+			GVAR(waitAndExecArrayIsSorted) = false;
+		};
+		#define CASE(command,inverse) case QUOTE(command): {                                                   \
+			GVAR(TRIPLES(waitAndExec,command,Array)) pushBack [command + _delay, _function, _args];            \
+			if (isNil QGVAR(TRIPLES(waitAndExec,command,handle))) then {                                       \
+                GVAR(TRIPLES(waitAndExec,command,handle)) = [_getter,inverse] call CBA_fnc_initWaitAndExecPFH; \
+			};                                                                                                 \
+		}
+		CASE(diag_ticktime,false);
+		CASE(diag_frameno,false);
+		CASE(time,false);
+		CASE(servertime,false);
+		CASE(getmusicplayedtime,false);
+		CASE(datetonumber,false);
+        CASE(playerrespawntime,true);
+	};
+} else {
+	// Scripted getter, convert it to waitUntilAndExecute
+	[{
+		([] call _this # 0) > (_this # 1)
+	},{
+		(_this # 2) call (_this # 3);
+	},[_getter, ([] call _getter) + _delay, _args, _function]] call CBA_fnc_waitUntilAndExecute;
+};
 
-GVAR(waitAndExecArray) pushBack [CBA_missionTime + _delay, _function, _args];
-GVAR(waitAndExecArrayIsSorted) = false;
+nil

--- a/addons/common/fnc_waitAndExecute.sqf
+++ b/addons/common/fnc_waitAndExecute.sqf
@@ -45,32 +45,32 @@ Author:
 
 params [["_function", {}, [{}]], ["_args", []], ["_delay", 0, [0]],["_getter","cba_missiontime",["",{}]]];
 if !(_getter isEqualType {}) then {
-	switch (toLower _getter) do {
-		case "cba_missiontime": {
-			GVAR(waitAndExecArray) pushBack [CBA_missionTime + _delay, _function, _args];
-			GVAR(waitAndExecArrayIsSorted) = false;
-		};
-		#define CASE(id,command,inverse) case QUOTE(id): {                                                \
-			GVAR(TRIPLES(waitAndExec,id,Array)) pushBack [command + _delay, _function, _args];            \
-			if (isNil QGVAR(TRIPLES(waitAndExec,id,handle))) then {                                       \
+    switch (toLower _getter) do {
+        case "cba_missiontime": {
+            GVAR(waitAndExecArray) pushBack [CBA_missionTime + _delay, _function, _args];
+            GVAR(waitAndExecArrayIsSorted) = false;
+        };
+        #define CASE(id,command,inverse) case QUOTE(id): {                                                \
+            GVAR(TRIPLES(waitAndExec,id,Array)) pushBack [command + _delay, _function, _args];            \
+            if (isNil QGVAR(TRIPLES(waitAndExec,id,handle))) then {                                       \
                 GVAR(TRIPLES(waitAndExec,id,handle)) = [_getter,inverse] call CBA_fnc_initWaitAndExecPFH; \
-			};                                                                                            \
-		}
-		CASE(diag_ticktime,diag_tickTime,false);
-		CASE(diag_frameno,diag_frameno,false);
-		CASE(time,time,false);
-		CASE(servertime,servertime,false);
-		CASE(getmusicplayedtime,getmusicplayedtime,false);
-		CASE(datetonumber,(datetonumber date),false);
+            };                                                                                            \
+        }
+        CASE(diag_ticktime,diag_tickTime,false);
+        CASE(diag_frameno,diag_frameno,false);
+        CASE(time,time,false);
+        CASE(servertime,servertime,false);
+        CASE(getmusicplayedtime,getmusicplayedtime,false);
+        CASE(datetonumber,(datetonumber date),false);
         CASE(playerrespawntime,playerrespawntime,true);
-	};
+    };
 } else {
-	// Scripted getter, convert it to waitUntilAndExecute
-	[{
-		([] call _this # 0) > (_this # 1)
-	},{
-		(_this # 2) call (_this # 3);
-	},[_getter, ([] call _getter) + _delay, _args, _function]] call CBA_fnc_waitUntilAndExecute;
+    // Scripted getter, convert it to waitUntilAndExecute
+    [{
+        ([] call _this # 0) > (_this # 1)
+    },{
+        (_this # 2) call (_this # 3);
+    },[_getter, ([] call _getter) + _delay, _args, _function]] call CBA_fnc_waitUntilAndExecute;
 };
 
 nil

--- a/addons/common/init_perFrameHandler.sqf
+++ b/addons/common/init_perFrameHandler.sqf
@@ -7,8 +7,23 @@ GVAR(perFrameHandlerArray) = [];
 GVAR(perFrameHandlersToRemove) = [];
 GVAR(lastTickTime) = diag_tickTime;
 
-GVAR(waitAndExecArray) = [];
-GVAR(waitAndExecArrayIsSorted) = false;
+GVAR(waitAndExecArray)                                      = [];
+GVAR(waitAndExecArrayIsSorted)                              = false;
+GVAR(TRIPLES(waitAndExec,diag_ticktime,Array))              = [];
+GVAR(TRIPLES(waitAndExec,diag_ticktime,ArrayIsSorted))      = false;
+GVAR(TRIPLES(waitAndExec,diag_frameno,Array))               = [];
+GVAR(TRIPLES(waitAndExec,diag_frameno,ArrayIsSorted))       = false;
+GVAR(TRIPLES(waitAndExec,time,Array))                       = [];
+GVAR(TRIPLES(waitAndExec,time,ArrayIsSorted))               = false;
+GVAR(TRIPLES(waitAndExec,servertime,Array))                 = [];
+GVAR(TRIPLES(waitAndExec,servertime,ArrayIsSorted))         = false;
+GVAR(TRIPLES(waitAndExec,getmusicplayedtime,Array))         = [];
+GVAR(TRIPLES(waitAndExec,getmusicplayedtime,ArrayIsSorted)) = false;
+GVAR(TRIPLES(waitAndExec,datetonumber,Array))               = [];
+GVAR(TRIPLES(waitAndExec,datetonumber,ArrayIsSorted))       = false;
+GVAR(TRIPLES(waitAndExec,playerrespawntime,Array))          = [];
+GVAR(TRIPLES(waitAndExec,playerrespawntime,ArrayIsSorted))  = false;
+
 GVAR(nextFrameNo) = diag_frameno + 1;
 GVAR(nextFrameBufferA) = [];
 GVAR(nextFrameBufferB) = [];


### PR DESCRIPTION
This allows for other time commands to be checked, such as diag_frameNo, diag_tickTime, dateToNumber, etc.

The main benefit to this is for environments where CBA_missionTime does not tick, such as in editor or while the game is paused where a perFrameHandler would otherwise have to be used.

<details>
<summary>Provided Examples</summary>

```sqf
[{player sideChat "5 frames later";}, [], 5, "diag_frameno"] call CBA_fnc_waitAndExecute;

// Does not take new years into account.
[{player sideChat "1 month later";}, [], 0.1, "dateToNumber"] call CBA_fnc_waitAndExecute;

[{player sideChat "5 units of time later"}, [], ([] call getMyTime) + 5, {[] call getMyTime}] call CBA_fnc_waitAndExecute;
```

</details>

**When merged this pull request will:**
- Allow diag_frameNo, diag_tickTime, dateToNumber, etc to be checked for CBA_fnc_waitAndExecute/waitUntilAndExecute.
- Add a wrapper for CBA_fnc_waitUntilAndExecute for usage with time based commands
