### PR TITLE
CBA_fnc_canAddItem for vehicles and crates

### DIFF
--- a/addons/common/fnc_canAddItem.sqf
+++ b/addons/common/fnc_canAddItem.sqf
@@ -105,7 +105,7 @@ if (_unit isKindOf "CAManBase") then {
             _mass == 0
             || {
                 // each time subtract whole number of items which can be put in container
-                _count = _count - floor (getContainerMaxLoad uniform _unit * (1 - loadUniform _unit) / _mass);
+                _count = _count - floor (maxLoad uniformContainer _unit * (1 - loadUniform _unit) / _mass);
                 _count <= 0
             }
         }
@@ -117,7 +117,7 @@ if (_unit isKindOf "CAManBase") then {
         && {
             _mass == 0
             || {
-                _count = _count - floor (getContainerMaxLoad vest _unit * (1 - loadVest _unit) / _mass);
+                _count = _count - floor (maxLoad vestContainer _unit * (1 - loadVest _unit) / _mass);
                 _count <= 0
             }
         }
@@ -129,7 +129,7 @@ if (_unit isKindOf "CAManBase") then {
         && {
             _mass == 0
             || {
-                _count = _count - floor (getContainerMaxLoad backpack _unit * (1 - loadBackpack _unit) / _mass);
+                _count = _count - floor (maxLoad backpackContainer _unit * (1 - loadBackpack _unit) / _mass);
                 _count <= 0
             }
         }


### PR DESCRIPTION
**When merged this pull request will:**
- make `CBA_fnc_canAddItem` work on vehicles and crates.
- use HashMap for item mass cache instead of pseudo namespace.

**This requires 2.08 to work** (maxLoad, load reporting anything != 0 for non person objects).
