### PR TITLE
Item Context Menu - Flexible menu width 

### DIFF
--- a/addons/ui/fnc_openItemContextMenu.sqf
+++ b/addons/ui/fnc_openItemContextMenu.sqf
@@ -48,6 +48,10 @@ if (_options isEqualTo []) exitWith {};
 // ctrlSetBackgroundColor command does not seem to work for RscListBox.
 private _list = _display ctrlCreate [QGVAR(ItemContextMenu), -1];
 
+private _font = getText (configfile >> QGVAR(ItemContextMenu) >> "font");
+private _fontSize = getNumber (configFile >> ctrlClassName _list >> "sizeEx");
+private _longestName = "";
+
 // ---
 // Populate context menu with options.
 {
@@ -56,6 +60,9 @@ private _list = _display ctrlCreate [QGVAR(ItemContextMenu), -1];
     private _args = [_unit, _container, _item, _slot, _params];
     if (isLocalized _displayName) then {
         _displayName = localize _displayName;
+    };
+    if (count _longestName < count _displayName) then {
+        _longestName = _displayName;
     };
 
     if (isLocalized _tooltip) then {
@@ -154,8 +161,8 @@ getMousePosition params ["_left", "_top"];
 _left = _left - pixelW;
 _top = _top - pixelH;
 
-private _width = ctrlPosition _list select 2;
-private _height = lbSize _list * getNumber (configFile >> ctrlClassName _list >> "sizeEx");
+private _width = (ctrlPosition _list select 2) max 1.1 * (_longestName getTextWidth [_font, _fontSize]);
+private _height = lbSize _list * _fontSize;
 
 _list ctrlSetPosition [_left, _top, _width, _height];
 _list ctrlCommit 0;

--- a/addons/ui/fnc_openItemContextMenu.sqf
+++ b/addons/ui/fnc_openItemContextMenu.sqf
@@ -67,10 +67,10 @@ private _longestName = "";
     };
 
     if ((_slot in _slots || {"ALL" in _slots}) && {_args call _conditionShow}) then {
-		if (count _longestName < count _displayName) then {
-			_longestName = _displayName;
-		};
-	
+        if (count _longestName < count _displayName) then {
+            _longestName = _displayName;
+        };
+
         private _index = _list lbAdd _displayName;
         _list lbSetTooltip [_index, "_tooltip"]; // Does not seem to work for RscDisplayInventory controls? Hard coded overwrite?
 

--- a/addons/ui/fnc_openItemContextMenu.sqf
+++ b/addons/ui/fnc_openItemContextMenu.sqf
@@ -61,15 +61,16 @@ private _longestName = "";
     if (isLocalized _displayName) then {
         _displayName = localize _displayName;
     };
-    if (count _longestName < count _displayName) then {
-        _longestName = _displayName;
-    };
 
     if (isLocalized _tooltip) then {
         _tooltip = localize _tooltip;
     };
 
     if ((_slot in _slots || {"ALL" in _slots}) && {_args call _conditionShow}) then {
+		if (count _longestName < count _displayName) then {
+			_longestName = _displayName;
+		};
+	
         private _index = _list lbAdd _displayName;
         _list lbSetTooltip [_index, "_tooltip"]; // Does not seem to work for RscDisplayInventory controls? Hard coded overwrite?
 
@@ -161,7 +162,7 @@ getMousePosition params ["_left", "_top"];
 _left = _left - pixelW;
 _top = _top - pixelH;
 
-private _width = (ctrlPosition _list select 2) max 1.1 * (_longestName getTextWidth [_font, _fontSize]);
+private _width = (ctrlPosition _list select 2) max ((_longestName getTextWidth [_font, _fontSize]) + TEXT_MARGINS_WIDTH + RSCLISTBOX_PICTURE_WIDTH);
 private _height = lbSize _list * _fontSize;
 
 _list ctrlSetPosition [_left, _top, _width, _height];

--- a/addons/ui/script_component.hpp
+++ b/addons/ui/script_component.hpp
@@ -36,6 +36,9 @@
 #define GRID_3DEN_W (pixelW * pixelGrid * 0.5)
 #define GRID_3DEN_H (pixelH * pixelGrid * 0.5)
 
+#define TEXT_MARGINS_WIDTH (2 * 0.008)  // Hardcoded value, see https://community.bistudio.com/wiki/getTextWidth
+#define RSCLISTBOX_PICTURE_WIDTH 0.05  // Empirical value, RSCListBox's left icon picture width
+
 // Lobby Manager
 #define IDC_LM_SLOTS 50
 #define IDC_LM_CALLSIGN 51


### PR DESCRIPTION
**When merged this pull request will:**
- Max width of the Context Menu now calculated depending on the size of the actions names. If there are long names - menu will be wide, otherwise - with default width (fixes https://github.com/CBATeam/CBA_A3/issues/1490)

![20210806003825_1](https://user-images.githubusercontent.com/9357337/128504924-760138fe-db04-43bf-8b39-408b1b0aea91.jpg)
