### PR TITLE
Accessory - Removes action from pointers while not in slot

### DIFF
--- a/addons/accessory/XEH_preInit.sqf
+++ b/addons/accessory/XEH_preInit.sqf
@@ -31,7 +31,7 @@ if (!hasInterface) exitWith {};
 ] call CBA_fnc_addItemContextMenuOption;
 
 [
-    "##AccessorySights", "POINTER", [LSTRING(opticNext), LSTRING(opticNext_tooltip)], nil, nil, {
+    "##AccessorySights", "OPTIC", [LSTRING(opticNext), LSTRING(opticNext_tooltip)], nil, nil, {
         params ["", "", "_item"];
         count (_item call CBA_fnc_switchableAttachments) > 1 // return
     }, {

--- a/addons/accessory/XEH_preInit.sqf
+++ b/addons/accessory/XEH_preInit.sqf
@@ -21,7 +21,7 @@ if (!hasInterface) exitWith {};
 }, {}, [DIK_SUBTRACT, [true, false, false]]] call CBA_fnc_addKeybind;
 
 [
-    "##AccessoryPointer", "ALL", [LSTRING(railNext), LSTRING(railNext_tooltip)], nil, nil, {
+    "##AccessoryPointer", "POINTER", [LSTRING(railNext), LSTRING(railNext_tooltip)], nil, nil, {
         params ["", "", "_item"];
         count (_item call CBA_fnc_switchableAttachments) > 1 // return
     }, {
@@ -31,7 +31,7 @@ if (!hasInterface) exitWith {};
 ] call CBA_fnc_addItemContextMenuOption;
 
 [
-    "##AccessorySights", "ALL", [LSTRING(opticNext), LSTRING(opticNext_tooltip)], nil, nil, {
+    "##AccessorySights", "POINTER", [LSTRING(opticNext), LSTRING(opticNext_tooltip)], nil, nil, {
         params ["", "", "_item"];
         count (_item call CBA_fnc_switchableAttachments) > 1 // return
     }, {


### PR DESCRIPTION
**When merged this pull request will:**
- fnc_switchAttachment operates only mounted items, but inventory action was available everywhere (and didn't work). Pull request changes action availabness to `POINTER` and `OPTICS` slots.

NOTE:
Currently if you place pointer with laser/flashlight MRT options (or optics) to e.g. untiform container - it will still have enabled 'Next rail item state' action in the item context menu. But when selected - item is not changed (because called function only works when item is attached to a gun).
