### PR TITLE
hashValues - don't copy arrays

### DIFF
--- a/addons/hashes/fnc_hashKeys.sqf
+++ b/addons/hashes/fnc_hashKeys.sqf
@@ -22,4 +22,4 @@ SCRIPT(hashKeys);
 // -----------------------------------------------------------------------------
 params [["_hash", [[], []], [[]]]];
 
-+(_hash select HASH_KEYS)
+[] + (_hash select HASH_KEYS) // flat-copy

--- a/addons/hashes/fnc_hashValues.sqf
+++ b/addons/hashes/fnc_hashValues.sqf
@@ -22,4 +22,4 @@ SCRIPT(hashValues);
 // -----------------------------------------------------------------------------
 params [["_hash", [[], []], [[]]]];
 
-[]+(_hash select HASH_VALUES)
+ [] + (_hash select HASH_VALUES) // flat-copy

--- a/addons/hashes/fnc_hashValues.sqf
+++ b/addons/hashes/fnc_hashValues.sqf
@@ -22,4 +22,4 @@ SCRIPT(hashValues);
 // -----------------------------------------------------------------------------
 params [["_hash", [[], []], [[]]]];
 
-+(_hash select HASH_VALUES)
+[]+(_hash select HASH_VALUES)

--- a/addons/hashes/test_hashes.sqf
+++ b/addons/hashes/test_hashes.sqf
@@ -129,6 +129,16 @@ TEST_OP(_keys,isEqualTo,[],"hashKeys");
 _keys = [_hash] call CBA_fnc_hashKeys;
 TEST_OP(_keys,isEqualTo,[ARR_3("123","124",125)],"hashKeys");
 
+// Using an array as a key
+_hash = [] call CBA_fnc_hashCreate;
+private _arrayKey = [];
+[_hash, _arrayKey, "whyWouldYouDoThis"] call CBA_fnc_hashSet;
+_keys = [_hash] call CBA_fnc_hashKeys;
+(_keys select 0) pushBack 7;
+TEST_OP(_arrayKey,isEqualTo,[7],"hashKeysDepth");
+_result = [_hash, [7]] call CBA_fnc_hashGet;
+TEST_OP(_result,==,"whyWouldYouDoThis","hashKeysDepth");
+
 // Test CBA_fnc_hashValues
 _hash = [] call CBA_fnc_hashCreate;
 private _values = [_hash] call CBA_fnc_hashValues;

--- a/addons/hashes/test_hashes.sqf
+++ b/addons/hashes/test_hashes.sqf
@@ -18,6 +18,7 @@ TEST_DEFINED("CBA_fnc_hashHasKey","");
 TEST_DEFINED("CBA_fnc_isHash","");
 TEST_DEFINED("CBA_fnc_hashSize","");
 TEST_DEFINED("CBA_fnc_hashKeys","");
+TEST_DEFINED("CBA_fnc_hashValues","");
 
 TEST_FALSE([[]] call CBA_fnc_isHash,"CBA_fnc_isHash");
 _hash = [5, [4], [1], 2]; // Not a real hash.
@@ -127,5 +128,29 @@ TEST_OP(_keys,isEqualTo,[],"hashKeys");
 [_hash, 125, 3] call CBA_fnc_hashSet;
 _keys = [_hash] call CBA_fnc_hashKeys;
 TEST_OP(_keys,isEqualTo,[ARR_3("123","124",125)],"hashKeys");
+
+// Test CBA_fnc_hashValues
+_hash = [] call CBA_fnc_hashCreate;
+private _values = [_hash] call CBA_fnc_hashValues;
+TEST_OP(_values,isEqualTo,[],"hashValues - empty");
+
+[_hash, "a", 1] call CBA_fnc_hashSet;
+[_hash, "b", 2] call CBA_fnc_hashSet;
+_values = [_hash] call CBA_fnc_hashValues;
+TEST_OP(_values,isEqualTo,[ARR_2(1,2)],"hashValues - values");
+
+[_hash, "a"] call CBA_fnc_hashRem;
+_values = [_hash] call CBA_fnc_hashValues;
+TEST_OP(_values,isEqualTo,[2],"hashValues - removed");
+
+_hash = [] call CBA_fnc_hashCreate;
+private _data = [3];
+[_hash, "c", _data] call CBA_fnc_hashSet;
+_values = [_hash] call CBA_fnc_hashValues;
+TEST_OP(_values,isEqualTo,[[3]],"hashValues - array");
+
+_data pushBack [7];
+TEST_OP(_values,isEqualTo,[[ARR_2(3,[7])]],"hashValues - deep array copy");
+
 
 nil;


### PR DESCRIPTION
Co-Authored-By: commy2 <6576312+commy2@users.noreply.github.com>

Without fix it will fail this test case
```
_data pushBack [7];
TEST_OP(_values,isEqualTo,[[ARR_2(3,[7])]],"hashValues - deep array copy");
```

```
[CBA] (hashes) ERROR: Test FAIL x\cba\addons\hashes\test_hashes.sqf:154
             (_values isEqualTo [[3, [7]]])
```

