### PR TITLE
AI - Add basic delay for `CBA_fnc_searchNearby` while loop

### DIFF
--- a/addons/ai/fnc_searchNearby.sqf
+++ b/addons/ai/fnc_searchNearby.sqf
@@ -66,6 +66,7 @@ if ((leader _group) distanceSqr _building > 250e3) exitwith {};
                 sleep 2;
             };
         } forEach _units;
+        sleep 0.25;
     };
     _group lockWP false;
 };


### PR DESCRIPTION
#1544 
#1545

cherry pick trivial partial fix from other PR
Without this `sleep` there could be an `while {true}` loop with no pause between iterations
The sleep is small enough it shouldn't be noticeable in terms of ai responsiveness

Based on @mrzachhigginsofficial 's PR - this might still run forever but should mostly eliminate any real performance issues