### PR TITLE
Settings - Fix data type of _isGlobal in docs

### DIFF
--- a/addons/settings/fnc_addSetting.sqf
+++ b/addons/settings/fnc_addSetting.sqf
@@ -11,7 +11,7 @@ Parameters:
     _title       - Display name or display name + tooltip (optional, default: same as setting name) <STRING, ARRAY>
     _category    - Category for the settings menu + optional sub-category <STRING, ARRAY>
     _valueInfo   - Extra properties of the setting depending of _settingType. See examples below <ANY>
-    _isGlobal    - 1: all clients share the same setting, 2: setting can't be overwritten (optional, default: 0) <ARRAY>
+    _isGlobal    - 1: all clients share the same setting, 2: setting can't be overwritten (optional, default: 0) <BOOL, NUMBER>
     _script      - Script to execute when setting is changed. (optional) <CODE>
     _needRestart - Setting will be marked as needing mission restart after being changed. (optional, default false) <BOOL>
 

--- a/addons/settings/fnc_init.sqf
+++ b/addons/settings/fnc_init.sqf
@@ -11,7 +11,7 @@ Parameters:
     _title       - Display name or display name + tooltip (optional, default: same as setting name) <STRING, ARRAY>
     _category    - Category for the settings menu + optional sub-category <STRING, ARRAY>
     _valueInfo   - Extra properties of the setting depending of _settingType. See examples below <ANY>
-    _isGlobal    - 1: all clients share the same setting, 2: setting can't be overwritten (optional, default: 0) <ARRAY>
+    _isGlobal    - 1: all clients share the same setting, 2: setting can't be overwritten (optional, default: 0) <BOOL, NUMBER>
     _script      - Script to execute when setting is changed. (optional) <CODE>
     _needRestart - Setting will be marked as needing mission restart after being changed. (optional, default false) <BOOL>
 


### PR DESCRIPTION
**When merged this pull request will:**
- Fix data type of `_isGlobal` in documentation of `CBA_fnc_addSetting` and `CBA_settings_fnc_init` (was `<ARRAY>`, will be `<BOOL, NUMBER>`).