### PR TITLE
Replace "Community Base Addons -" by "CBA" in the `Network` menu

### DIFF
--- a/addons/network/stringtable.xml
+++ b/addons/network/stringtable.xml
@@ -2,18 +2,18 @@
 <Project name="CBA_A3">
     <Package name="Network">
         <Key ID="STR_CBA_Network_Component">
-            <English>Community Base Addons - Network</English>
-            <German>Community Base Addons - Netzwerk</German>
-            <Japanese>Community Base Addons - ネットワーク</Japanese>
-            <Chinese>社群基礎模組 - 網路</Chinese>
-            <Chinesesimp>社群基础模组 - 网路</Chinesesimp>
-            <Portuguese>Extensões de Base Comunitária - Rede</Portuguese>
-            <Russian>Community Base Addons - Сеть</Russian>
-            <French>Community Base Addons - Réseau</French>
-            <Polish>Community Base Addons - Sieć</Polish>
-            <Turkish>Community Base Addons - Ağ</Turkish>
-            <Italian>Community Base Addons - Rete</Italian>
-            <Czech>Community Base Addons - Síť</Czech>
+            <English>CBA Network</English>
+            <German>CBA Netzwerk</German>
+            <Japanese>CBA ネットワーク</Japanese>
+            <Chinese>CBA 網路</Chinese>
+            <Chinesesimp>CBA 网路</Chinesesimp>
+            <Portuguese>CBA Rede</Portuguese>
+            <Russian>CBA Сеть</Russian>
+            <French>CBA Réseau</French>
+            <Polish>CBA Sieć</Polish>
+            <Turkish>CBA Ağ</Turkish>
+            <Italian>CBA Rete</Italian>
+            <Czech>CBA Síť</Czech>
         </Key>
         <Key ID="STR_CBA_Network_LoadoutValidation">
             <English>Loadout validation</English>


### PR DESCRIPTION
**When merged this pull request will:**
- For better consistency with the rest of the mod, the "Community Base Addons -" prefix has been replaced by "CBA" for the Network menu.

As a reminder, here is the current appearance, before modification :
![CBA_network_menu](https://user-images.githubusercontent.com/22501336/119210689-df190700-baad-11eb-9cc7-0d26ffc21711.png)
