### PR TITLE
Tools - Update make.py and build.py for change to mikro

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -9,6 +9,16 @@ MAINPREFIX = "x"
 PREFIX = "cba_"
 ##########################
 
+def tryHemttBuild(projectpath):
+    hemttPath = os.path.join(projectpath, "hemtt.exe")
+    if os.path.isfile(hemttPath):
+        ret = subprocess.check_output([hemttPath, "pack"], stderr=subprocess.STDOUT)
+        print("Using hemtt: {}".format(ret));
+        return True
+    else:
+        print("hemtt not installed");
+    return False
+
 def mod_time(path):
     if not os.path.isdir(path):
         return os.path.getmtime(path)
@@ -39,6 +49,8 @@ def main():
     scriptpath = os.path.realpath(__file__)
     projectpath = os.path.dirname(os.path.dirname(scriptpath))
     addonspath = os.path.join(projectpath, "addons")
+
+    if (tryHemttBuild(projectpath)): return
 
     os.chdir(addonspath)
 

--- a/tools/build.py
+++ b/tools/build.py
@@ -10,9 +10,10 @@ PREFIX = "cba_"
 ##########################
 
 def tryHemttBuild(projectpath):
-    hemttPath = os.path.join(projectpath, "hemtt.exe")
-    if os.path.isfile(hemttPath):
-        ret = subprocess.check_output([hemttPath, "pack"], stderr=subprocess.STDOUT)
+    hemttExe = os.path.join(projectpath, "hemtt.exe")
+    if os.path.isfile(hemttExe):
+        os.chdir(projectpath)
+        ret = subprocess.call([hemttExe, "pack"], stderr=subprocess.STDOUT)
         print("Using hemtt: {}".format(ret));
         return True
     else:

--- a/tools/make.py
+++ b/tools/make.py
@@ -1262,8 +1262,7 @@ See the make.cfg file for additional build options.
 
                     if os.path.isfile(nobinFilePath):
                         print_green("$NOBIN$ Found. Proceeding with non-binarizing!")
-                        # Warning - no longer supported in mikro after late 2020
-                        cmd = [makepboTool, "-P","-A","-N","-X=*.backup", os.path.join(work_drive, prefix, module),os.path.join(module_root, release_dir, project,"addons")]
+                        cmd = [makepboTool, "-P","-A","-X=*.backup", os.path.join(work_drive, prefix, module),os.path.join(module_root, release_dir, project,"addons")]
 
                     else:
                         cmd = [pboproject, "-P", os.path.join(work_drive, prefix, module), "+Engine=Arma3", "-S", "+Noisy", "+Clean", "-Warnings", "+Mod="+os.path.join(module_root, release_dir, project), "-Key"]

--- a/tools/make.py
+++ b/tools/make.py
@@ -1262,10 +1262,11 @@ See the make.cfg file for additional build options.
 
                     if os.path.isfile(nobinFilePath):
                         print_green("$NOBIN$ Found. Proceeding with non-binarizing!")
+                        # Warning - no longer supported in mikro after late 2020
                         cmd = [makepboTool, "-P","-A","-N","-X=*.backup", os.path.join(work_drive, prefix, module),os.path.join(module_root, release_dir, project,"addons")]
 
                     else:
-                        cmd = [pboproject, "-P", os.path.join(work_drive, prefix, module), "+Engine=Arma3", "-S", "+Noisy", "+Clean", "+Mod="+os.path.join(module_root, release_dir, project), "-Key"]
+                        cmd = [pboproject, "-P", os.path.join(work_drive, prefix, module), "+Engine=Arma3", "-S", "+Noisy", "+Clean", "-Warnings", "+Mod="+os.path.join(module_root, release_dir, project), "-Key"]
 
                     color("grey")
                     if quiet:


### PR DESCRIPTION
Based on https://github.com/acemod/ACE3/pull/8049

New tools no longer supports  "What you see is what you get" flag for nobins
but can handle the weird ` scope = "1 + parseNumber isClass (` in ee without error now...