### PR TITLE
Use execVM for all unit tests

### DIFF
--- a/addons/arrays/test.sqf
+++ b/addons/arrays/test.sqf
@@ -13,7 +13,6 @@ SCRIPT(test-arrays);
 LOG("=== Testing Arrays ===");
 
 {
-    call compile preprocessFileLineNumbers format ["\x\cba\addons\arrays\test_%1.sqf", _x];
+    private _test = execVM format ["\x\cba\addons\arrays\test_%1.sqf", _x];
+    waitUntil { scriptDone _test };
 } forEach TESTS;
-
-nil;

--- a/addons/common/test.sqf
+++ b/addons/common/test.sqf
@@ -14,7 +14,6 @@ SCRIPT(test-common);
 LOG("=== Testing Common ===");
 
 {
-    call compile preprocessFileLineNumbers format ["\x\cba\addons\common\test_%1.sqf", _x];
+    private _test = execVM format ["\x\cba\addons\common\test_%1.sqf", _x];
+    waitUntil { scriptDone _test };
 } forEach TESTS;
-
-nil;

--- a/addons/common/test_config.sqf
+++ b/addons/common/test_config.sqf
@@ -1,7 +1,7 @@
 #include "script_component.hpp"
 SCRIPT(test_config);
 
-// 0 spawn compile preprocessFileLineNumbers "\x\cba\addons\common\test_config.sqf";
+// execVM "\x\cba\addons\common\test_config.sqf";
 
 private ["_funcName", "_result"];
 

--- a/addons/common/test_inventory.sqf
+++ b/addons/common/test_inventory.sqf
@@ -1,7 +1,7 @@
 #include "script_component.hpp"
 SCRIPT(test_inventory);
 
-// 0 spawn compile preprocessFileLineNumbers "\x\cba\addons\common\test_inventory.sqf";
+// execVM "\x\cba\addons\common\test_inventory.sqf";
 
 // Note: test requires a player with space in inventory
 

--- a/addons/common/test_ret.sqf
+++ b/addons/common/test_ret.sqf
@@ -1,7 +1,7 @@
 #include "script_component.hpp"
 SCRIPT(test_ret);
 
-// 0 spawn compile preprocessFileLineNumbers "\x\cba\addons\common\test_ret.sqf";
+// execVM "\x\cba\addons\common\test_ret.sqf";
 
 private ["_funcName", "_result"];
 

--- a/addons/common/test_weaponComponents.sqf
+++ b/addons/common/test_weaponComponents.sqf
@@ -1,4 +1,4 @@
-// 0 spawn compile preprocessFileLineNumbers "\x\cba\addons\common\test_weaponComponents.sqf";
+// execVM "\x\cba\addons\common\test_weaponComponents.sqf";
 
 #define LOGF diag_log text format
 #define TESTEXP if (!isNil "_result" && {_result isEqualTo _expected}) then {LOGF ["TEST: OK - %1 result", _result]} else {LOGF ["TEST: FAIL - %1 result; %2 expected", _result, _expected]}

--- a/addons/diagnostic/fnc_test.sqf
+++ b/addons/diagnostic/fnc_test.sqf
@@ -42,8 +42,7 @@ DEFAULT_PARAM(1,_component,"main");
 
 LOG('===== STARTING TESTS =====');
 
-call compile preprocessFileLineNumbers format ["\x\%1\addons\%2\test.sqf", _addon, _component];
+private _test = execVM format ["\x\%1\addons\%2\test.sqf", _addon, _component];
+waitUntil { scriptDone _test };
 
 LOG('===== COMPLETED TESTS =====');
-
-nil;

--- a/addons/diagnostic/test.sqf
+++ b/addons/diagnostic/test.sqf
@@ -14,7 +14,6 @@ SCRIPT(test-diagnostic);
 LOG("=== Testing Diagnostic ===");
 
 {
-    call compile preprocessFileLineNumbers format ["\x\cba\addons\diagnostic\test_%1.sqf", _x];
+    private _test = execVM format ["\x\cba\addons\diagnostic\test_%1.sqf", _x];
+    waitUntil { scriptDone _test };
 } forEach TESTS;
-
-nil;

--- a/addons/events/test.sqf
+++ b/addons/events/test.sqf
@@ -14,7 +14,6 @@ SCRIPT(test-events);
 LOG("=== Testing Events ===");
 
 {
-    0 spawn compile preprocessFileLineNumbers format ["\x\cba\addons\events\test_%1.sqf", _x];
+    private _test = execVM format ["\x\cba\addons\events\test_%1.sqf", _x];
+    waitUntil { scriptDone _test };
 } forEach TESTS;
-
-nil

--- a/addons/hashes/test.sqf
+++ b/addons/hashes/test.sqf
@@ -14,7 +14,6 @@ SCRIPT(test-hashes);
 LOG("=== Testing Hashes ===");
 
 {
-    0 spawn compile preprocessFileLineNumbers format ["\x\cba\addons\hashes\test_%1.sqf", _x];
+    private _test = execVM format ["\x\cba\addons\hashes\test_%1.sqf", _x];
+    waitUntil { scriptDone _test };
 } forEach TESTS;
-
-nil

--- a/addons/jr/test.sqf
+++ b/addons/jr/test.sqf
@@ -14,7 +14,6 @@ SCRIPT(test-jr);
 LOG("=== Testing JR ===");
 
 {
-    call compile preprocessFileLineNumbers format ["\x\cba\addons\jr\test_%1.sqf", _x];
+    private _test = execVM format ["\x\cba\addons\jr\test_%1.sqf", _x];
+    waitUntil { scriptDone _test };
 } forEach TESTS;
-
-nil;

--- a/addons/main/test.sqf
+++ b/addons/main/test.sqf
@@ -14,7 +14,6 @@ SCRIPT(test);
 LOG("===--- Testing ---===");
 
 {
-    call compile preprocessFileLineNumbers format ["\x\cba\addons\%1\test.sqf", _x];
+    private _test = execVM format ["\x\cba\addons\%1\test.sqf", _x];
+    waitUntil { scriptDone _test };
 } forEach CATEGORIES;
-
-nil;

--- a/addons/network/test.sqf
+++ b/addons/network/test.sqf
@@ -14,7 +14,6 @@ SCRIPT(test-network);
 LOG("=== Testing Network ===");
 
 {
-    call compile preprocessFileLineNumbers format ["\x\cba\addons\network\test_%1.sqf", _x];
+    private _test = execVM format ["\x\cba\addons\network\test_%1.sqf", _x];
+    waitUntil { scriptDone _test };
 } forEach TESTS;
-
-nil;

--- a/addons/network/test_network.sqf
+++ b/addons/network/test_network.sqf
@@ -1,7 +1,7 @@
 #include "script_component.hpp"
 SCRIPT(test_network);
 
-// 0 spawn compile preprocessFileLineNumbers "\x\cba\addons\network\test_network.sqf";
+// execVM "\x\cba\addons\network\test_network.sqf";
 // test has to be done with an existing "player" object (not 3den!!)
 
 private ["_funcName", "_result"];

--- a/addons/strings/test.sqf
+++ b/addons/strings/test.sqf
@@ -14,7 +14,6 @@ SCRIPT(test-strings);
 LOG("=== Testing Strings ===");
 
 {
-    call compile preprocessFileLineNumbers format ["\x\cba\addons\strings\test_%1.sqf", _x];
+    private _test = execVM format ["\x\cba\addons\strings\test_%1.sqf", _x];
+    waitUntil { scriptDone _test };
 } forEach TESTS;
-
-nil

--- a/addons/vectors/test.sqf
+++ b/addons/vectors/test.sqf
@@ -14,7 +14,6 @@ SCRIPT(test-vectors);
 LOG("=== Testing Vectors ===");
 
 {
-    call compile preprocessFileLineNumbers format ["\x\cba\addons\vectors\test_%1.sqf", _x];
+    private _test = execVM format ["\x\cba\addons\vectors\test_%1.sqf", _x];
+    waitUntil { scriptDone _test };
 } forEach TESTS;
-
-nil;


### PR DESCRIPTION
**When merged this pull request will:**
- Run as unit tests with execVM instead of call

```sqf
execVM "\x\cba\addons\main\test.sqf"
```

557 Test OK
1 Test FAIL