### PR TITLE
Remove outdated unit tests from arrays

### DIFF
--- a/addons/arrays/test_findMax.sqf
+++ b/addons/arrays/test_findMax.sqf
@@ -56,10 +56,6 @@ TEST_TRUE(isNil "_result",_fn);
 _result = [1, "not a number", 3, 4, 5] call CBA_fnc_findMax;
 TEST_TRUE(isNil "_result",_fn);
 
-// Test invalid array given
-_result = "not an array" call CBA_fnc_findMax;
-TEST_TRUE(isNil "_result",_fn);
-
 // Test empty array given
 _result = [] call CBA_fnc_findMax;
 TEST_TRUE(isNil "_result",_fn);

--- a/addons/arrays/test_findMin.sqf
+++ b/addons/arrays/test_findMin.sqf
@@ -55,10 +55,6 @@ TEST_TRUE(isNil "_result",_fn);
 _result = [1, "not a number", 3, 4, 5] call CBA_fnc_findMin;
 TEST_TRUE(isNil "_result",_fn);
 
-// Test invalid array given
-_result = "not an array" call CBA_fnc_findMin;
-TEST_TRUE(isNil "_result",_fn);
-
 // Test empty array given
 _result = [] call CBA_fnc_findMin;
 TEST_TRUE(isNil "_result",_fn);

--- a/addons/arrays/test_findNil.sqf
+++ b/addons/arrays/test_findNil.sqf
@@ -34,9 +34,4 @@ _result = [] call CBA_fnc_findNil;
 _expected = -1;
 TEST_OP(_result,==,_expected,_fn);
 
-// Return a not found when a non array is given
-_result = "not an array" call CBA_fnc_findNil;
-_expected = -1;
-TEST_OP(_result,==,_expected,_fn);
-
 nil;

--- a/addons/arrays/test_findNull.sqf
+++ b/addons/arrays/test_findNull.sqf
@@ -34,9 +34,4 @@ _result = [] call CBA_fnc_findNull;
 _expected = -1;
 TEST_OP(_result,==,_expected,_fn);
 
-// Return a not found when a non array is given
-_result = "not an array" call CBA_fnc_findNull;
-_expected = -1;
-TEST_OP(_result,==,_expected,_fn);
-
 nil;

--- a/addons/arrays/test_findTypeName.sqf
+++ b/addons/arrays/test_findTypeName.sqf
@@ -106,11 +106,6 @@ _result = [[], "STRING"] call CBA_fnc_findTypeName;
 _expected = -1;
 TEST_OP(_result,==,_expected,_fn);
 
-// Return not found if non array is given
-_result = ["not an array", "STRING"] call CBA_fnc_findTypeName;
-_expected = -1;
-TEST_OP(_result,==,_expected,_fn);
-
 // Return not found if parameters are nil
 _result = [nil, nil] call CBA_fnc_findTypeName;
 _expected = -1;

--- a/addons/arrays/test_findTypeOf.sqf
+++ b/addons/arrays/test_findTypeOf.sqf
@@ -43,16 +43,6 @@ _result = [[], typeOf player] call CBA_fnc_findTypeOf;
 _expected = -1;
 TEST_OP(_result,==,_expected,_fn);
 
-// Return not found, when a non array is passed
-_result = ["not an array", typeOf player] call CBA_fnc_findTypeOf;
-_expected = -1;
-TEST_OP(_result,==,_expected,_fn);
-
-// Return not found, when search parameter is not an object or string
-_result = [["", player, 5, objNull], 5] call CBA_fnc_findTypeOf;
-_expected = -1;
-TEST_OP(_result,==,_expected,_fn);
-
 // Return not found, when parameters are nil
 _result = [nil, nil] call CBA_fnc_findTypeOf;
 _expected = -1;

--- a/addons/arrays/test_shuffle.sqf
+++ b/addons/arrays/test_shuffle.sqf
@@ -21,10 +21,6 @@ TEST_OP(count _result,==,count _original,_fn);
     TEST_OP(_x,in,_original,_fn);
 } forEach _result;
 
-_original = [1, 2, 3];
-_result = _original call CBA_fnc_shuffle;
-TEST_OP(count _result,==,1,_fn);
-
 _original = [];
 _result = [_original] call CBA_fnc_shuffle;
 TEST_OP(count _result,==,count _original,_fn);


### PR DESCRIPTION
**When merged this pull request will:**
- Remove unit tests in `arrays` component that pass invalide arguments.
