### PR TITLE
Events - Make player muzzle event args consistent for retro

### DIFF
--- a/addons/events/fnc_addPlayerEventHandler.sqf
+++ b/addons/events/fnc_addPlayerEventHandler.sqf
@@ -73,7 +73,7 @@ private _id = switch (_type) do {
     };
     case "muzzle": {
         if (_applyRetroactively) then {
-            [GVAR(oldUnit), currentMuzzle GVAR(oldUnit), ""] call _function;
+            [currentMuzzle GVAR(oldUnit), ""] call _function;
         };
         [QGVAR(muzzleEvent), _function] call CBA_fnc_addEventHandler // return id
     };


### PR DESCRIPTION
Fix https://github.com/CBATeam/CBA_A3/issues/1363

playerEvent.sqf does (just the 2 muzzles, no unit)
```
    if (_newMuzzle isNotEqualTo GVAR(oldMuzzle)) then {
        [QGVAR(muzzleEvent), [_newMuzzle select 2, GVAR(oldMuzzle) select 2]] call CBA_fnc_localEvent;
```
We need to make the two args arrays the same, and I think it's much safer to modify the retro one