### PR TITLE
Main - Fix `script_macros_mission` redefinitions

### DIFF
--- a/addons/main/script_macros_mission.hpp
+++ b/addons/main/script_macros_mission.hpp
@@ -43,6 +43,9 @@
 
 */
 
+#undef PATHTO_SYS
+#undef PATHTOF_SYS
+#undef PATHTOF2_SYS
 #ifdef CUSTOM_FOLDER
     #define PATHTO_SYS(var1,var2,var3) ##CUSTOM_FOLDER\##var3.sqf
     #define PATHTOF_SYS(var1,var2,var3) ##CUSTOM_FOLDER\##var3


### PR DESCRIPTION
```
\x\cba\addons\test\config.cpp Rapify:Rap: In File \x\cba\addons\main\script_macros_mission.hpp: 
circa Line 53 #define altered without an #undef
```
these 3 are all defined in script_macros_common.hpp which is included first at the top of macro_mission