### PR TITLE
Fix nil throwing errors in scheduled environment

### DIFF
--- a/addons/hashes/fnc_encodeJSON.sqf
+++ b/addons/hashes/fnc_encodeJSON.sqf
@@ -86,7 +86,7 @@ switch (typeName _object) do {
 
         private _json = ((allVariables _object) apply {
             private _name = _x;
-            private _value = _object getVariable _name;
+            private _value = _object getVariable [_name, objNull];
 
             format ["%1: %2", [_name] call CBA_fnc_encodeJSON, [_value] call CBA_fnc_encodeJSON]
         }) joinString ", ";


### PR DESCRIPTION
**When merged this pull request will:**
- Fixes popup error when running CBA_fnc_encodeJSON on an object with nil variables

Repro:
```sqf
private _foo = call CBA_fnc_createNamespace;
_foo setVariable ["bar", nil];
_foo spawn CBA_fnc_encodeJSON;
```