### PR TITLE
Item Context Menu -- Add custom tooltip [WIP]

### DIFF
--- a/addons/ui/config.cpp
+++ b/addons/ui/config.cpp
@@ -38,6 +38,11 @@ class GVAR(ItemContextMenu): RscListBox {
     colorBackground[] = {0.05, 0.05, 0.05, 0.95};
 };
 
+class GVAR(ItemContextMenu_Tooltip): GVAR(ItemContextMenu) {
+    colorBackground[] = {0, 0, 0, 1};
+    sizeEx = 0.0325;
+};
+
 #include "CfgEventHandlers.hpp"
 #include "CfgFunctions.hpp"
 #include "RscTitles.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- Add custom tooltip for item context menu. Fixes https://github.com/CBATeam/CBA_A3/issues/1332
- It should work better with single click selection type (https://github.com/CBATeam/CBA_A3/pull/1486)

Note:
This is a workaround for engine limitation -- currently tooltips of any control added to inventory display are not displayed. 
Also i used a workaround for not yet implemented command - https://community.bistudio.com/wiki/lbTooltip.

![a3_tltp4](https://user-images.githubusercontent.com/9357337/128580657-8ce93212-043d-43a8-b002-ea0f065b859a.gif)
