### PR TITLE
Consolidate settings into a single category

### DIFF
--- a/addons/diagnostic/initSettings.sqf
+++ b/addons/diagnostic/initSettings.sqf
@@ -2,7 +2,7 @@
 [
     QGVAR(ConsoleIndentType), "LIST",
     [LLSTRING(ConsoleIndentType), LLSTRING(ConsoleIndentTypeTooltip)],
-    LELSTRING(Ui,Category),
+    [LELSTRING(main,DisplayName), LELSTRING(UI,Category)],
     [
         [-1, 0],
         [localize "STR_A3_OPTIONS_DISABLED", LLSTRING(ConsoleIndentSpaces)],

--- a/addons/diagnostic/stringtable.xml
+++ b/addons/diagnostic/stringtable.xml
@@ -93,7 +93,7 @@
             <Czech>[CBA] Povoluje ladění vzdáleného cíle. Vyžaduje ladící konzoli.</Czech>
         </Key>
         <Key ID="STR_CBA_Diagnostic_ConsoleIndentType">
-            <English>Debug console indentation</English>
+            <English>Debug Console Indentation</English>
             <Polish>Indentacja w konsoli debugowania</Polish>
             <French>Indentation dans la console de débogage</French>
         </Key>

--- a/addons/disposable/initSettings.sqf
+++ b/addons/disposable/initSettings.sqf
@@ -2,7 +2,7 @@
     QGVAR(replaceDisposableLauncher),
     "CHECKBOX",
     [LLSTRING(ReplaceDisposableLauncher), LLSTRING(ReplaceDisposableLauncherTooltip)],
-    ELSTRING(common,WeaponsCategory),
+    [LELSTRING(main,DisplayName), "str_a3_firing1"],
     true, // default value
     1 // isGlobal
 ] call CBA_fnc_addSetting;
@@ -11,7 +11,7 @@
     QGVAR(dropUsedLauncher),
     "LIST",
     LLSTRING(DropUsedLauncher),
-    ELSTRING(common,WeaponsCategory),
+    [LELSTRING(main,DisplayName), "str_a3_firing1"],
     [
         [0,1,2],
         [

--- a/addons/events/initSettings.sqf
+++ b/addons/events/initSettings.sqf
@@ -2,7 +2,7 @@
     QGVAR(repetitionMode),
     "LIST",
     [LLSTRING(RepetitionMode), LLSTRING(RepetitionModeTooltip)],
-    ELSTRING(common,WeaponsCategory),
+    [LELSTRING(main,DisplayName), "str_a3_firing1"],
     [
         [0, 1, 2],
         [

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -31,6 +31,20 @@
             <Turkish>https://www.github.com/CBATeam/CBA_A3</Turkish>
             <Japanese>https://www.github.com/CBATeam/CBA_A3</Japanese>
         </Key>
+        <Key ID="STR_CBA_Main_DisplayName">
+            <English>Community Base Addons</English>
+            <German>Community Base Addons</German>
+            <Japanese>Community Base Addons</Japanese>
+            <Chinese>社群基礎模組</Chinese>
+            <Chinesesimp>社群基础模组</Chinesesimp>
+            <Portuguese>Extensões de Base Comunitária</Portuguese>
+            <Russian>Community Base Addons</Russian>
+            <French>Community Base Addons</French>
+            <Polish>Community Base Addons</Polish>
+            <Turkish>Community Base Addons</Turkish>
+            <Italian>Community Base Addons</Italian>
+            <Czech>Community Base Addons</Czech>
+        </Key>
         <Key ID="STR_CBA_Main_Component">
             <English>Community Base Addons - Main Component</English>
             <German>Community Base Addons - Hauptkomponente</German>

--- a/addons/network/initSettings.sqf
+++ b/addons/network/initSettings.sqf
@@ -2,7 +2,7 @@
     QGVAR(loadoutValidation),
     "LIST",
     [LLSTRING(LoadoutValidation), LLSTRING(LoadoutValidationTooltip)],
-    LSTRING(Component),
+    [LELSTRING(main,DisplayName), LSTRING(Category)],
     [
         [0, 1, 2],
         [

--- a/addons/network/stringtable.xml
+++ b/addons/network/stringtable.xml
@@ -15,8 +15,22 @@
             <Italian>CBA Rete</Italian>
             <Czech>CBA Síť</Czech>
         </Key>
+        <Key ID="STR_CBA_Network_Category">
+            <English>Network</English>
+            <German>Netzwerk</German>
+            <Japanese>ネットワーク</Japanese>
+            <Chinese>網路</Chinese>
+            <Chinesesimp>网路</Chinesesimp>
+            <Portuguese>Rede</Portuguese>
+            <Russian>Сеть</Russian>
+            <French>Réseau</French>
+            <Polish>Sieć</Polish>
+            <Turkish>Ağ</Turkish>
+            <Italian>Rete</Italian>
+            <Czech>Síť</Czech>
+        </Key>
         <Key ID="STR_CBA_Network_LoadoutValidation">
-            <English>Loadout validation</English>
+            <English>Loadout Validation</English>
             <German>Überprüfung von Ausrüstungen</German>
             <French>Vérification de l'équipement</French>
         </Key>

--- a/addons/optics/initSettings.sqf
+++ b/addons/optics/initSettings.sqf
@@ -2,7 +2,7 @@
     QGVAR(usePipOptics),
     "CHECKBOX",
     LLSTRING(UsePIP),
-    ELSTRING(common,WeaponsCategory),
+    [LELSTRING(main,DisplayName), "str_a3_firing1"],
     true, // default value
     2, // isGlobal
     {

--- a/addons/optics/stringtable.xml
+++ b/addons/optics/stringtable.xml
@@ -14,7 +14,7 @@
             <Russian>Community Base Addons - Оптика</Russian>
         </Key>
         <Key ID="STR_cba_optics_UsePIP">
-            <English>Use picture in picture optics</English>
+            <English>Use Picture-in-Picture Optics</English>
             <German>Bild in Bild-Optiken verwenden</German>
             <Japanese>ピクチャー イン ピクチャー照準器を使う</Japanese>
             <Polish>Używaj optyki typu Obraz w obrazie (PIP)</Polish>

--- a/addons/ui/initSettings.sqf
+++ b/addons/ui/initSettings.sqf
@@ -1,7 +1,7 @@
 [
     QGVAR(StorePasswords), "LIST",
     [LLSTRING(StoreServerPasswords), LLSTRING(StoreServerPasswordsTooltip)],
-    LLSTRING(Category),
+    [LELSTRING(main,DisplayName), LLSTRING(Category)],
     [[1, 0, -1], [
         [LLSTRING(SavePasswords), LLSTRING(SavePasswordsTooltip)],
         [LLSTRING(DoNotSavePasswords), LLSTRING(DoNotSavePasswordsTooltip)],
@@ -22,7 +22,7 @@
     QGVAR(notifyLifetime),
     "SLIDER",
     [LLSTRING(NotifyLifetime), LLSTRING(NotifyLifetimeTooltip)],
-    LLSTRING(Category),
+    [LELSTRING(main,DisplayName), LLSTRING(Category)],
     [1, 10, 4, 1], // default value
     2 // global
 ] call CBA_fnc_addSetting;

--- a/addons/ui/stringtable.xml
+++ b/addons/ui/stringtable.xml
@@ -15,6 +15,22 @@
             <Italian>Community Base Addons - Interfaccia utente</Italian>
             <Czech>Community Base Addons - Uživatelské prostředí</Czech>
         </Key>
+        <Key ID="STR_CBA_UI_Category">
+            <English>User Interface</English>
+            <Czech>Uživatelské rozhraní</Czech>
+            <Portuguese>Interface do usuário</Portuguese>
+            <French>Interface Utilisateur</French>
+            <Russian>Интерфейс</Russian>
+            <Japanese>ユーザ インタフェイス</Japanese>
+            <Polish>Interfejs użytkownika</Polish>
+            <German>Benutzeroberfläche</German>
+            <Korean>사용자 인터페이스</Korean>
+            <Italian>Interfaccia Utente</Italian>
+            <Chinesesimp>使用者介面</Chinesesimp>
+            <Chinese>使用者介面</Chinese>
+            <Spanish>Interfaz de usuario</Spanish>
+            <Turkish>Kullanıcı Arayüzü</Turkish>
+        </Key>
         <Key ID="STR_CBA_UI_ProgressBarPositionName">
             <English>Progress Bar</English>
             <German>Fortschrittsanzeige</German>
@@ -41,21 +57,8 @@
             <Czech>Pozici ukazatele průběhu.</Czech>
             <Russian>Позиция индикатора выполнения.</Russian>
         </Key>
-        <Key ID="STR_CBA_UI_Category">
-            <English>CBA UI</English>
-            <German>CBA UI</German>
-            <Polish>CBA UI</Polish>
-            <French>CBA IU</French>
-            <Turkish>CBA UI</Turkish>
-            <Japanese>CBA UI</Japanese>
-            <Italian>CBA IU</Italian>
-            <Czech>CBA UI</Czech>
-            <Spanish>CBA Interfaz</Spanish>
-            <Chinese>社群基礎模組 界面</Chinese>
-            <Russian>CBA Пользовательский интерфейс</Russian>
-        </Key>
         <Key ID="STR_CBA_UI_StoreServerPasswords">
-            <English>Store server passwords</English>
+            <English>Store Server Passwords</English>
             <German>Serverpasswörter speichern</German>
             <Polish>Zapamiętuj hasła serwerów</Polish>
             <French>Enregistrer les mots de passe serveur</French>


### PR DESCRIPTION
**When merged this pull request will:**
- Consolidate the 8 settings currently added by CBA itself into a single category separated into subcategories
- For consistency, make all setting display names title case

<details>
<summary>Image</summary>

![cba_settings_3](https://user-images.githubusercontent.com/34453221/121600318-49b8c500-ca12-11eb-96f2-aebd5a42ca20.png)


</details>