### PR TITLE
Strings - Fix for formatElapsedTime rounding error

### DIFF
--- a/addons/strings/fnc_formatElapsedTime.sqf
+++ b/addons/strings/fnc_formatElapsedTime.sqf
@@ -39,12 +39,12 @@ _elapsed = switch (_format) do {
         format ["%1:%2:%3",
             _hours,
             [_minutes, 2] call CBA_fnc_formatNumber,
-            [_seconds, 2, 0] call CBA_fnc_formatNumber];
+            [floor _seconds, 2] call CBA_fnc_formatNumber];
     };
     case "M:SS": {
         format ["%1:%2",
             _minutes,
-            [_seconds, 2, 0] call CBA_fnc_formatNumber];
+            [floor _seconds, 2] call CBA_fnc_formatNumber];
     };
     case "H:MM:SS.mmm": {
         format ["%1:%2:%3",


### PR DESCRIPTION
CBA_fnc_formatElapsedTime is sending unrounded seconds to CBA_fnc_formatNumber, which is causing the output string to be half a second off and showing impossible "60" seconds when the input time is decimal (like from "serverTime") and above {n}.5

**When merged this pull request will:**
- Fix the output string to display time from 0 - 59 seconds only, like a clock works.

Before:
systemChat (3599.5 call CBA_fnc_formatElapsedTime); 
Output -> **"0:59:60"**

After:
systemChat (3599.5 call CBA_fnc_formatElapsedTime); 
Output -> **"0:59:59"**