### PR TITLE
Fix statemachine conditions using global variables

### DIFF
--- a/addons/statemachine/script_component.hpp
+++ b/addons/statemachine/script_component.hpp
@@ -20,7 +20,7 @@
 #define ONSTATEENTERED(var) (var + "_onStateEntered")
 #define ONSTATELEAVING(var) (var + "_onStateLeaving")
 #define GET_FUNCTION(var,cfg) private var = getText (cfg); \
-    if (isNil var) then { \
+    if (isNil var || {!((missionNamespace getVariable var) isEqualType {})}) then { \
         var = compile var; \
     } else { \
         var = missionNamespace getVariable var;\


### PR DESCRIPTION
**When merged this pull request will:**
- Fix conditions using global variables

This was originally intended to directly link condition functions, but global variables, especially from settings, also make a lot of sense.
See also: acemod/ACE3#7998
