### PR TITLE
Adds edge case check to vectRotate3D

### DIFF
--- a/addons/vectors/fnc_vectRotate3D.sqf
+++ b/addons/vectors/fnc_vectRotate3D.sqf
@@ -28,6 +28,8 @@ Author:
 
 params ["_vector", "_rotationAxis", "_theta"];
 
+if (_theta == 0) exitWith {_vector};
+
 private _normalVector = vectorNormalized _rotationAxis;
 private _sinTheta = sin _theta;
 private _cosTheta = cos _theta;


### PR DESCRIPTION
Intercepts an error if 0 is entered as a theta value, and just returns the vector unchanged.

**When merged this pull request will:**
- Prevent an error when `theta` is zero.
- Return an unchanged vector in vectRotate3D, if `theta` is zero.
