### PR TITLE
XEH - Add support for backpack containers

### DIFF
--- a/addons/xeh/CfgVehicles.hpp
+++ b/addons/xeh/CfgVehicles.hpp
@@ -233,6 +233,9 @@ class CfgVehicles {
     class WeaponHolder: ReammoBox {
         XEH_ENABLED;
     };
+    class Bag_Base: ReammoBox {
+        XEH_ENABLED;
+    };
 
     class ThingX;
     class WeaponHolderSimulated: ThingX {


### PR DESCRIPTION
**When merged this pull request will:**
- add XEH support for backpack containers <details><summary>spoiler</summary>"title"</details>

```cpp
class Extended_InitPost_EventHandlers {
    class Bag_Base {
        Mission_Test = "systemChat str _this; diag_log _this";
    };
};
```

Note however, that the retroactive flag does not seem to pick up already existing backpacks:
```sqf
["Bag_Base", "InitPost", {
    systemChat str _this;
}, nil, nil, true] call CBA_fnc_addClassEventHandler;
```