### PR TITLE
Optics - Fixed magnification text flickering at 1.0x zoom level

### DIFF
--- a/addons/optics/fnc_animateScriptedOptic.sqf
+++ b/addons/optics/fnc_animateScriptedOptic.sqf
@@ -75,7 +75,7 @@ private _zoom = 0.25 call CBA_fnc_getFov select 1;
 
 // To avoid flickering of the magnification text, anything above and including 0.995 is rounded to 1
 if (_zoom >= 0.995) then {
-	_zoom = 1 max _zoom;
+    _zoom = 1 max _zoom;
 };
 
 _ctrlMagnification ctrlSetText format [

--- a/addons/optics/fnc_animateScriptedOptic.sqf
+++ b/addons/optics/fnc_animateScriptedOptic.sqf
@@ -73,6 +73,11 @@ if (cameraView == "GUNNER") then {
 // Add magnification to zeroing control.
 private _zoom = 0.25 call CBA_fnc_getFov select 1;
 
+// To avoid flickering of the magnification text, anything above and including 0.995 is rounded to 1
+if (_zoom >= 0.995) then {
+	_zoom = 1 max _zoom;
+};
+
 _ctrlMagnification ctrlSetText format [
     "(%1x)",
     [_zoom, 1, 1] call CBA_fnc_formatNumber

--- a/addons/optics/fnc_animateScriptedOptic.sqf
+++ b/addons/optics/fnc_animateScriptedOptic.sqf
@@ -73,9 +73,13 @@ if (cameraView == "GUNNER") then {
 // Add magnification to zeroing control.
 private _zoom = 0.25 call CBA_fnc_getFov select 1;
 
-// To avoid flickering of the magnification text, anything above and including 0.995 is rounded to 1
-if (_zoom >= 0.995) then {
-    _zoom = 1 max _zoom;
+// To avoid flickering of the magnification text, cache magnification and only modify magnification if change is big enough
+if (abs (GVAR(magnificationCache) - _zoom) <= 0.005) then {
+    _zoom = GVAR(magnificationCache);
+} else {
+    if (_zoom >= 1) then {
+        GVAR(magnificationCache) = _zoom;
+    };
 };
 
 _ctrlMagnification ctrlSetText format [
@@ -134,10 +138,6 @@ _ctrlBodyNight ctrlSetAngle [_bank, 0.5, 0.5];
 
 // zooming reticle
 if (isNull (_display displayCtrl IDC_ENABLE_ZOOM)) exitWith {};
-
-if (_zoom >= 1) then {
-    GVAR(magnificationCache) = _zoom;
-};
 
 GVAR(ReticleAdjust) set [2, _zoom];
 private _reticleAdjust = linearConversion GVAR(ReticleAdjust);


### PR DESCRIPTION
**When merged this pull request will:**
- Stops the magnification text in the top right corner from flickering when the magnification level is 1.0x.

---

```SQF
0.25 call CBA_fnc_getFov select 1
```
does not return a stable value (it oscillates lightly around 1).

An example scope is the `hlc_optic_atacr` from NIArms.
