### PR TITLE
Fix Projectile Tracking Heights

### DIFF
--- a/addons/diagnostic/fnc_projectileTracking_drawProjectilePaths.sqf
+++ b/addons/diagnostic/fnc_projectileTracking_drawProjectilePaths.sqf
@@ -52,7 +52,11 @@ for "_index" from 0 to _maxLines do {
                 private _green = _currentSpeed / _startSpeed;
                 private _red = 1 - _green;
 
-                drawLine3D [_currentProjectileData select 0, _nextProjectileData select 0, [_red, _green, 0, 1]];
+                drawLine3D [
+                    ASLToAGL (_currentProjectileData select 0),
+                    ASLToAGL (_nextProjectileData select 0),
+                    [_red, _green, 0, 1]
+                ];
 
             } forEach _projectileData;
         };

--- a/addons/diagnostic/fnc_projectileTracking_handleFired.sqf
+++ b/addons/diagnostic/fnc_projectileTracking_handleFired.sqf
@@ -35,7 +35,7 @@ if (_index <= (count GVAR(projectileData) - 1)) then {
 };
 
 // using 0.1 to improve performance, we don't need that many bullet position to draw a line
-[FUNC(projectileTracking_trackProjectile), 0.1, [_projectile, _index, [(getPos _projectile), vectorMagnitude (velocity _projectile)]]] call CBA_fnc_addPerFrameHandler;
+[FUNC(projectileTracking_trackProjectile), 0.1, [_projectile, _index, [getPosASL _projectile, vectorMagnitude velocity _projectile]]] call CBA_fnc_addPerFrameHandler;
 
 private _maxLines = GVAR(projectileMaxLines) min 20;
 

--- a/addons/diagnostic/fnc_projectileTracking_trackProjectile.sqf
+++ b/addons/diagnostic/fnc_projectileTracking_trackProjectile.sqf
@@ -45,7 +45,7 @@ if (!isNull _projectile) then {
         _data = [_handle, _bulletData];
         GVAR(projectileData) set [_index, _data];
     };
-    _bulletData pushBack [(getPos _projectile), _speed];
+    _bulletData pushBack [getPosASL _projectile, _speed];
 
 } else {
     [_handle] call CBA_fnc_removePerFrameHandler;


### PR DESCRIPTION
**When merged this pull request will:**
- Change `projectileTracking` to store bullet positions as ASL instead of AGLS.
- This makes the tracking record the correct heights while the bullet is above buildings (or other objects with walkable surface).
- This also makes the drawn lines above the sea not wobble with the waves.
- fix #1444

Note Note Note: 
- Storing the positions as AGL is **not** an option. They have to be converted from ASL immediately before the draw command is used (same frame even): Over water, AGL is dependent on the current wave height, which means that the data is only valid at the wave height it was recorded at.

- The big lesson here is to absolutely never use, calculate with or store AGL.