### PR TITLE
Common - Replace canAdd with CBA_fnc_canAddItem

### DIFF
--- a/addons/common/fnc_addBackpackCargo.sqf
+++ b/addons/common/fnc_addBackpackCargo.sqf
@@ -53,11 +53,11 @@ if (isNull _config || {getNumber (_config >> "scope") < 1} || {getNumber (_confi
 };
 
 if (_verify) then {
-    if (_container canAdd [_item, _count]) then {
+    if ([_container, _item, _count] call CBA_fnc_canAddItem) then {
         _container addBackpackCargoGlobal [_item, _count];
         _return = true;
     } else {
-        while {_container canAdd _item && {_count > 0}} do {
+        while {[_container, _item] call CBA_fnc_canAddItem && {_count > 0}} do {
             _container addBackpackCargoGlobal [_item, 1];
             _count = _count - 1;
         };

--- a/addons/common/fnc_addItem.sqf
+++ b/addons/common/fnc_addItem.sqf
@@ -48,7 +48,7 @@ if (isNull _config || {getNumber (_config >> "scope") < 1}) exitWith {
 };
 
 if (_verify) then {
-    if (_unit canAdd _item) then {
+    if ([_unit, _item] call CBA_fnc_canAddItem) then {
         _unit addItem _item;
         _return = true;
     } else {

--- a/addons/common/fnc_addItemCargo.sqf
+++ b/addons/common/fnc_addItemCargo.sqf
@@ -53,11 +53,11 @@ if (isNull _config || {getNumber (_config >> "scope") < 1}) exitWith {
 };
 
 if (_verify) then {
-    if (_container canAdd [_item, _count]) then {
+    if ([_container, _item, _count] call CBA_fnc_canAddItem) then {
         _container addItemCargoGlobal [_item, _count];
         _return = true;
     } else {
-        while {_container canAdd _item && {_count > 0}} do {
+        while {[_container, _item] call CBA_fnc_canAddItem && {_count > 0}} do {
             _container addItemCargoGlobal [_item, 1];
             _count = _count - 1;
         };

--- a/addons/common/fnc_addMagazineCargo.sqf
+++ b/addons/common/fnc_addMagazineCargo.sqf
@@ -54,11 +54,11 @@ if (isNull _config || {getNumber (_config >> "scope") < 2}) exitWith {
 };
 
 if (_verify) then {
-    if (_container canAdd [_item, _count]) then {
+    if ([_container, _item, _count] call CBA_fnc_canAddItem) then {
         _container addMagazineAmmoCargo [_item, _count, _ammo];
         _return = true;
     } else {
-        while {_container canAdd _item && {_count > 0}} do {
+        while {[_container, _item] call CBA_fnc_canAddItem && {_count > 0}} do {
             _container addMagazineAmmoCargo [_item, 1, _ammo];
             _count = _count - 1;
         };

--- a/addons/common/fnc_addWeaponCargo.sqf
+++ b/addons/common/fnc_addWeaponCargo.sqf
@@ -53,11 +53,11 @@ if (isNull _config || {getNumber (_config >> "scope") < 1}) exitWith {
 };
 
 if (_verify) then {
-    if (_container canAdd [_item, _count]) then {
+    if ([_container, _item, _count] call CBA_fnc_canAddItem) then {
         _container addWeaponCargoGlobal [_item, _count];
         _return = true;
     } else {
-        while {_container canAdd _item && {_count > 0}} do {
+        while {[_container, _item] call CBA_fnc_canAddItem && {_count > 0}} do {
             _container addWeaponCargoGlobal [_item, 1];
             _count = _count - 1;
         };

--- a/addons/common/fnc_canAddItem.sqf
+++ b/addons/common/fnc_canAddItem.sqf
@@ -54,6 +54,7 @@ if (isNil "_mass") then {
     _allowedSlots = [TYPE_UNIFORM, TYPE_VEST, TYPE_BACKPACK];
     private _cfgWeaponsItem = configFile >> "CfgWeapons" >> _item;
     private _cfgMagazinesItem = configFile >> "CfgMagazines" >> _item;
+    private _cfgVehiclesItem = configFile >> "CfgVehicles" >> _item;
     private _cfgGlassesItem = configFile >> "CfgGlasses" >> _item;
     switch true do {
         case (isClass _cfgWeaponsItem): {
@@ -75,9 +76,10 @@ if (isNil "_mass") then {
                 _cfgWeaponSlotsInfo >> "allowedSlots"
             ];
         };
-        case (isClass _cfgMagazinesItem): {
-            _mass = getNumber (_cfgMagazinesItem >> "mass");
-            private _cfgAllowedSlots = _cfgMagazinesItem >> "allowedSlots";
+        case (isClass _cfgMagazinesItem || {isClass _cfgVehiclesItem}): {
+            private _cfgItem = [_cfgVehiclesItem, _cfgMagazinesItem] select isClass _cfgMagazinesItem;
+            _mass = getNumber (_cfgItem >> "mass");
+            private _cfgAllowedSlots = _cfgItem >> "allowedSlots";
             if (isArray _cfgAllowedSlots) then {
                 _allowedSlots = getArray _cfgAllowedSlots;
             };

--- a/addons/common/fnc_canAddItem.sqf
+++ b/addons/common/fnc_canAddItem.sqf
@@ -43,6 +43,7 @@ if (isNull _unit || {_item isEqualTo ""}) exitWith {false};
 #define TYPE_VEST 701
 #define TYPE_UNIFORM 801
 #define TYPE_BACKPACK 901
+#define FLOAT_CORRECTION 0.0001
 
 if (isNil QGVAR(itemMassAllowedSlots)) then {
     GVAR(itemMassAllowedSlots) = createHashMap;
@@ -107,7 +108,7 @@ if (_unit isKindOf "CAManBase") then {
             _mass == 0
             || {
                 // each time subtract whole number of items which can be put in container
-                _count = _count - floor (maxLoad uniformContainer _unit * (1 - loadUniform _unit) / _mass);
+                _count = _count - floor (maxLoad uniformContainer _unit * (1 - loadUniform _unit) / _mass + FLOAT_CORRECTION);
                 _count <= 0
             }
         }
@@ -119,7 +120,7 @@ if (_unit isKindOf "CAManBase") then {
         && {
             _mass == 0
             || {
-                _count = _count - floor (maxLoad vestContainer _unit * (1 - loadVest _unit) / _mass);
+                _count = _count - floor (maxLoad vestContainer _unit * (1 - loadVest _unit) / _mass + FLOAT_CORRECTION);
                 _count <= 0
             }
         }
@@ -131,7 +132,7 @@ if (_unit isKindOf "CAManBase") then {
         && {
             _mass == 0
             || {
-                _count = _count - floor (maxLoad backpackContainer _unit * (1 - loadBackpack _unit) / _mass);
+                _count = _count - floor (maxLoad backpackContainer _unit * (1 - loadBackpack _unit) / _mass + FLOAT_CORRECTION);
                 _count <= 0
             }
         }
@@ -142,7 +143,7 @@ if (_unit isKindOf "CAManBase") then {
     // is a vehicle, crate etc.
     _mass == 0
     || {
-        _count = _count - floor (maxLoad _unit * (1 - load _unit) / _mass);
+        _count = _count - floor (maxLoad _unit * (1 - load _unit) / _mass + FLOAT_CORRECTION);
         _count <= 0
     }
 };


### PR DESCRIPTION
**When merged this pull request will:**
- replace `canAdd` with `CBA_fnc_canAddItem`;
- add backpack support to `CBA_fnc_canAddItem`;
- fix float rounding error leading to wrong `CBA_fnc_canAddItem` result.

Mostly because ACE towing rope can disappear in the ground because of full load.

Adding backpack support is required for `addBackpackCargo` function.

In some cases current function implementation can't count correctly. This code puts 28 designators to quadbike and 2 designators to player inventory (or near player):
```
private _v = createVehicle ["B_Quadbike_01_F", player];
clearItemCargoGlobal _v;
[_v, "LaserDesignator", 28, true] call CBA_fnc_addItemCargo;
[player, "LaserDesignator", true] call CBA_fnc_addItem;
[player, "LaserDesignator", true] call CBA_fnc_addItem;
[_v, "LaserDesignator", 2] call CBA_fnc_canAddItem
```
The result is `false` but you can put exactly 2 designators to quadbike inventory.
Here is why (`cursorObject` is quadbike with 28 designators):
```
maxLoad cursorObject = 600
designator mass = 20
load cursorObject = 0.9(3) (==20*28/600)
maxLoad cursorObject * (1 - load cursorObject) / 20 = 600 * 0.0(6) / 20 = 39.(9) / 20 = 1.(9)
floor 1.(9) = 1
1 < 2
```
To work around this problem I added 0.0001 to number before `floor`. I think it's small enough not to make troubles.

Also `floor parseNumber (maxLoad cursorObject * (1 - load cursorObject) / 20 toFixed 5)` can be used as workaround. It's slower but maybe looks better. 