### PR TITLE
Add support for encoding and decoding JSON with hash maps

### DIFF
--- a/addons/hashes/fnc_encodeJSON.sqf
+++ b/addons/hashes/fnc_encodeJSON.sqf
@@ -16,6 +16,7 @@ Description:
     - STRING
     - TASK
     - TEAM_MEMBER
+    - HASHMAP
     - Everything else will simply be stringified.
 
 Parameters:
@@ -75,6 +76,19 @@ switch (typeName _object) do {
             private _json = (_object apply {[_x] call CBA_fnc_encodeJSON}) joinString ", ";
             "[" + _json + "]"
         };
+    };
+
+    case "HASHMAP": {
+        private _json = ((_object toArray false) apply {
+            _x params ["_key", ["_value", objNull]];
+
+            if !(_key isEqualType "") then {
+                _key = str _key;
+            };
+
+            format ["%1: %2", [_key] call CBA_fnc_encodeJSON, [_value] call CBA_fnc_encodeJSON]
+        }) joinString ", ";
+        "{" + _json + "}"
     };
 
     default {

--- a/addons/hashes/fnc_parseJSON.sqf
+++ b/addons/hashes/fnc_parseJSON.sqf
@@ -6,13 +6,15 @@ Description:
     Deserializes a JSON string.
 
 Parameters:
-    _json      - String containing valid JSON. <STRING>
-    _useHashes - Output CBA hashes instead of namespaces
-                 (optional, default: false) <BOOLEAN>
+    _json       - String containing valid JSON. <STRING>
+    _objectType - Selects the type used for deserializing objects (optional) <BOOLEAN or NUMBER>
+                  0, false: CBA namespace (default)
+                  1, true:  CBA hash
+                  2:        Native hash map
 
 Returns:
-    _object    - The deserialized JSON object or nil if JSON is invalid.
-                 <LOCATION, ARRAY, STRING, NUMBER, BOOL, NIL>
+    _object     - The deserialized JSON object or nil if JSON is invalid.
+                  <LOCATION, ARRAY, STRING, NUMBER, BOOL, HASHMAP, NIL>
 
 Examples:
     (begin example)
@@ -28,18 +30,33 @@ Author:
     BaerMitUmlaut
 ---------------------------------------------------------------------------- */
 SCRIPT(parseJSON);
-params ["_json", ["_useHashes", false]];
+params ["_json", ["_objectType", 0]];
 
 // Wrappers for creating "objects" and setting values on them
 private ["_objectSet", "_createObject"];
-if (_useHashes) then {
-    _createObject = CBA_fnc_hashCreate;
-    _objectSet = CBA_fnc_hashSet;
-} else {
-    _createObject = CBA_fnc_createNamespace;
-    _objectSet = {
-        params ["_obj", "_key", "_val"];
-        _obj setVariable [_key, _val];
+
+switch (_objectType) do {
+    case false;
+    case 0: {
+        _createObject = CBA_fnc_createNamespace;
+        _objectSet = {
+            params ["_obj", "_key", "_val"];
+            _obj setVariable [_key, _val];
+        };
+    };
+
+    case true;
+    case 1: {
+        _createObject = CBA_fnc_hashCreate;
+        _objectSet = CBA_fnc_hashSet;
+    };
+
+    case 2: {
+        _createObject = { createHashMap };
+        _objectSet = {
+            params ["_obj", "_key", "_val"];
+            _obj set [_key, _val];
+        };
     };
 };
 

--- a/addons/hashes/test_parseJSON.sqf
+++ b/addons/hashes/test_parseJSON.sqf
@@ -108,16 +108,16 @@ private _testCases = [
 ];
 
 {
-    private _useHashes = _x;
+    private _objectType = _x;
 
     {
         diag_log _x;
         private _input  = _x;
-        private _object = [_x, _useHashes] call CBA_fnc_parseJSON;
+        private _object = [_x, _objectType] call CBA_fnc_parseJSON;
         private _output = [_object] call CBA_fnc_encodeJSON;
         TEST_OP(_input,==,_output,_fn);
     } forEach _testCases;
-} forEach [true, false];
+} forEach [true, false, 0, 1, 2];
 
 // Special test for complex object because properties are unordered
 private _json = "{""OBJECT"": null, ""BOOL"": true, ""SCALAR"": 1.2, ""STRING"": ""Hello, World!"", ""ARRAY"": [], ""LOCATION"": {}}";


### PR DESCRIPTION
**When merged this pull request will:**
- Enable parsing JSON objects as hash maps
- Enable encoding hash maps as JSON

Since JSON, unlike hash maps, accepts only strings as keys, every other key type is stringified.
