### PR TITLE
Lobby Manager - Always use maximum available space for warning label

### DIFF
--- a/addons/ui/LobbyManager.hpp
+++ b/addons/ui/LobbyManager.hpp
@@ -99,6 +99,7 @@ class GVAR(LobbyManager) {
             idc = IDC_LM_WARNING;
             x = (getResolution select 2) * 0.5 * pixelW - (140/2) * GRID_3DEN_W;
             y = 0.5 + (120/2 - 10 - 1) * GRID_3DEN_H;
+            w = 87 * GRID_3DEN_W;
             h = 5 * GRID_3DEN_H;
         };
         class ButtonOK: ctrlButtonOK {

--- a/addons/ui/fnc_openLobbyManager.sqf
+++ b/addons/ui/fnc_openLobbyManager.sqf
@@ -28,8 +28,6 @@ private _display = _display3DEN createDisplay QGVAR(LobbyManager);
 // Initialize warning label
 private _ctrlWarning = _display displayCtrl IDC_LM_WARNING;
 _ctrlWarning ctrlSetStructuredText parseText format ["<img image='%1'/><t> %2</t>", ICON_WARNING, LLSTRING(LobbyManager_Warning)];
-_ctrlWarning ctrlSetPositionW ctrlTextWidth _ctrlWarning;
-_ctrlWarning ctrlCommit 0;
 
 private _ctrlSlots = _display displayCtrl IDC_LM_SLOTS;
 


### PR DESCRIPTION
**When merged this pull request will:**
- title.
- As reported by @Elgin675 on ACE Slack, text could get cut off sometimes.
