### PR TITLE
Optics - Increase width of hidePeripheralVision slightly to prevent gaps

### DIFF
--- a/addons/optics/fnc_initDisplayInterrupt.sqf
+++ b/addons/optics/fnc_initDisplayInterrupt.sqf
@@ -46,7 +46,7 @@ private _ctrlBlackRight = _display ctrlCreate ["RscText", IDC_BLACK_RIGHT];
 private _width = THIRD_SCREEN_WIDTH;
 
 if (GVAR(hidePeripheralVision)) then {
-    _width = 0.5 - (_bodyPosition select 2)/2 - safezoneXAbs;
+    _width = 0.5 - (_bodyPosition select 2)/2 - safezoneXAbs + pixelW/2;
 };
 
 _ctrlBlackLeft ctrlSetBackgroundColor [0,0,0,1];

--- a/addons/optics/fnc_loadScriptedOptic.sqf
+++ b/addons/optics/fnc_loadScriptedOptic.sqf
@@ -85,7 +85,7 @@ _ctrlReticleSafezone ctrlCommit 0;
 private _width = THIRD_SCREEN_WIDTH;
 
 if (GVAR(hidePeripheralVision)) then {
-    _width = 0.5 - (_bodyPosition select 2)/2 - safezoneXAbs;
+    _width = 0.5 - (_bodyPosition select 2)/2 - safezoneXAbs + pixelW/2;
 };
 
 _ctrlBlackLeft ctrlSetPositionW _width;


### PR DESCRIPTION
ref https://github.com/acemod/ACE3/issues/9141

I can reproduce at those exact resolution and scale/
![20230214000042_1](https://user-images.githubusercontent.com/9376747/218652860-188e8ee2-6d0d-48d5-8919-5cf286dcab5d.jpg)

mine has a gap on the left which is easy to see, but there also is a gap on the right at the edge of the image.

Checking the 3 `ctrlPosition`
Left: `[-0.918847,-0.563663,0.0890598,2.12733]`
Body: `[-0.829787,-1.27305,2.65957,3.5461]`
Right: `[1.82979,-0.563663,0.0890598,2.12733]`

Add up the widths and you get `2.83769` which is identical to the safezoneW
But I guess it's just a rounding error and the left ends a pixel short of where the body begins?
I think just adding half a pixel should be enough?