### PR TITLE
Add Disassembled XEH support

### DIFF
--- a/addons/xeh/script_component.hpp
+++ b/addons/xeh/script_component.hpp
@@ -89,4 +89,5 @@
     "FiredMan", \
     "TurnIn", \
     "TurnOut", \
-    "Deleted"
+    "Deleted", \
+    "Disassembled"

--- a/addons/xeh/script_xeh.hpp
+++ b/addons/xeh/script_xeh.hpp
@@ -54,7 +54,8 @@ reloaded = "call cba_xeh_fnc_reloaded"; \
 firedMan = "call cba_xeh_fnc_firedMan"; \
 turnIn = "call cba_xeh_fnc_turnIn"; \
 turnOut = "call cba_xeh_fnc_turnOut"; \
-deleted = "call cba_xeh_fnc_deleted";
+deleted = "call cba_xeh_fnc_deleted"; \
+disassembled = "call cba_xeh_fnc_disassembled";
 
 /*
    MACRO: DELETE_EVENTHANDLERS


### PR DESCRIPTION
**When merged this pull request will:**
- Add XEH support for new Disassembled EH - https://community.bistudio.com/wiki/Arma_3:_Event_Handlers#Disassembled

Tested:
```sqf
["AllVehicles", "Disassembled", {hint str _this}, true] call CBA_fnc_addClassEventHandler;
```
```cpp
class Extended_Disassembled_EventHandlers {
    class AllVehicles {
        class My_test_eh {
            disassembled = "hint str _this";
        };
    };
};
```