### PR TITLE
diagnostic - target watch variable is broadcasted to all

### DIFF
--- a/addons/diagnostic/XEH_preInit.sqf
+++ b/addons/diagnostic/XEH_preInit.sqf
@@ -45,7 +45,7 @@ if (getMissionConfigValue ["EnableTargetDebug", 0] == 1 || {getNumber (configFil
 
         missionNamespace setVariable [_varName, [_statementText, _returnString, _duration]];
         if (_clientID != CBA_clientID) then {
-            publicVariable _varName; // send back over network
+            _clientID publicVariableClient _varName; // send back over network
         };
     }] call CBA_fnc_addEventHandler;
 

--- a/addons/diagnostic/fnc_initTargetDebugConsole.sqf
+++ b/addons/diagnostic/fnc_initTargetDebugConsole.sqf
@@ -144,7 +144,7 @@ private _fnc_updateWatchInfo = {
             missionNamespace setVariable [_varName, nil];
         } else {
             if ((_editText isEqualTo _responseStatement) && {_duration > 0.1}) exitWith {}; // don't re-run if statement that took a long time
-            if ((diag_tickTime - _lastSent) > random [0.1, 0.2, 0.3]) then {
+            if ((diag_tickTime - _lastSent) > random GVAR(watchInfoRefreshRateArray)) then {
                 _x set [3, diag_tickTime]; // set last run to now
                 [QGVAR(watchVariable), [CBA_clientID, _varIndex, _editText], GVAR(selectedClientID)] call CBA_fnc_ownerEvent; // send statement to target
             };

--- a/addons/diagnostic/initSettings.sqf
+++ b/addons/diagnostic/initSettings.sqf
@@ -15,6 +15,10 @@
     QGVAR(watchInfoRefreshRate), "SLIDER",
     [LLSTRING(WatchInfoRefreshRate), LLSTRING(WatchInfoRefreshRateTooltip)],
     [LELSTRING(main,DisplayName), LELSTRING(UI,Category)],
-    [0.1, 60, 0.2, 1],
-    1
+    [0.2, 60, 0.2, 1],
+    1,
+    {
+        params ["_value"];
+        GVAR(watchInfoRefreshRateArray) = [_value - 0.1, _value, _value + 0.1];
+    }
 ] call CBA_fnc_addSetting;

--- a/addons/diagnostic/initSettings.sqf
+++ b/addons/diagnostic/initSettings.sqf
@@ -10,3 +10,11 @@
     ],
     2
 ] call CBA_fnc_addSetting;
+
+[
+    QGVAR(watchInfoRefreshRate), "SLIDER",
+    [LLSTRING(WatchInfoRefreshRate), LLSTRING(WatchInfoRefreshRateTooltip)],
+    [LELSTRING(main,DisplayName), LELSTRING(UI,Category)],
+    [0.1, 60, 0.2, 1],
+    1
+] call CBA_fnc_addSetting;

--- a/addons/diagnostic/stringtable.xml
+++ b/addons/diagnostic/stringtable.xml
@@ -115,7 +115,7 @@
             <English>Refresh rate target watcher field</English>
         </Key>
         <Key ID="STR_CBA_Diagnostic_WatchInfoRefreshRateTooltip">
-            <English>Sets the refresh rate in seconds for the CBA target watcher fields to the right of the debug console</English>
+            <English>Refresh rate (in seconds) for the CBA target watcher fields to the right of the debug console.</English>
         </Key>
         <Key ID="STR_CBA_Diagnostic_ConsoleIndentSpaces">
             <English>4 Spaces</English>

--- a/addons/diagnostic/stringtable.xml
+++ b/addons/diagnostic/stringtable.xml
@@ -111,6 +111,12 @@
             <French>Type d'indentation qui peut être employée dans la console de débogage.\nTab ajoute une indentation, et Shift + Tab en supprime une.</French>
             <Spanish>Tipo de sangría que se puede agregar a la expresión en la consola de depuración presionando la tecla Tab o eliminar presionando Shift + Tab</Spanish>
         </Key>
+        <Key ID="STR_CBA_Diagnostic_WatchInfoRefreshRate">
+            <English>Refresh rate target watcher field</English>
+        </Key>
+        <Key ID="STR_CBA_Diagnostic_WatchInfoRefreshRateTooltip">
+            <English>Sets the refresh rate in seconds for the CBA target watcher fields to the right of the debug console</English>
+        </Key>
         <Key ID="STR_CBA_Diagnostic_ConsoleIndentSpaces">
             <English>4 Spaces</English>
             <Polish>4 Spacje</Polish>


### PR DESCRIPTION
**When merged this pull request will:**
- fix #1521
- this change will send the result only to the person how ask for it
- you can now set the refreshRate in the settings