### PR TITLE
Fix CBA_fnc_mapGridToPos off by one

### DIFF
--- a/addons/common/fnc_mapGridToPos.sqf
+++ b/addons/common/fnc_mapGridToPos.sqf
@@ -120,15 +120,15 @@ if (IS_STRING(_pos)) then {
             private _check = _start;
             private _minus = 0;
             while {_check == _start} do {
-                _check = format["%1", mapGridPosition [0, _minus]];
                 _minus = _minus - 1;
+                _check = format["%1", mapGridPosition [0, _minus]];
             };
             _rvOriginY = _rvOriginY+(abs _minus)-1;
             _minus = 0;
             _check = _start;
             while {_check == _start} do {
-                _check = format["%1", mapGridPosition [_minus, 0]];
                 _minus = _minus - 1;
+                _check = format["%1", mapGridPosition [_minus, 0]];
             };
             _rvOriginX = _rvOriginX+(abs _minus)-1;
         };


### PR DESCRIPTION
Fix #1362 

With check-decrement ordering the while loops execute twice, leaving `_minus` at -2, then `_rvOriginX`/`_rvOriginY` get set to `0 + (abs - 2) - 1` = 1 (and get cached at `GVAR(rvOriginX)`/`GVAR(rvOriginY)`), then at line 176 said variables get subtracted from previous calculated coordinates, leading to [-1, -1, 0] offset mentioned in the issue.
Manual tests on Altis/Stratis/Malden/VR/Livonia seem to return proper results.

**When merged this pull request will:**
- Describe what this pull request will do
- Each change in a separate line
- Respect the [Submitting Content Guidelines](https://github.com/CBATeam/CBA_A3/wiki/Submitting%20content)
