### PR TITLE
WIP: Terrain library

### DIFF
--- a/addons/terrain/$PBOPREFIX$
+++ b/addons/terrain/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\cba\addons\terrain

--- a/addons/terrain/CfgEventHandlers.hpp
+++ b/addons/terrain/CfgEventHandlers.hpp
@@ -1,0 +1,5 @@
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_preInit));
+    };
+};

--- a/addons/terrain/CfgFunctions.hpp
+++ b/addons/terrain/CfgFunctions.hpp
@@ -1,0 +1,8 @@
+class CfgFunctions {
+    class CBA {
+        class Terrain {
+            PATHTO_FNC(nearestTerrainPoint);
+            PATHTO_FNC(setTerrainHeight);
+        };
+    };
+};

--- a/addons/terrain/CfgFunctions.hpp
+++ b/addons/terrain/CfgFunctions.hpp
@@ -1,8 +1,10 @@
 class CfgFunctions {
     class CBA {
         class Terrain {
+            PATHTO_FNC(addTerrainHeight);
             PATHTO_FNC(nearestTerrainPoint);
             PATHTO_FNC(setTerrainHeight);
+            PATHTO_FNC(getAreaTerrainGrid);
         };
     };
 };

--- a/addons/terrain/XEH_PREP.sqf
+++ b/addons/terrain/XEH_PREP.sqf
@@ -1,0 +1,3 @@
+PREP(getChunk);
+PREP(chunkOrigin);
+PREP(positionsAndHeightsToChunks);

--- a/addons/terrain/XEH_preInit.sqf
+++ b/addons/terrain/XEH_preInit.sqf
@@ -1,0 +1,10 @@
+#include "script_component.hpp"
+SCRIPT(XEH_preInit);
+
+ADDON = false;
+#include "XEH_PREP.sqf"
+
+GVAR(terrainChunks) = createHashMap;
+GVAR(originalTerrainChunks) = createHashMap;
+
+ADDON = true;

--- a/addons/terrain/config.cpp
+++ b/addons/terrain/config.cpp
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = CSTRING(component);
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"cba_common", "cba_xeh"};
+        author = "$STR_CBA_Author";
+        authors[] = {"Seb"};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgFunctions.hpp"
+#include "CfgEventHandlers.hpp"

--- a/addons/terrain/fnc_addTerrainHeight.sqf
+++ b/addons/terrain/fnc_addTerrainHeight.sqf
@@ -1,0 +1,36 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_addTerrainHeight
+
+Description:
+    Add terrain height to an area. 
+
+Parameters:
+    _area - argument compatible with https://community.bistudio.com/wiki/BIS_fnc_getArea 
+        [TRIGGER, MARKER, LOCATION, ARRAY]
+    _height - height in metres to add. Negative number lowers terrain [NUMBER]
+    _adjustObjects - Adjust objects to new height [BOOL]
+    _smooth - if true, add 0 height at edge of area and _height at centre. UNIMPLEMENTED
+
+
+Returns:
+    Whether the terrain was succesfully changed
+
+Examples:
+    ["marker1", 20, false, true] call CBA_fnc_addTerrainHeight
+
+Author:
+    Seb
+---------------------------------------------------------------------------- */
+
+params [
+    "_area",
+    "_height",
+    "_adjustObjects",
+    "_smooth"
+];
+private _positionsAndHeights = _area call CBA_fnc_getAreaTerrainGrid;
+_positionsAndHeights = _positionsAndHeights apply {_x vectorAdd [0, 0, _height]};
+// TODO: implement smoothing
+private _success = [_positionsAndHeights, _adjustObjects] call CBA_fnc_setTerrainHeight;
+_success

--- a/addons/terrain/fnc_chunkOrigin.sqf
+++ b/addons/terrain/fnc_chunkOrigin.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 /* ----------------------------------------------------------------------------
-Function: CBA_fnc_chunkOrigin
+Function: CBA_terrain_fnc_chunkOrigin
 
 Description:
     Returns the origin (south-west) corner position of the chunk containing the provided position
@@ -13,7 +13,7 @@ Returns:
 
 Examples:
     (begin example)
-        _origin = [getPos player] call CBA_fnc_chunkOrigin
+        _origin = [getPos player] call CBA_terrain_fnc_chunkOrigin
         systemchat str ["The origin of your chunk is:", _origin]
     (end)
 

--- a/addons/terrain/fnc_chunkOrigin.sqf
+++ b/addons/terrain/fnc_chunkOrigin.sqf
@@ -1,0 +1,28 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_chunkOrigin
+
+Description:
+    Returns the origin (south-west) corner position of the chunk containing the provided position
+
+Parameters:
+    _pos - Position to check the chunk origin of [ARRAY]
+
+Returns:
+    The origin position of the chunk containing the provided position. Z is always 0. [ARRAY]
+
+Examples:
+    (begin example)
+        _origin = [getPos player] call CBA_fnc_chunkOrigin
+        systemchat str ["The origin of your chunk is:", _origin]
+    (end)
+
+Author:
+    Seb
+---------------------------------------------------------------------------- */
+params ["_pos"];
+getTerrainInfo params ["", "", "_cellSize", "_resolution", ""];
+private _step = _cellSize*CHUNKSIZE;
+private _origin = _pos apply {(floor (_x/_step))*_step};
+_origin set [2, 0];
+_origin

--- a/addons/terrain/fnc_getAreaTerrainGrid.sqf
+++ b/addons/terrain/fnc_getAreaTerrainGrid.sqf
@@ -1,0 +1,59 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_getAreaTerrainGrid
+
+Description:
+    Returns all terrain points in the specified area
+
+Parameters:
+    _area - the area to get the terrain points within [
+        TRIGGER, 
+        MARKER, 
+        LOCATION, 
+        ARRAY in format [center, distance] or [center, [a, b, angle, rect]] or [center, [a, b, angle, rect, height]]
+    ]
+    see https://community.bistudio.com/wiki/BIS_fnc_getArea
+
+Returns:
+    Array of positions [[x1,y1,z1], [x2,y2,z2]...] [ARRAY]
+
+Examples:
+    (begin example)
+        _allPoints = "marker1" call CBA_fnc_getAreaTerrainGrid;
+    (end)
+
+Author:
+    Seb
+---------------------------------------------------------------------------- */
+
+params [
+    "_areaArg"
+];
+
+getTerrainInfo params ["", "", "_cellSize", "_resolution", ""];
+private _area = _areaArg call BIS_fnc_getArea;
+_area set [5, -1]; // Ignore Z value from objects/markers
+private _centre = (_area#0) select [0,2];
+
+// Get all points that lie within a rectangle guaranteed to contain the entire area
+private _boundarySize = ((_area#1) max (_area#2)) * 1.42;
+private _numCells = ceil (2*_boundarySize/_cellSize);
+_centre apply {floor ((_x-_boundarySize)/_cellSize)} params ["_cellX", "_cellY"];
+private _minX = _cellX max 0;
+private _minY = _cellY max 0;
+private _maxX = (_cellX + _numCells) min _resolution;
+private _maxY = (_cellY + _numCells) min _resolution;
+private _positionsAndHeights = [];
+for "_cx" from _minX to _maxX do {
+    for "_cy" from _minY to _maxY do {
+        _positionsAndHeights pushBack ([_cx, _cy, 0] vectorMultiply _cellSize);
+    };
+};
+
+// Filter list to points actually within the area
+_positionsAndHeights = (_positionsAndHeights inAreaArray _area);
+{
+    _x set [2, getTerrainHeight _x]
+} forEach _positionsAndHeights;
+
+_positionsAndHeights

--- a/addons/terrain/fnc_getChunk.sqf
+++ b/addons/terrain/fnc_getChunk.sqf
@@ -13,7 +13,7 @@ Returns:
 
 Examples:
     (begin example)
-    private _chunkData = [getPos player] call CBA_fnc_getChunk;
+    private _chunkData = [getPos player] call CBA_terrain_fnc_getChunk;
     (end)
 
 Author:

--- a/addons/terrain/fnc_getChunk.sqf
+++ b/addons/terrain/fnc_getChunk.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 /* ----------------------------------------------------------------------------
-Function: CBA_fnc_getChunk
+Function: CBA_terrain_fnc_getChunk
 
 Description:
     Given a a coordinate, return all terrain points in the chunk containing the coordinate. 

--- a/addons/terrain/fnc_getChunk.sqf
+++ b/addons/terrain/fnc_getChunk.sqf
@@ -1,0 +1,39 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_getChunk
+
+Description:
+    Given a a coordinate, return all terrain points in the chunk containing the coordinate. 
+
+Parameters:
+    _pos = Position inside chunk [ARRAY]
+
+Returns:
+    Array of positions [[x1,y1,z1], [x2,y2,z2]...] [ARRAY]
+
+Examples:
+    (begin example)
+    private _chunkData = [getPos player] call CBA_fnc_getChunk;
+    (end)
+
+Author:
+    Seb
+---------------------------------------------------------------------------- */
+params ["_pos"];
+_pos = [_pos] call FUNC(chunkOrigin);
+getTerrainInfo params ["", "", "_cellSize", "_resolution", ""];
+private _chunkPositionsAndHeights = [];
+for "_cellX" from 0 to CHUNKSIZE - 1 do {
+    for "_cellY" from 0 to CHUNKSIZE - 1 do {
+        private _coordPos = _pos vectorAdd ([_cellX, _cellY, 0] vectorMultiply _cellSize);
+        _coordPos set [2, getTerrainHeight _coordPos];
+        _chunkPositionsAndHeights pushBack _coordPos;
+    };
+};
+// If this is the first time getting this chunk, save original terrain.
+private _key = str _pos;
+if (isServer && {!(_key in GVAR(originalTerrainChunks))}) then {
+    GVAR(originalTerrainChunks) set [_key, _chunkPositionsAndHeights];
+};
+
+_chunkPositionsAndHeights

--- a/addons/terrain/fnc_nearestTerrainPoint.sqf
+++ b/addons/terrain/fnc_nearestTerrainPoint.sqf
@@ -1,0 +1,28 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_nearestTerrainPoint
+
+Description:
+    Given a a coordinate, return the closest terrain point and the Z value of that terrain point
+
+Parameters:
+    _pos = position to find the nearest chunk to
+
+Returns:
+    positionASL of the nearest terrain point [ARRAY] 
+
+Examples:
+    (begin example)
+    player setPosASL ([getPos player] call CBA_fnc_nearestTerrainPoint);
+    (end)
+
+Author:
+    Seb
+---------------------------------------------------------------------------- */
+params ["_position"];
+getTerrainInfo params ["", "", "_cellSize", "_resolution", ""];
+private _pos = (_position select [0,2]) apply {
+    (round (_x/_cellsize))*_cellSize
+};
+_pos set [2, getTerrainHeight _pos];
+_pos

--- a/addons/terrain/fnc_positionsAndHeightsToChunks.sqf
+++ b/addons/terrain/fnc_positionsAndHeightsToChunks.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 /* ----------------------------------------------------------------------------
-Function: CBA_fnc_positionsAndHeightsToChunks
+Function: CBA_terrain_fnc_positionsAndHeightsToChunks
 
 Description:
     Given a set of coordinates, [[x1,y1,z1], [x2,y2,z2]...], this function will return a complete
@@ -25,7 +25,7 @@ Examples:
             [1000, 1005, 25], 
             [1005, 1005, 25]
         ]
-    ] call CBA_fnc_positionsAndHeightsToChunks;
+    ] call CBA_terrain_fnc_positionsAndHeightsToChunks;
     {
         private _origin = parseSimpleArray _x;
         private _chunkPositionsAndHeights = _y;

--- a/addons/terrain/fnc_positionsAndHeightsToChunks.sqf
+++ b/addons/terrain/fnc_positionsAndHeightsToChunks.sqf
@@ -1,0 +1,70 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_positionsAndHeightsToChunks
+
+Description:
+    Given a set of coordinates, [[x1,y1,z1], [x2,y2,z2]...], this function will return a complete
+    set of modified chunks where the closest point to each provided point is set to the provided
+    Z value.
+    Where only part of a chunk is modified, the rest of the chunk will be returned with the
+    existing terrain height.
+
+Parameters:
+    _positionsAndHeights - array of [[x1,y1,z1], [x2,y2,z2]...]  [ARRAY]
+
+Returns:
+    Hashmap where the key is a string of origin position and the value is the [[x1,y1,z1], [x2,y2,z2]...]
+    in chunk data format.
+
+Examples:
+    (begin example)
+    private _chunkData = [
+        [
+            [1000, 1000, 25], 
+            [1005, 1000, 25], 
+            [1000, 1005, 25], 
+            [1005, 1005, 25]
+        ]
+    ] call CBA_fnc_positionsAndHeightsToChunks;
+    {
+        private _origin = parseSimpleArray _x;
+        private _chunkPositionsAndHeights = _y;
+    } forEach _chunkData;
+    (end)
+
+Author:
+    Seb
+---------------------------------------------------------------------------- */
+params ["_positionsAndHeights"];
+
+private _fnc_chunkGetOrDefault = {
+    params ["_pos", "_chunksData"];
+    getTerrainInfo params ["", "", "_cellSize", "_resolution", ""];
+    // Nearest chunk origin (bottom-left)
+    _pos = [_pos] call FUNC(chunkOrigin);
+    private _hash = str _pos;
+    private _chunkPositionsAndHeights = _chunksData get _hash;
+    if (isNil "_chunkPositionsAndHeights") then {
+        _chunkPositionsAndHeights = [_pos] call FUNC(getChunk);
+        _chunksData set [_hash, _chunkPositionsAndHeights];
+    };
+    [_pos, _chunkPositionsAndHeights]
+};
+
+getTerrainInfo params ["", "", "_cellSize", "_resolution", ""];
+// Cache calls to chunk builder
+private _chunksData = createHashMap;
+{
+    private _pos = [_x] call CBA_fnc_nearestTerrainPoint;
+    _pos set [2, _x#2];
+    private _chunkInfo = [_pos, _chunksData] call _fnc_chunkGetOrDefault;
+    _chunkInfo params ["_chunkOrigin", "_chunkPositionsAndHeights"];
+    private _indices = (_pos vectorDiff _chunkOrigin) vectorMultiply (1/_cellSize);
+    _indices params ["_indexX", "_indexY"];
+    // List of points is a flat array but is ordered so calc and set index
+    private _index = CHUNKSIZE*_indexX + _indexY;
+    systemChat str _index;
+    _chunkPositionsAndHeights set [_index, _pos];
+} forEach _positionsAndHeights;
+
+_chunksData

--- a/addons/terrain/fnc_setTerrainHeight.sqf
+++ b/addons/terrain/fnc_setTerrainHeight.sqf
@@ -1,0 +1,44 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_setTerrainHeight
+
+Description:
+    Replicate functionality of setTerrainHeight command, but internally split the provided set of 
+    positions up into 'chunks' and save the resulting changes for save serialisation/deserialisation
+
+Parameters:
+    _positionsAndHeights - array of [[x1,y1,z1], [x2,y2,z2]...]  [ARRAY]
+    _adjustObjects - if true then objects on modified points are moved up/down to keep the same ATL height  [BOOL]
+
+Returns:
+    Whether the terrain was successfully edited [BOOL];
+
+Examples:
+    (begin example)
+    [
+        [
+            [1000, 1000, 25], 
+            [1005, 1000, 25], 
+            [1000, 1005, 25], 
+            [1005, 1005, 25]
+        ],
+        true
+    ] call CBA_fnc_setTerrainHeight;
+    (end)
+
+Author:
+    Seb
+---------------------------------------------------------------------------- */
+params [
+    "_positionsAndHeights", 
+    "_adjustObjects"
+];
+if !(isServer) exitWith {false};
+private _chunksData = [_positionsAndHeights] call FUNC(positionsAndHeightsToChunks);
+{
+    private _key = _x;
+    private _chunkPositionsAndHeights = _y;
+    setTerrainHeight [_chunkPositionsAndHeights, _adjustObjects];
+    GVAR(modifiedChunks) set [_key, [_chunkPositionsAndHeights, _adjustObjects]];
+} forEach _chunksData;
+true

--- a/addons/terrain/license.txt
+++ b/addons/terrain/license.txt
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/addons/terrain/script_component.hpp
+++ b/addons/terrain/script_component.hpp
@@ -1,0 +1,15 @@
+#define COMPONENT terrain
+#include "\x\cba\addons\main\script_mod.hpp"
+
+
+#ifdef DEBUG_ENABLED_COMMON
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_COMMON
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_COMMON
+#endif
+
+#include "\x\cba\addons\main\script_macros.hpp"
+
+#define CHUNKSIZE 8

--- a/addons/terrain/stringtable.xml
+++ b/addons/terrain/stringtable.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project name="CBA_A3">
+    <Package name="Strings">
+        <Key ID="STR_CBA_Strings_Component">
+            <English>Community Base Addons - Terrain</English>
+            <German>Community Base Addons - Zeichenketten</German>
+            <Japanese>Community Base Addons - ストリングス</Japanese>
+            <Chinese>社群基礎模組 - 字串</Chinese>
+            <Chinesesimp>社群基础模组 - 字串</Chinesesimp>
+            <Portuguese>Extensões de Base Comunitária - Palavras</Portuguese>
+            <Russian>Community Base Addons - Строки</Russian>
+            <Polish>Community Base Addons - Ciągi znaków</Polish>
+            <French>Community Base Addons - Textes</French>
+            <Turkish>Community Base Addons - Yazılar</Turkish>
+            <Italian>Community Base Addons - Stringhe</Italian>
+            <Czech>Community Base Addons - Texty</Czech>
+        </Key>
+    </Package>
+</Project>

--- a/addons/terrain/stringtable.xml
+++ b/addons/terrain/stringtable.xml
@@ -3,17 +3,6 @@
     <Package name="Strings">
         <Key ID="STR_CBA_Strings_Component">
             <English>Community Base Addons - Terrain</English>
-            <German>Community Base Addons - Zeichenketten</German>
-            <Japanese>Community Base Addons - ストリングス</Japanese>
-            <Chinese>社群基礎模組 - 字串</Chinese>
-            <Chinesesimp>社群基础模组 - 字串</Chinesesimp>
-            <Portuguese>Extensões de Base Comunitária - Palavras</Portuguese>
-            <Russian>Community Base Addons - Строки</Russian>
-            <Polish>Community Base Addons - Ciągi znaków</Polish>
-            <French>Community Base Addons - Textes</French>
-            <Turkish>Community Base Addons - Yazılar</Turkish>
-            <Italian>Community Base Addons - Stringhe</Italian>
-            <Czech>Community Base Addons - Texty</Czech>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
## Terrain library

The basic idea is a wrapper library for setTerrainHeight which addresses some of its [shortcomings ](https://community.bistudio.com/wiki/setTerrainHeight)(network optimisations, savegame serialisation, ease of use).

### Network optimisation:

Split terrain heights up into `n*n` sized chunks of terrain cells, and expose a set of commands which update these chunks instead of whatever was passed verbatim.

The `CBA_fnc_setTerrainHeight` function uses the exact same syntax as the vanilla command, but under the hood will only ever modify terrain height in groups of `n*n` chunks aligned to a grid.

Any mod can use this command and know that the JIP queue isn't spammed any more than it needs to be.

### Savegames;

Chunks are uninitialsed by default, but when a function touches that chunk any changes are stored so they can be retrieved during savegame load. Therefore modders don't have to manage this themselves, which could be a source of issues if two mods try and modify the same terrain and save/load it themselves.

### Ease of use commands

Set terrain height is a bit unwieldy. I have created the addTerrainHeight as an example command for how life could be made easier by working in areas instead of groups of points

## TODO:

- [ ] Create chunking system
- [ ] Create savegame serialisation
- [ ] Create suite of helper functions that use areas instead of coordinates:
- - [ ] addTerrainHeight
- - [ ] flattenTerrainArea, 
- - [ ] restoreTerrainHeight
- - [ ] any other QOL stuff?
- [ ] Bugtest

**WIP proof of concept, all the commands added thus for do work but I'm not going to spend any more time unless this is something people are actually interested in**