### PR TITLE
Common - Added CBA_fnc_execAfterNFrames from ZEN

### DIFF
--- a/addons/common/CfgFunctions.hpp
+++ b/addons/common/CfgFunctions.hpp
@@ -131,6 +131,7 @@ class CfgFunctions {
             PATHTO_FNC(directCall);
             PATHTO_FNC(objectRandom);
             PATHTO_FNC(execNextFrame);
+            PATHTO_FNC(execAfterNFrames);
             PATHTO_FNC(waitAndExecute);
             PATHTO_FNC(waitUntilAndExecute);
             PATHTO_FNC(compileFinal);

--- a/addons/common/fnc_execAfterNFrames.sqf
+++ b/addons/common/fnc_execAfterNFrames.sqf
@@ -1,0 +1,35 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_execAfterNFrames
+
+Description:
+    Executes the given code after the specified number of frames.
+
+Parameters:
+    _function - The function to run. <CODE>
+    _args     - Parameters passed to the function executing. This will be the same array every execution. (optional, default: []) <ANY>
+    _frames   - The amount of frames the execution of the function should be delayed by. (optional, default: 0) <NUMBER>
+
+Returns:
+    Nothing
+
+Examples:
+    (begin example)
+        [{hint "Done!"}, [], 5] call cba_fnc_execAfterNFrames;
+    (end)
+
+Author:
+    mharis001, donated from ZEN
+---------------------------------------------------------------------------- */
+
+if (canSuspend) exitWith {
+    [CBA_fnc_execAfterNFrames, _this] call CBA_fnc_directCall;
+};
+
+params [["_function", {}, [{}]], ["_args", []], ["_frames", 0, [0]]];
+
+if (_frames > 0) exitWith {
+    [CBA_fnc_execAfterNFrames, [_function, _args, _frames - 1]] call CBA_fnc_execNextFrame;
+};
+
+_args call _function;

--- a/addons/common/fnc_execAfterNFrames.sqf
+++ b/addons/common/fnc_execAfterNFrames.sqf
@@ -11,7 +11,7 @@ Parameters:
     _frames   - The amount of frames the execution of the function should be delayed by. (optional, default: 0) <NUMBER>
 
 Returns:
-    Nothing
+    Nothing Useful
 
 Examples:
     (begin example)

--- a/addons/common/fnc_execNextFrame.sqf
+++ b/addons/common/fnc_execNextFrame.sqf
@@ -3,11 +3,12 @@
 Function: CBA_fnc_execNextFrame
 
 Description:
-    Executes a code once in non sched environment on the next frame.
+    Executes a code once in non sched environment delayed by n frames.
 
 Parameters:
     _function - The function to run. <CODE>
-    _args     - Parameters passed to the function executing. This will be the same array every execution. [optional] <ANY>
+    _args     - Parameters passed to the function executing. This will be the same array every execution. (optional, default: []) <ANY>
+    _frames   - The number of frames the execution will be delayed by. (optional, default: 1) <NUMBER>
 
 Returns:
     Nothing
@@ -21,9 +22,17 @@ Author:
     esteldunedain and PabstMirror, donated from ACE3
 ---------------------------------------------------------------------------- */
 
-params [["_function", {}, [{}]], ["_args", []]];
+params [["_function", {}, [{}]], ["_args", []], ["_frames", 1, [0]]];
 
-if (diag_frameno != GVAR(nextFrameNo)) then {
+// Do not allow negative or 0 frame delays
+_frames = _frames max 1;
+
+if (_frames > 1) exitWith {
+    GVAR(nextFrameNBuffer) pushBack [diag_frameNo + _frames, _args, _function];
+    GVAR(nextFrameNBufferIsSorted) = false;
+};
+
+if (diag_frameNo != GVAR(nextFrameNo)) then {
     GVAR(nextFrameBufferA) pushBack [_args, _function];
 } else {
     GVAR(nextFrameBufferB) pushBack [_args, _function];

--- a/addons/common/fnc_execNextFrame.sqf
+++ b/addons/common/fnc_execNextFrame.sqf
@@ -7,7 +7,7 @@ Description:
 
 Parameters:
     _function - The function to run. <CODE>
-    _args     - Parameters passed to the function executing. This will be the same array every execution. [optional] <ANY>
+    _args     - Parameters passed to the function executing. This will be the same array every execution. (optional, default: []) <ANY>
 
 Returns:
     Nothing

--- a/addons/common/fnc_execNextFrame.sqf
+++ b/addons/common/fnc_execNextFrame.sqf
@@ -3,12 +3,11 @@
 Function: CBA_fnc_execNextFrame
 
 Description:
-    Executes a code once in non sched environment delayed by n frames.
+    Executes a code once in non sched environment on the next frame.
 
 Parameters:
     _function - The function to run. <CODE>
-    _args     - Parameters passed to the function executing. This will be the same array every execution. (optional, default: []) <ANY>
-    _frames   - The number of frames the execution will be delayed by. (optional, default: 1) <NUMBER>
+    _args     - Parameters passed to the function executing. This will be the same array every execution. [optional] <ANY>
 
 Returns:
     Nothing
@@ -22,17 +21,9 @@ Author:
     esteldunedain and PabstMirror, donated from ACE3
 ---------------------------------------------------------------------------- */
 
-params [["_function", {}, [{}]], ["_args", []], ["_frames", 1, [0]]];
+params [["_function", {}, [{}]], ["_args", []]];
 
-// Do not allow negative or 0 frame delays
-_frames = _frames max 1;
-
-if (_frames > 1) exitWith {
-    GVAR(nextFrameNBuffer) pushBack [diag_frameNo + _frames, _args, _function];
-    GVAR(nextFrameNBufferIsSorted) = false;
-};
-
-if (diag_frameNo != GVAR(nextFrameNo)) then {
+if (diag_frameno != GVAR(nextFrameNo)) then {
     GVAR(nextFrameBufferA) pushBack [_args, _function];
 } else {
     GVAR(nextFrameBufferB) pushBack [_args, _function];

--- a/addons/common/fnc_execNextFrame.sqf
+++ b/addons/common/fnc_execNextFrame.sqf
@@ -10,7 +10,7 @@ Parameters:
     _args     - Parameters passed to the function executing. This will be the same array every execution. (optional, default: []) <ANY>
 
 Returns:
-    Nothing
+    Nothing Useful
 
 Examples:
     (begin example)

--- a/addons/common/init_perFrameHandler.sqf
+++ b/addons/common/init_perFrameHandler.sqf
@@ -9,7 +9,9 @@ GVAR(lastTickTime) = diag_tickTime;
 
 GVAR(waitAndExecArray) = [];
 GVAR(waitAndExecArrayIsSorted) = false;
-GVAR(nextFrameNo) = diag_frameno + 1;
+GVAR(nextFrameNBuffer) = [];
+GVAR(nextFrameNBufferAIsSorted) = false;
+GVAR(nextFrameNo) = diag_frameNo + 1;
 GVAR(nextFrameBufferA) = [];
 GVAR(nextFrameBufferB) = [];
 GVAR(waitUntilAndExecArray) = [];
@@ -22,9 +24,9 @@ GVAR(waitUntilAndExecArray) = [];
 
     // frame number does not match expected; can happen between pre and postInit, save-game load and on closing map
     // need to manually set nextFrameNo, so new items get added to buffer B and are not executed this frame
-    if (diag_frameno != GVAR(nextFrameNo)) then {
-        TRACE_2("frame mismatch",diag_frameno,GVAR(nextFrameNo));
-        GVAR(nextFrameNo) = diag_frameno;
+    if (diag_frameNo != GVAR(nextFrameNo)) then {
+        TRACE_2("frame mismatch",diag_frameNo,GVAR(nextFrameNo));
+        GVAR(nextFrameNo) = diag_frameNo;
     };
 
     // Execute per frame handlers
@@ -44,7 +46,9 @@ GVAR(waitUntilAndExecArray) = [];
         GVAR(waitAndExecArray) sort true;
         GVAR(waitAndExecArrayIsSorted) = true;
     };
+
     private _delete = false;
+
     {
         if (_x select 0 > CBA_missionTime) exitWith {};
 
@@ -54,8 +58,31 @@ GVAR(waitUntilAndExecArray) = [];
         GVAR(waitAndExecArray) set [_forEachIndex, objNull];
         _delete = true;
     } forEach GVAR(waitAndExecArray);
+
     if (_delete) then {
         GVAR(waitAndExecArray) = GVAR(waitAndExecArray) - [objNull];
+        _delete = false;
+    };
+
+
+    // Execute the exec next n frame functions
+    if (!GVAR(nextFrameNBufferIsSorted)) then {
+        GVAR(nextFrameNBuffer) sort true;
+        GVAR(nextFrameNBufferIsSorted) = true;
+    };
+
+    {
+        if (_x select 0 > GVAR(nextFrameNo)) exitWith {};
+
+        (_x select 1) call (_x select 2);
+
+        // Mark the element for deletion so it's not executed ever again
+        GVAR(nextFrameNBuffer) set [_forEachIndex, objNull];
+        _delete = true;
+    } forEach GVAR(nextFrameNBuffer);
+
+    if (_delete) then {
+        GVAR(nextFrameNBuffer) = GVAR(nextFrameNBuffer) - [objNull];
         _delete = false;
     };
 
@@ -64,10 +91,12 @@ GVAR(waitUntilAndExecArray) = [];
     {
         (_x select 0) call (_x select 1);
     } forEach GVAR(nextFrameBufferA);
+
     // Swap double-buffer:
     GVAR(nextFrameBufferA) = GVAR(nextFrameBufferB);
     GVAR(nextFrameBufferB) = [];
-    GVAR(nextFrameNo) = diag_frameno + 1;
+
+    GVAR(nextFrameNo) = diag_frameNo + 1;
 
 
     // Execute the waitUntilAndExec functions:
@@ -81,6 +110,7 @@ GVAR(waitUntilAndExecArray) = [];
             _delete = true;
         };
     } forEach GVAR(waitUntilAndExecArray);
+
     if (_delete) then {
         GVAR(waitUntilAndExecArray) = GVAR(waitUntilAndExecArray) - [objNull];
     };

--- a/addons/common/init_perFrameHandler.sqf
+++ b/addons/common/init_perFrameHandler.sqf
@@ -9,9 +9,7 @@ GVAR(lastTickTime) = diag_tickTime;
 
 GVAR(waitAndExecArray) = [];
 GVAR(waitAndExecArrayIsSorted) = false;
-GVAR(nextFrameNBuffer) = [];
-GVAR(nextFrameNBufferAIsSorted) = false;
-GVAR(nextFrameNo) = diag_frameNo + 1;
+GVAR(nextFrameNo) = diag_frameno + 1;
 GVAR(nextFrameBufferA) = [];
 GVAR(nextFrameBufferB) = [];
 GVAR(waitUntilAndExecArray) = [];
@@ -24,9 +22,9 @@ GVAR(waitUntilAndExecArray) = [];
 
     // frame number does not match expected; can happen between pre and postInit, save-game load and on closing map
     // need to manually set nextFrameNo, so new items get added to buffer B and are not executed this frame
-    if (diag_frameNo != GVAR(nextFrameNo)) then {
-        TRACE_2("frame mismatch",diag_frameNo,GVAR(nextFrameNo));
-        GVAR(nextFrameNo) = diag_frameNo;
+    if (diag_frameno != GVAR(nextFrameNo)) then {
+        TRACE_2("frame mismatch",diag_frameno,GVAR(nextFrameNo));
+        GVAR(nextFrameNo) = diag_frameno;
     };
 
     // Execute per frame handlers
@@ -46,9 +44,7 @@ GVAR(waitUntilAndExecArray) = [];
         GVAR(waitAndExecArray) sort true;
         GVAR(waitAndExecArrayIsSorted) = true;
     };
-
     private _delete = false;
-
     {
         if (_x select 0 > CBA_missionTime) exitWith {};
 
@@ -58,31 +54,8 @@ GVAR(waitUntilAndExecArray) = [];
         GVAR(waitAndExecArray) set [_forEachIndex, objNull];
         _delete = true;
     } forEach GVAR(waitAndExecArray);
-
     if (_delete) then {
         GVAR(waitAndExecArray) = GVAR(waitAndExecArray) - [objNull];
-        _delete = false;
-    };
-
-
-    // Execute the exec next n frame functions
-    if (!GVAR(nextFrameNBufferIsSorted)) then {
-        GVAR(nextFrameNBuffer) sort true;
-        GVAR(nextFrameNBufferIsSorted) = true;
-    };
-
-    {
-        if (_x select 0 > GVAR(nextFrameNo)) exitWith {};
-
-        (_x select 1) call (_x select 2);
-
-        // Mark the element for deletion so it's not executed ever again
-        GVAR(nextFrameNBuffer) set [_forEachIndex, objNull];
-        _delete = true;
-    } forEach GVAR(nextFrameNBuffer);
-
-    if (_delete) then {
-        GVAR(nextFrameNBuffer) = GVAR(nextFrameNBuffer) - [objNull];
         _delete = false;
     };
 
@@ -91,12 +64,10 @@ GVAR(waitUntilAndExecArray) = [];
     {
         (_x select 0) call (_x select 1);
     } forEach GVAR(nextFrameBufferA);
-
     // Swap double-buffer:
     GVAR(nextFrameBufferA) = GVAR(nextFrameBufferB);
     GVAR(nextFrameBufferB) = [];
-
-    GVAR(nextFrameNo) = diag_frameNo + 1;
+    GVAR(nextFrameNo) = diag_frameno + 1;
 
 
     // Execute the waitUntilAndExec functions:
@@ -110,7 +81,6 @@ GVAR(waitUntilAndExecArray) = [];
             _delete = true;
         };
     } forEach GVAR(waitUntilAndExecArray);
-
     if (_delete) then {
         GVAR(waitUntilAndExecArray) = GVAR(waitUntilAndExecArray) - [objNull];
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Adds ~~an extra parameter to `CBA_fnc_execNextFrame`~~ a new function `CBA_fnc_execAfterNFrames` that allows you to specify by how many frames you want the execution of the passed code to be delayed by. Closes #1578.

~~For robustness' sake I left the existing code of `CBA_fnc_execNextFrame` alone, which means if the delay is 1 frame, then it uses the old code.~~

During testing I noticed there is a bug, where if you call the function in a certain manner, it (EDIT: it = `CBA_fnc_execNextFrame`) will add an extra frame of waiting. This also happens in the current steam release however, so I'm not sure if it's worth trying to fix.
Here's the code I used to test this part specifically:

```SQF
private _delay = 1;

for "_index" from 1 to 10000 do {
    [{
        // If expected result, don't print result
        if (diag_frameno == ((_this select 0) + (_this select 1))) exitWith {};

        systemChat format ["%1, %2", diag_frameno, _this select 0];
    }, [diag_frameno, _delay], _delay] call CBA_fnc_execNextFrame;
	
    uiSleep 0.00005;
};
```