### PR TITLE
SearchNearby Endless Loop #1544

### DIFF
--- a/addons/ai/fnc_searchNearby.sqf
+++ b/addons/ai/fnc_searchNearby.sqf
@@ -51,7 +51,7 @@ if ((leader _group) distanceSqr _building > 250e3) exitwith {};
     // Search while there are still available positions
     private _positions = _building buildingPos -1;
 
-    // Create Limiters For Each Unit
+    // Create limiters for each unit
     private _timeout = (count(_positions) * 15) min 120;
     private _timetag = "CBASearchTime";
     {_x setVariable [_timetag,time]} forEach units _group;

--- a/addons/ai/fnc_searchNearby.sqf
+++ b/addons/ai/fnc_searchNearby.sqf
@@ -54,7 +54,7 @@ if ((leader _group) distanceSqr _building > 250e3) exitwith {};
     // Create Limiters For Each Unit
     private _timeout = (count(_positions) * 15) min 120;
     private _timetag = "CBASearchTime";
-    (units _group) apply {_x setVariable [_timetag,time]};
+    {_x setVariable [_timetag,time]} forEach units _group;
 
     while {_positions isNotEqualTo []} do {
         // Update units in case of death

--- a/addons/ai/fnc_searchNearby.sqf
+++ b/addons/ai/fnc_searchNearby.sqf
@@ -20,7 +20,7 @@ Author:
 
 ---------------------------------------------------------------------------- */
 
-params ["_group",["_timeoutcoef",-1],["_maxtimeout",-1]];
+params ["_group",["_timeoutCoef",-1],["_maxTimeout",-1]];
 
 _group = _group call CBA_fnc_getGroup;
 if !(local _group) exitWith {}; // Don't create waypoints on each machine
@@ -28,8 +28,8 @@ if !(local _group) exitWith {}; // Don't create waypoints on each machine
 private _building = nearestBuilding (leader _group);
 if ((leader _group) distanceSqr _building > 250e3) exitwith {};
 
-[_group, _building] spawn {
-    params ["_group", "_building","_timeoutcoef","_maxtimeout"];
+[_group, _building, _timeoutCoef, _maxTimeout] spawn {
+    params ["_group", "_building","_timeoutCoef","_maxTimeout"];
     private _leader = leader _group;
 
     // Add a waypoint to regroup after the search
@@ -52,8 +52,8 @@ if ((leader _group) distanceSqr _building > 250e3) exitwith {};
     private _positions = _building buildingPos -1;
 
     // Create limiters for each unit
-    private _timeout = if (_timeoutcoef > -1 && _maxtimeout > -1) then {(
-        count _positions * _timeoutcoef) min _maxtimeout
+    private _timeout = if (_timeoutCoef > -1 && _maxTimeout > -1) then {(
+        count _positions * _timeoutCoef) min _maxTimeout
     } else {
         -1 
     };

--- a/addons/ai/fnc_searchNearby.sqf
+++ b/addons/ai/fnc_searchNearby.sqf
@@ -52,7 +52,7 @@ if ((leader _group) distanceSqr _building > 250e3) exitwith {};
     private _positions = _building buildingPos -1;
 
     // Create limiters for each unit
-    private _timeout = (count(_positions) * 15) min 120;
+    private _timeout = (count _positions * 15) min 120;
     private _timetag = "CBASearchTime";
     {_x setVariable [_timetag,time]} forEach units _group;
 

--- a/addons/ai/fnc_searchNearby.sqf
+++ b/addons/ai/fnc_searchNearby.sqf
@@ -68,7 +68,7 @@ if ((leader _group) distanceSqr _building > 250e3) exitwith {};
             private _starttime = _x getVariable _timetag;
 
             if (_positions isEqualTo []) exitWith {};
-            if (unitReady _x or (_starttime + _timeout) < time) then {
+            if (unitReady _x || {_starttime + _timeout < time}) then {
                 private _pos = _positions deleteAt 0;
                 _x commandMove _pos;
                 _x setVariable [_timetag,time];

--- a/addons/ai/fnc_searchNearby.sqf
+++ b/addons/ai/fnc_searchNearby.sqf
@@ -50,6 +50,12 @@ if ((leader _group) distanceSqr _building > 250e3) exitwith {};
 
     // Search while there are still available positions
     private _positions = _building buildingPos -1;
+
+    // Create Limiters For Each Unit
+    private _timeout = (count(_positions) * 15) min 120;
+    private _timetag = "CBASearchTime";
+    (units _group) apply {_x setVariable [_timetag,time]};
+
     while {_positions isNotEqualTo []} do {
         // Update units in case of death
         private _units = (units _group) - [_leader];
@@ -59,12 +65,17 @@ if ((leader _group) distanceSqr _building > 250e3) exitwith {};
 
         // Send all available units to the next available position
         {
+            private _starttime = _x getVariable _timetag;
+
             if (_positions isEqualTo []) exitWith {};
-            if (unitReady _x) then {
+            if (unitReady _x or (_starttime + _timeout) < time) then {
                 private _pos = _positions deleteAt 0;
                 _x commandMove _pos;
+                _x setVariable [_timetag,time];
                 sleep 2;
             };
+
+            sleep .25;
         } forEach _units;
     };
     _group lockWP false;

--- a/addons/ai/fnc_taskSearchArea.sqf
+++ b/addons/ai/fnc_taskSearchArea.sqf
@@ -39,7 +39,9 @@ params [
     ["_speed", "UNCHANGED", [""]],
     ["_formation", "NO CHANGE", [""]],
     ["_onComplete", "", [""]],
-    ["_timeout", [0, 0, 0], [[]], 3]
+    ["_timeout", [0, 0, 0], [[]], 3],
+    ["_timeoutCoef",-1],
+    ["_maxTimeout", -1]
 ];
 
 _group = _group call CBA_fnc_getGroup;
@@ -77,7 +79,7 @@ if ((_building distanceSqr _pos) < 400) then {
     // Clear waypoint to prevent getting stuck in a search loop
     _statements append [
         "deleteWaypoint [group this, currentWaypoint (group this)]",
-        "[group this] call CBA_fnc_searchNearby"
+        format["[group this,%1,%2] call CBA_fnc_searchNearby",_timeoutCoef,_maxTimeout]
     ];
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Performance and reliability adjustments for SearchNearby function
- Set a max timeout for each unit move order (positions *15 and no more than 2 minutes).
- Set a time start variable "CBASearchTime" on each unit.
- Added a quarter-second pause between unit iterations.
- If the timeout is exceeded before the unit is ready, the unit will receive a new command for the next position. Command time is updated to reflect timeout for the next move command.
