### PR TITLE
Joint Rails - Pistol Pointer slot uses Bipod slot overlay

### DIFF
--- a/addons/jr/jr_classes.hpp
+++ b/addons/jr/jr_classes.hpp
@@ -56,7 +56,7 @@ class asdg_UnderSlot: asdg_SlotInfo { // Base under barrel slot
 class asdg_PistolUnderRail: asdg_SlotInfo { // under rail for handguns
     linkProxy = "\a3\data_f\proxies\weapon_slots\SIDE";
     displayName = "$STR_A3_PointerSlot0";
-    iconPicture = "\a3\weapons_f_mark\Data\UI\attachment_under";
+    iconPicture = "\a3\weapons_f\Data\ui\attachment_side";
     iconPinpoint = "Bottom";
     class compatibleItems {
         acc_flashlight_pistol = 1;


### PR DESCRIPTION
**When merged this pull request will:**
- changes the `asdg_PistolUnderRail` class to use a pointer overlay instead of a bipod overlay

`asdg_PistolUnderRail` is a point attachment slot class, but it uses the glowy bipod overlay:
![https://i.imgur.com/2PbhWM2.jpg](https://i.imgur.com/2PbhWM2.jpg)

Credit Aggr0 with this.