### PR TITLE
Have CBA_fnc_players return player logic entities

### DIFF
--- a/addons/common/fnc_players.sqf
+++ b/addons/common/fnc_players.sqf
@@ -8,7 +8,7 @@ Description:
     Unlike "BIS_fnc_listPlayers", this function will not report the game logics of headless clients.
 
 Parameters:
-    None
+    _listLogics - List player game logics (Zeus, Spectator, etc). (optional, default: false) <BOOL>
 
 Returns:
     List of all player objects <ARRAY>
@@ -23,4 +23,11 @@ Author:
 ---------------------------------------------------------------------------- */
 SCRIPT(players);
 
-(units sideLogic + allUnits + allDeadMen) select {isPlayer _x && {!(_x isKindOf "HeadlessClient_F")}}
+params [["_listLogics", false]];
+
+private _units = allUnits + allDeadMen;
+if _listLogics then {
+    _units append units sideLogic;
+};
+
+_units select {isPlayer _x && {!(_x isKindOf "HeadlessClient_F")}}

--- a/addons/common/fnc_players.sqf
+++ b/addons/common/fnc_players.sqf
@@ -23,4 +23,4 @@ Author:
 ---------------------------------------------------------------------------- */
 SCRIPT(players);
 
-(allUnits + allDeadMen) select {isPlayer _x && {!(_x isKindOf "HeadlessClient_F")}}
+(units sideLogic + allUnits + allDeadMen) select {isPlayer _x && {!(_x isKindOf "HeadlessClient_F")}}


### PR DESCRIPTION
**When merged this pull request will:**
- Make CBA_fnc_players return player logic entities

Strange that there's a check for headless clients even though there was seemingly no way for the function to list logic entities previously. This allows the function to list player spectator/Zeus logic entities and similar.