### PR TITLE
UI - Show `worldname` as tooltip for maps on mission select

### DIFF
--- a/addons/ui/fnc_initDisplayRemoteMissions.sqf
+++ b/addons/ui/fnc_initDisplayRemoteMissions.sqf
@@ -25,6 +25,20 @@ private _fnc_findMissions = {
 
 _display setVariable [QGVAR(stockMissions), _stockMissions];
 
+// Show worldnames for maps
+private _mapNames = createHashMap;
+{
+    private _worldName = configName _x;
+    private _description = getText (configFile >> "CfgWorlds" >> _worldName >> "description");
+    _mapNames set [_description, _worldname];
+} forEach (configProperties [configfile >> "CfgWorldList", "isClass _x"]);
+
+for "_index" from 0 to ((lbSize _ctrlMaps) - 1) do {
+    private _description = _ctrlMaps lbText _index;
+    private _worldName = _mapNames getOrDefault [_description, ""];
+    _ctrlMaps lbSetText [_index, format ["%1 [%2]", _description, _worldName]];
+};
+
 lbSort _ctrlMaps;
 _ctrlMaps lbSetCurSel 0;
 

--- a/addons/ui/fnc_initDisplayRemoteMissions.sqf
+++ b/addons/ui/fnc_initDisplayRemoteMissions.sqf
@@ -25,18 +25,17 @@ private _fnc_findMissions = {
 
 _display setVariable [QGVAR(stockMissions), _stockMissions];
 
-// Show worldnames for maps
+// Show worldnames as tooltips on map list
 private _mapNames = createHashMap;
 {
     private _worldName = configName _x;
     private _description = getText (configFile >> "CfgWorlds" >> _worldName >> "description");
     _mapNames set [_description, _worldname];
 } forEach (configProperties [configfile >> "CfgWorldList", "isClass _x"]);
-
 for "_index" from 0 to ((lbSize _ctrlMaps) - 1) do {
     private _description = _ctrlMaps lbText _index;
     private _worldName = _mapNames getOrDefault [_description, ""];
-    _ctrlMaps lbSetText [_index, format ["%1 [%2]", _description, _worldName]];
+    _ctrlMaps lbSetTooltip [_index, _worldName];
 };
 
 lbSort _ctrlMaps;

--- a/addons/ui/fnc_initDisplayRemoteMissions.sqf
+++ b/addons/ui/fnc_initDisplayRemoteMissions.sqf
@@ -26,15 +26,15 @@ private _fnc_findMissions = {
 _display setVariable [QGVAR(stockMissions), _stockMissions];
 
 // Show worldnames as tooltips on map list
-private _mapNames = createHashMap;
+private _worldNames = createHashMap;
 {
     private _worldName = configName _x;
     private _description = getText (configFile >> "CfgWorlds" >> _worldName >> "description");
-    _mapNames set [_description, _worldname];
+    _worldNames set [_description, _worldname];
 } forEach (configProperties [configfile >> "CfgWorldList", "isClass _x"]);
 for "_index" from 0 to ((lbSize _ctrlMaps) - 1) do {
     private _description = _ctrlMaps lbText _index;
-    private _worldName = _mapNames getOrDefault [_description, ""];
+    private _worldName = _worldNames getOrDefault [_description, ""];
     _ctrlMaps lbSetTooltip [_index, _worldName];
 };
 


### PR DESCRIPTION
Sometimes the worldname is completely different from the displayed name 
and it can be pain to figure out what map you want if you are looking for `MissionX.Woodland_ACR`


![20220318143819_1](https://user-images.githubusercontent.com/9376747/159072917-e528e813-fa82-40cc-a7f3-16055e1219f1.jpg)