### PR TITLE
Add CBA_fnc_prettyFormat 

### DIFF
--- a/addons/strings/CfgFunctions.hpp
+++ b/addons/strings/CfgFunctions.hpp
@@ -9,6 +9,7 @@ class CfgFunctions {
             PATHTO_FNC(formatElapsedTime);
             PATHTO_FNC(formatNumber);
             PATHTO_FNC(leftTrim);
+            PATHTO_FNC(prettyFormat);
             PATHTO_FNC(removeWhitespace);
             PATHTO_FNC(replace);
             PATHTO_FNC(rightTrim);

--- a/addons/strings/fnc_prettyFormat.sqf
+++ b/addons/strings/fnc_prettyFormat.sqf
@@ -1,0 +1,72 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_prettyFormat
+
+Description:
+    Makes an array easy to read.
+
+Parameters:
+    _array     - Array to format <ARRAY>
+    _indents   - Indentation string (optional, default: "    ") <STRING>
+    _lineBreak - Seperator string (optional, default: endl) <STRING>
+    _depth     - Initial indentation count (optional, default: 0) <NUMBER>
+
+Returns:
+    Formatted string <STRING>
+
+Examples:
+    (begin example)
+        [[0, 1, ["22", 33, []], 4]] call CBA_fnc_prettyFormat;
+        //[
+        //    0,
+        //    1,
+        //    [
+        //        "22",
+        //        33,
+        //        []
+        //    ],
+        //    4
+        //]
+
+        [[0, 1, ["22", 33, []], 4], ">---"] call CBA_fnc_prettyFormat;
+        //[
+        //>---0,
+        //>---1,
+        //>---[
+        //>--->---"22",
+        //>--->---33,
+        //>--->---[]
+        //>---],
+        //>---4
+        //]
+
+        [[0, 1, ["22", 33, []], 4], ">---", "\n"] call CBA_fnc_prettyFormat;
+        //[\n>---0,\n>---1,\n>---[\n>--->---"22",\n>--->---33,\n>--->---[]\n>---],\n>---4\n]
+    (end)
+
+Author:
+   Terra, Dystopian, commy2
+
+---------------------------------------------------------------------------- */
+params [
+    ["_array", [], [[]]],
+    ["_indent", "    ", [""]],
+    ["_lineBreak", endl, [""]],
+    ["_depth", 0, [0]]
+];
+
+private _indents = STRING_REPEAT(_indent, _depth);
+
+if (_array isEqualTo []) exitWith {
+    _indents + "[]" // return
+};
+
+private _lines = _array apply {
+    if (_x isEqualType []) then {
+        [_x, _indent, _lineBreak, _depth + 1] call CBA_fnc_prettyFormat
+    } else {
+        _indents + _indent + str _x
+    };
+};
+
+_indents + "[" + _lineBreak + (_lines joinString ("," + _lineBreak)) + _lineBreak + _indents + "]" // return

--- a/addons/strings/script_component.hpp
+++ b/addons/strings/script_component.hpp
@@ -11,6 +11,12 @@
 
 #include "\x\cba\addons\main\script_macros.hpp"
 
+#define STRING_REPEAT(string, repeats) (call {\
+    private _return = [];\
+    _return resize (repeats);\
+    _return apply {string} joinString ""\
+})
+
 #define UTF8_TABLE [\
     ["%20"," "],\
     ["%21","!"],\

--- a/addons/strings/test.sqf
+++ b/addons/strings/test.sqf
@@ -5,7 +5,7 @@
 #define DEBUG_MODE_FULL
 #include "script_component.hpp"
 
-#define TESTS ["strings"]
+#define TESTS ["strings", "prettyFormat"]
 
 SCRIPT(test-strings);
 

--- a/addons/strings/test_prettyFormat.sqf
+++ b/addons/strings/test_prettyFormat.sqf
@@ -1,0 +1,49 @@
+// ----------------------------------------------------------------------------
+#define DEBUG_MODE_FULL
+#include "script_component.hpp"
+
+SCRIPT(test_prettyFormat);
+
+// ----------------------------------------------------------------------------
+
+LOG("Testing CBA_fnc_prettyFormat");
+
+private _fn = "CBA_fnc_prettyFormat";
+TEST_DEFINED("CBA_fnc_prettyFormat","");
+
+private _val = [] call CBA_fnc_prettyFormat;
+private _exp = "[]";
+TEST_OP(_val,isEqualTo,_exp,_fn);
+
+_val = [[], "xY", nil, 2] call CBA_fnc_prettyFormat;
+_exp = "xYxY[]";
+TEST_OP(_val,isEqualTo,_exp,_fn);
+
+_val = [[0, 1, ["22", 33, []], 4]] call CBA_fnc_prettyFormat;
+_exp = [
+    "[",
+    "    0,",
+    "    1,",
+    "    [",
+    "        ""22"",",
+    "        33,",
+    "        []",
+    "    ],",
+    "    4",
+    "]"
+] joinString endl;
+TEST_OP(_val,isEqualTo,_exp,_fn);
+
+_val = [[0, 1, ["22", 33, []], 4], ">---", "\n"] call CBA_fnc_prettyFormat;
+_exp = "[\n>---0,\n>---1,\n>---[\n>--->---""22"",\n>--->---33,\n>--->---[]\n>---],\n>---4\n]";
+TEST_OP(_val,isEqualTo,_exp,_fn);
+
+_val = [[[[]]], """", endl, 1] call CBA_fnc_prettyFormat;
+_exp = [
+    """[",
+    """""[",
+    """""""[]",
+    """""]",
+    """]"
+] joinString endl;
+TEST_OP(_val,isEqualTo,_exp,_fn);


### PR DESCRIPTION
**When merged this pull request will:**
- Implements close https://github.com/CBATeam/CBA_A3/pull/1519
- but with tests

<details><summary>CLICK

```sqf
execVM "x\cba\addons\strings\test.sqf"
```

</summary>

```sqf
...
19:58:09 [CBA] (strings) LOG: Testing CBA_fnc_prettyFormat
19:58:09 [CBA] (strings) Test OK: (CBA_fnc_prettyFormat is defined) x\cba\addons\strings\test_prettyFormat.sqf:13
19:58:09 [CBA] (strings) Test OK: (_val isEqualTo _exp) x\cba\addons\strings\test_prettyFormat.sqf:17
19:58:09 [CBA] (strings) Test OK: (_val isEqualTo _exp) x\cba\addons\strings\test_prettyFormat.sqf:21
19:58:09 [CBA] (strings) Test OK: (_val isEqualTo _exp) x\cba\addons\strings\test_prettyFormat.sqf:36
19:58:09 [CBA] (strings) Test OK: (_val isEqualTo _exp) x\cba\addons\strings\test_prettyFormat.sqf:40
19:58:09 [CBA] (strings) Test OK: (_val isEqualTo _exp) x\cba\addons\strings\test_prettyFormat.sqf:50
...
```

</details>