### PR TITLE
Fix CBA_fnc_removeMagazineCargo for ground containers

### DIFF
--- a/addons/common/fnc_removeMagazineCargo.sqf
+++ b/addons/common/fnc_removeMagazineCargo.sqf
@@ -64,6 +64,13 @@ private _magazinesAmmo = magazinesAmmoCargo _container;
 // Clear cargo space and readd the items as long it's not the type in question
 clearMagazineCargoGlobal _container;
 
+// Engine will agressively cleanup "empty" ground containers, even if magazines are re-added in same frame, so re-create a new container
+private _containerType = typeOf _container;
+if (((toLower _containerType) in ["groundweaponholder", "weaponholdersimulated"]) 
+&& {(weaponCargo _container) isEqualTo []} && {(itemCargo _container) isEqualTo []} && {(backpackCargo _container) isEqualTo []}) then {
+    _container = createVehicle [_containerType, getPosATL _container, [], 0, "CAN_COLLIDE"];
+};
+
 {
     _x params ["_magazineClass", "_magazineAmmo"];
 

--- a/addons/common/fnc_removeMagazineCargo.sqf
+++ b/addons/common/fnc_removeMagazineCargo.sqf
@@ -67,7 +67,9 @@ clearMagazineCargoGlobal _container;
 // Engine will agressively cleanup "empty" ground containers, even if magazines are re-added in same frame, so re-create a new container
 private _containerType = typeOf _container;
 if (((toLower _containerType) in ["groundweaponholder", "weaponholdersimulated"]) 
-&& {(weaponCargo _container) isEqualTo []} && {(itemCargo _container) isEqualTo []} && {(backpackCargo _container) isEqualTo []}) then {
+    && {(weaponCargo _container) isEqualTo []}
+    && {(itemCargo _container) isEqualTo []}
+    && {(backpackCargo _container) isEqualTo []}) then {
     _container = createVehicle [_containerType, getPosATL _container, [], 0, "CAN_COLLIDE"];
 };
 

--- a/addons/common/fnc_removeMagazineCargo.sqf
+++ b/addons/common/fnc_removeMagazineCargo.sqf
@@ -66,7 +66,8 @@ clearMagazineCargoGlobal _container;
 
 // Engine will agressively cleanup "empty" ground containers, even if magazines are re-added in same frame, so re-create a new container
 private _containerType = typeOf _container;
-if (((toLower _containerType) in ["groundweaponholder", "weaponholdersimulated"]) 
+if ((_containerType isKindOf "WeaponHolder")
+    && {([configOf _container >> "forceSupply", "NUMBER", 0] call CBA_fnc_getConfigEntry) != 0}
     && {(weaponCargo _container) isEqualTo []}
     && {(itemCargo _container) isEqualTo []}
     && {(backpackCargo _container) isEqualTo []}) then {


### PR DESCRIPTION
Based on https://github.com/acemod/ACE3/pull/8399

Test code
```
xx = "GroundWeaponHolder" createVehicle (getpos player); 
xx addMagazineCargo ["smokeshell", 2];
```
then
```
[xx, "SmokeShell", 1] call CBA_fnc_removeMagazineCargo;
```

left with nothing