### PR TITLE
Item Context Menu -- Add class-specific actions support 

### DIFF
--- a/addons/ui/fnc_addItemContextMenuOption.sqf
+++ b/addons/ui/fnc_addItemContextMenuOption.sqf
@@ -9,6 +9,9 @@ Parameters:
     _item                   - Item classname <STRING>
                               Can be base class.
 
+                              Can be specific class without being inherited by child classes:
+                                 "!MyMod_Class1"
+
                               Can be item type as reported by BIS_fnc_itemType:
                                 ["Equipment","Headgear"]
                                 ->
@@ -133,7 +136,7 @@ if (!hasInterface) exitWith {};
 
 // Initialize system on first execution.
 if (isNil QGVAR(ItemContextMenuOptions)) then {
-    GVAR(ItemContextMenuOptions) = false call CBA_fnc_createNamespace;
+    GVAR(ItemContextMenuOptions) = createHashMap;
 
     ["CAManBase", "InventoryOpened", {
         params ["_unit", "_container1", "_container2"];
@@ -222,11 +225,11 @@ _condition params [
     ["_conditionShow", {true}, [{}]]
 ];
 
-private _options = GVAR(ItemContextMenuOptions) getVariable _item;
+private _options = GVAR(ItemContextMenuOptions) get _item;
 
 if (isNil "_options") then {
     _options = [];
-    GVAR(ItemContextMenuOptions) setVariable [_item, _options];
+    GVAR(ItemContextMenuOptions) set [_item, _options];
 };
 
 _options pushBack [_slots, _displayName, _tooltip, _color, _icon, _conditionEnable, _conditionShow, _statement, _consume, _params];

--- a/addons/ui/fnc_openItemContextMenu.sqf
+++ b/addons/ui/fnc_openItemContextMenu.sqf
@@ -30,15 +30,19 @@ private _config = _item call CBA_fnc_getItemConfig;
 
 private _options = [];
 while {
-    _options append (GVAR(ItemContextMenuOptions) getVariable configName _config);
+    _options append (GVAR(ItemContextMenuOptions) get configName _config);
     _config = inheritsFrom _config;
     !isNull _config
 } do {};
 
+// Read unique class options (not inherited)
+_options append (GVAR(ItemContextMenuOptions) getOrDefault [format["!%1", _item], []]);
+
+// Read type and wildcard options
 _item call BIS_fnc_itemType params ["_itemType1", "_itemType2"];
-_options append (GVAR(ItemContextMenuOptions) getVariable [format ["##%1", _itemType2], []]);
-_options append (GVAR(ItemContextMenuOptions) getVariable [format ["#%1", _itemType1], []]);
-_options append (GVAR(ItemContextMenuOptions) getVariable ["#All", []]);
+_options append (GVAR(ItemContextMenuOptions) getOrDefault [format ["##%1", _itemType2], []]);
+_options append (GVAR(ItemContextMenuOptions) getOrDefault [format ["#%1", _itemType1], []]);
+_options append (GVAR(ItemContextMenuOptions) getOrDefault ["#All", []]);
 
 // Skip menu if no options.
 if (_options isEqualTo []) exitWith {};


### PR DESCRIPTION
**When merged this pull request will:**
- Rework Inventory actions to use HashMap to store actions.
- Add a way to make action apply to specific class only (without being inherited by child classes). 

**Note:**
Framework allows to apply actions(options) to item class, item type or "#All" wildcard. Actions added to class will be inherited by all it's child classes. 
Mods often do not have strict inheritance scheme (class_base (scope=0) -> various class_variants (scope=2)), but may inherit from classes with scope=2. If I want to add some specific action for parent item - it now inherited by all it's childs, which is sometimes unwanted.

This PR adds new way to specify `_item` parameter -- `!<classname>` -- which prevents actions for being inherited.

<details>
<summary>Example</summary>

Config:

```cpp
  class CUP_acc_ANPEQ_15: ItemBase;
  class CUP_acc_ANPEQ_15_Black: CUP_acc_ANPEQ_15;
```

Add action to `CUP_acc_ANPEQ_15` only:

```sqf
[
  "!CUP_acc_ANPEQ_15",
  ["VEST_CONTAINER"], 
  "Paint to black", 
  [], "", {true}, { _this call fnc_replaceItem }, true, 
  "CUP_acc_ANPEQ_15_Black"
] call CBA_fnc_addItemContextMenuOption;
```
</details>