### PR TITLE
Add subcomponent support to macros

### DIFF
--- a/addons/jam/jam_finish/config.cpp
+++ b/addons/jam/jam_finish/config.cpp
@@ -1,8 +1,8 @@
 #include "script_component.hpp"
 
 class CfgPatches {
-    class ADDON {
-        name = ECSTRING(jam,component);
+    class SUBADDON {
+        name = CSTRING(component);
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;

--- a/addons/jam/jam_finish/script_component.hpp
+++ b/addons/jam/jam_finish/script_component.hpp
@@ -1,3 +1,2 @@
-#define COMPONENT jam_finish
-#include "\x\cba\addons\main\script_mod.hpp"
-#include "\x\cba\addons\main\script_macros.hpp"
+#define SUBCOMPONENT finish
+#include "\x\cba\addons\jam\script_component.hpp"

--- a/addons/jr/jr_prep/config.cpp
+++ b/addons/jr/jr_prep/config.cpp
@@ -1,8 +1,8 @@
 #include "script_component.hpp"
 
 class CfgPatches {
-    class ADDON {
-        name = ECSTRING(jr,component);
+    class SUBADDON {
+        name = CSTRING(component);
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;

--- a/addons/jr/jr_prep/script_component.hpp
+++ b/addons/jr/jr_prep/script_component.hpp
@@ -1,3 +1,2 @@
-#define COMPONENT jr_prep
-#include "\x\cba\addons\main\script_mod.hpp"
-#include "\x\cba\addons\main\script_macros.hpp"
+#define SUBCOMPONENT prep
+#include "\x\cba\addons\jr\script_component.hpp"

--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -897,10 +897,13 @@ Author:
     Sickboy
 ------------------------------------------- */
 #define GVAR(var1) DOUBLES(ADDON,var1)
+#define SUBGVAR(var1) TRIPLES(ADDON,SUBCOMPONENT,var1)
 #define EGVAR(var1,var2) TRIPLES(PREFIX,var1,var2)
 #define QGVAR(var1) QUOTE(GVAR(var1))
+#define QSUBGVAR(var1) QUOTE(SUBGVAR(var1))
 #define QEGVAR(var1,var2) QUOTE(EGVAR(var1,var2))
 #define QQGVAR(var1) QUOTE(QGVAR(var1))
+#define QQSUBGVAR(var1) QUOTE(QSUBGVAR(var1))
 #define QQEGVAR(var1,var2) QUOTE(QEGVAR(var1,var2))
 
 /* -------------------------------------------

--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -897,13 +897,10 @@ Author:
     Sickboy
 ------------------------------------------- */
 #define GVAR(var1) DOUBLES(ADDON,var1)
-#define SUBGVAR(var1) TRIPLES(ADDON,SUBCOMPONENT,var1)
 #define EGVAR(var1,var2) TRIPLES(PREFIX,var1,var2)
 #define QGVAR(var1) QUOTE(GVAR(var1))
-#define QSUBGVAR(var1) QUOTE(SUBGVAR(var1))
 #define QEGVAR(var1,var2) QUOTE(EGVAR(var1,var2))
 #define QQGVAR(var1) QUOTE(QGVAR(var1))
-#define QQSUBGVAR(var1) QUOTE(QSUBGVAR(var1))
 #define QQEGVAR(var1,var2) QUOTE(QEGVAR(var1,var2))
 
 /* -------------------------------------------

--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -15,11 +15,11 @@
    - Provide a solid structure that can be dynamic and easy editable (Which sometimes means we cannot adhere to Aim #1 ;-)
      An example is the path that is built from defines. Some available in this file, others in mods and addons.
 
- Follows  Standard:
-   Object variables: PREFIX_COMPONENT
+ Follows Standard:
+   Object variables: PREFIX_COMPONENT (or PREFIX_COMPONENT_SUBCOMPONENT)
    Main-object variables: PREFIX_main
-   Paths: MAINPREFIX\PREFIX\SUBPREFIX\COMPONENT\SCRIPTNAME.sqf
-   e.g: x\six\addons\sys_menu\fDate.sqf
+   Paths: MAINPREFIX\PREFIX\SUBPREFIX\COMPONENT\SCRIPTNAME.sqf (or MAINPREFIX\PREFIX\SUBPREFIX\COMPONENT\SUBCOMPONENT\SCRIPTNAME.sqf)
+   e.g: x\six\addons\sys_menu\fDate.sqf (or x\six\addons\sys_menu\compat\fDate.sqf)
 
  Usage:
    define PREFIX and COMPONENT, then include this file
@@ -28,6 +28,9 @@
    Then in your addons, add a component.hpp, define the COMPONENT,
    and include your mod's script_macros.hpp
    In your scripts you can then include the addon's component.hpp with relative path)
+
+   use in subcomponents (subconfigs)
+   define SUBCOMPONENT and include parent component's script_component.hpp
 
  TODO:
    - Try only to use 1 string type " vs '
@@ -51,8 +54,13 @@
     #define MAINLOGIC main
 #endif
 
-#define ADDON DOUBLES(PREFIX,COMPONENT)
 #define MAIN_ADDON DOUBLES(PREFIX,main)
+
+#ifdef SUBCOMPONENT
+    #define ADDON TRIPLES(PREFIX,COMPONENT,SUBCOMPONENT)
+#else
+    #define ADDON DOUBLES(PREFIX,COMPONENT)
+#endif
 
 /* -------------------------------------------
 Macro: VERSION_CONFIG

--- a/addons/main/script_macros_common.hpp
+++ b/addons/main/script_macros_common.hpp
@@ -16,10 +16,10 @@
      An example is the path that is built from defines. Some available in this file, others in mods and addons.
 
  Follows Standard:
-   Object variables: PREFIX_COMPONENT (or PREFIX_COMPONENT_SUBCOMPONENT)
+   Object variables: PREFIX_COMPONENT
    Main-object variables: PREFIX_main
-   Paths: MAINPREFIX\PREFIX\SUBPREFIX\COMPONENT\SCRIPTNAME.sqf (or MAINPREFIX\PREFIX\SUBPREFIX\COMPONENT\SUBCOMPONENT\SCRIPTNAME.sqf)
-   e.g: x\six\addons\sys_menu\fDate.sqf (or x\six\addons\sys_menu\compat\fDate.sqf)
+   Paths: MAINPREFIX\PREFIX\SUBPREFIX\COMPONENT\SCRIPTNAME.sqf
+   e.g: x\six\addons\sys_menu\fDate.sqf
 
  Usage:
    define PREFIX and COMPONENT, then include this file
@@ -31,6 +31,7 @@
 
    use in subcomponents (subconfigs)
    define SUBCOMPONENT and include parent component's script_component.hpp
+   currently only supported by SUBADDON, additional macros may be added in the future
 
  TODO:
    - Try only to use 1 string type " vs '
@@ -54,12 +55,11 @@
     #define MAINLOGIC main
 #endif
 
+#define ADDON DOUBLES(PREFIX,COMPONENT)
 #define MAIN_ADDON DOUBLES(PREFIX,main)
 
 #ifdef SUBCOMPONENT
-    #define ADDON TRIPLES(PREFIX,COMPONENT,SUBCOMPONENT)
-#else
-    #define ADDON DOUBLES(PREFIX,COMPONENT)
+    #define SUBADDON DOUBLES(ADDON,SUBCOMPONENT)
 #endif
 
 /* -------------------------------------------

--- a/addons/ui/ui_helper/config.cpp
+++ b/addons/ui/ui_helper/config.cpp
@@ -1,5 +1,5 @@
 class CfgPatches {
-    class cba_ui_helper {
+    class SUBADDON {
         requiredAddons[] = {"cba_ui"};
         units[] = {};
     };

--- a/addons/ui/ui_helper/script_component.hpp
+++ b/addons/ui/ui_helper/script_component.hpp
@@ -1,0 +1,2 @@
+#define SUBCOMPONENT helper
+#include "\x\cba\addons\ui\script_component.hpp"

--- a/addons/xeh/xeh_a3/config.cpp
+++ b/addons/xeh/xeh_a3/config.cpp
@@ -1,5 +1,5 @@
 class CfgPatches {
-    class cba_xeh_a3 {
+    class SUBADDON {
         requiredAddons[] = {"cba_xeh"};
         units[] = {};
     };

--- a/addons/xeh/xeh_a3/script_component.hpp
+++ b/addons/xeh/xeh_a3/script_component.hpp
@@ -1,0 +1,2 @@
+#define SUBCOMPONENT a3
+#include "\x\cba\addons\xeh\script_component.hpp"

--- a/addons/xeh/xeh_contact/CfgVehicles.hpp
+++ b/addons/xeh/xeh_contact/CfgVehicles.hpp
@@ -1,22 +1,3 @@
-#include "\x\cba\addons\xeh\script_component.hpp"
-#undef COMPONENT
-#define COMPONENT xeh_compat_contact
-
-class CfgPatches {
-    class ADDON {
-        units[] = {};
-        weapons[] = {};
-        requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = { "cba_xeh", "A3_Data_F_Contact" };
-        skipWhenMissingDependencies = 1;
-        author = "$STR_CBA_Author";
-        VERSION_CONFIG;
-        // this prevents any patched class from requiring XEH
-        addonRootClass = "A3_Characters_F";
-    };
-};
-class XEH_CLASS_BASE;
-
 class CfgVehicles {
     class B_W_Soldier_F;
     class B_W_Story_Protagonist_01_F: B_W_Soldier_F {

--- a/addons/xeh/xeh_contact/config.cpp
+++ b/addons/xeh/xeh_contact/config.cpp
@@ -18,4 +18,6 @@ class CfgPatches {
     };
 };
 
+class XEH_CLASS_BASE;
+
 #include "CfgVehicles.hpp"

--- a/addons/xeh/xeh_contact/config.cpp
+++ b/addons/xeh/xeh_contact/config.cpp
@@ -1,8 +1,8 @@
 #include "script_component.hpp"
 
 class CfgPatches {
-    class ADDON {
-        name = ECSTRING(xeh,component);
+    class SUBADDON {
+        name = CSTRING(component);
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;

--- a/addons/xeh/xeh_contact/config.cpp
+++ b/addons/xeh/xeh_contact/config.cpp
@@ -1,0 +1,21 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = ECSTRING(xeh,component);
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"cba_xeh", "A3_Data_F_Contact"};
+        skipWhenMissingDependencies = 1;
+        author = "$STR_CBA_Author";
+        authors[] = {"PabstMirror"};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
+
+        // this prevents any patched class from requiring XEH
+        addonRootClass = "A3_Characters_F";
+    };
+};
+
+#include "CfgVehicles.hpp"

--- a/addons/xeh/xeh_contact/script_component.hpp
+++ b/addons/xeh/xeh_contact/script_component.hpp
@@ -1,0 +1,2 @@
+#define SUBCOMPONENT contact
+#include "\x\cba\addons\xeh\script_component.hpp"

--- a/addons/xeh/xeh_csla/CfgVehicles.hpp
+++ b/addons/xeh/xeh_csla/CfgVehicles.hpp
@@ -1,22 +1,3 @@
-#include "\x\cba\addons\xeh\script_component.hpp"
-#undef COMPONENT
-#define COMPONENT xeh_compat_csla
-
-class CfgPatches {
-    class ADDON {
-        units[] = {};
-        weapons[] = {};
-        requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = { "cba_xeh", "CSLA", "US85" };
-        skipWhenMissingDependencies = 1;
-        author = "$STR_CBA_Author";
-        VERSION_CONFIG;
-        // this prevents any patched class from requiring XEH
-        addonRootClass = "A3_Characters_F";
-    };
-};
-class XEH_CLASS_BASE;
-
 class CfgVehicles {
     class StaticATWeapon;
     class CSLA_9K113_Stat: StaticATWeapon {

--- a/addons/xeh/xeh_csla/config.cpp
+++ b/addons/xeh/xeh_csla/config.cpp
@@ -18,4 +18,6 @@ class CfgPatches {
     };
 };
 
+class XEH_CLASS_BASE;
+
 #include "CfgVehicles.hpp"

--- a/addons/xeh/xeh_csla/config.cpp
+++ b/addons/xeh/xeh_csla/config.cpp
@@ -1,8 +1,8 @@
 #include "script_component.hpp"
 
 class CfgPatches {
-    class ADDON {
-        name = ECSTRING(xeh,component);
+    class SUBADDON {
+        name = CSTRING(component);
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;

--- a/addons/xeh/xeh_csla/config.cpp
+++ b/addons/xeh/xeh_csla/config.cpp
@@ -9,7 +9,7 @@ class CfgPatches {
         requiredAddons[] = {"cba_xeh", "CSLA", "US85"};
         skipWhenMissingDependencies = 1;
         author = "$STR_CBA_Author";
-        authors[] = {"PabstMirror"};
+        authors[] = {"Dahlgren"};
         url = "$STR_CBA_URL";
         VERSION_CONFIG;
 

--- a/addons/xeh/xeh_csla/config.cpp
+++ b/addons/xeh/xeh_csla/config.cpp
@@ -1,0 +1,21 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = ECSTRING(xeh,component);
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"cba_xeh", "CSLA", "US85"};
+        skipWhenMissingDependencies = 1;
+        author = "$STR_CBA_Author";
+        authors[] = {"PabstMirror"};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
+
+        // this prevents any patched class from requiring XEH
+        addonRootClass = "A3_Characters_F";
+    };
+};
+
+#include "CfgVehicles.hpp"

--- a/addons/xeh/xeh_csla/script_component.hpp
+++ b/addons/xeh/xeh_csla/script_component.hpp
@@ -1,0 +1,2 @@
+#define SUBCOMPONENT csla
+#include "\x\cba\addons\xeh\script_component.hpp"

--- a/addons/xeh/xeh_sog/CfgVehicles.hpp
+++ b/addons/xeh/xeh_sog/CfgVehicles.hpp
@@ -1,22 +1,3 @@
-#include "\x\cba\addons\xeh\script_component.hpp"
-#undef COMPONENT
-#define COMPONENT xeh_compat_sog
-
-class CfgPatches {
-    class ADDON {
-        units[] = {};
-        weapons[] = {};
-        requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = { "cba_xeh", "loadorder_f_vietnam" };
-        skipWhenMissingDependencies = 1;
-        author = "$STR_CBA_Author";
-        VERSION_CONFIG;
-        // this prevents any patched class from requiring XEH
-        addonRootClass = "A3_Characters_F";
-    };
-};
-class XEH_CLASS_BASE;
-
 class CfgVehicles {
     class vn_object_b_base_02;
     class Land_vn_candle_01: vn_object_b_base_02 {

--- a/addons/xeh/xeh_sog/config.cpp
+++ b/addons/xeh/xeh_sog/config.cpp
@@ -18,4 +18,6 @@ class CfgPatches {
     };
 };
 
+class XEH_CLASS_BASE;
+
 #include "CfgVehicles.hpp"

--- a/addons/xeh/xeh_sog/config.cpp
+++ b/addons/xeh/xeh_sog/config.cpp
@@ -1,8 +1,8 @@
 #include "script_component.hpp"
 
 class CfgPatches {
-    class ADDON {
-        name = ECSTRING(xeh,component);
+    class SUBADDON {
+        name = CSTRING(component);
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;

--- a/addons/xeh/xeh_sog/config.cpp
+++ b/addons/xeh/xeh_sog/config.cpp
@@ -9,7 +9,7 @@ class CfgPatches {
         requiredAddons[] = {"cba_xeh", "loadorder_f_vietnam"};
         skipWhenMissingDependencies = 1;
         author = "$STR_CBA_Author";
-        authors[] = {"PabstMirror"};
+        authors[] = {"Dahlgren"};
         url = "$STR_CBA_URL";
         VERSION_CONFIG;
 

--- a/addons/xeh/xeh_sog/config.cpp
+++ b/addons/xeh/xeh_sog/config.cpp
@@ -1,0 +1,21 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = ECSTRING(xeh,component);
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"cba_xeh", "loadorder_f_vietnam"};
+        skipWhenMissingDependencies = 1;
+        author = "$STR_CBA_Author";
+        authors[] = {"PabstMirror"};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
+
+        // this prevents any patched class from requiring XEH
+        addonRootClass = "A3_Characters_F";
+    };
+};
+
+#include "CfgVehicles.hpp"

--- a/addons/xeh/xeh_sog/script_component.hpp
+++ b/addons/xeh/xeh_sog/script_component.hpp
@@ -1,0 +1,2 @@
+#define SUBCOMPONENT sog
+#include "\x\cba\addons\xeh\script_component.hpp"

--- a/addons/xeh/xeh_ws/CfgVehicles.hpp
+++ b/addons/xeh/xeh_ws/CfgVehicles.hpp
@@ -1,22 +1,3 @@
-#include "\x\cba\addons\xeh\script_component.hpp"
-#undef COMPONENT
-#define COMPONENT xeh_compat_ws
-
-class CfgPatches {
-    class ADDON {
-        units[] = {};
-        weapons[] = {};
-        requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = { "cba_xeh", "data_f_lxWS" };
-        skipWhenMissingDependencies = 1;
-        author = "$STR_CBA_Author";
-        VERSION_CONFIG;
-        // this prevents any patched class from requiring XEH
-        addonRootClass = "A3_Characters_F";
-    };
-};
-class XEH_CLASS_BASE;
-
 class CfgVehicles {
     class PowerLines_Small_base_F;
     class Land_PowerPoleWooden_lxWS: PowerLines_Small_base_F {
@@ -38,12 +19,12 @@ class CfgVehicles {
     class C_Journalist_lxWS: C_journalist_F {
         XEH_ENABLED;
     };
-    
+
     class C_Man_casual_1_F_afro;
     class C_Tak_01_A_lxWS: C_Man_casual_1_F_afro {
         XEH_ENABLED;
     };
-    
+
     class B_Soldier_TL_F;
     class B_ION_Story_Givens_lxWS: B_Soldier_TL_F {
         XEH_ENABLED;

--- a/addons/xeh/xeh_ws/config.cpp
+++ b/addons/xeh/xeh_ws/config.cpp
@@ -18,4 +18,6 @@ class CfgPatches {
     };
 };
 
+class XEH_CLASS_BASE;
+
 #include "CfgVehicles.hpp"

--- a/addons/xeh/xeh_ws/config.cpp
+++ b/addons/xeh/xeh_ws/config.cpp
@@ -1,8 +1,8 @@
 #include "script_component.hpp"
 
 class CfgPatches {
-    class ADDON {
-        name = ECSTRING(xeh,component);
+    class SUBADDON {
+        name = CSTRING(component);
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;

--- a/addons/xeh/xeh_ws/config.cpp
+++ b/addons/xeh/xeh_ws/config.cpp
@@ -1,0 +1,21 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = ECSTRING(xeh,component);
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"cba_xeh", "data_f_lxWS"};
+        skipWhenMissingDependencies = 1;
+        author = "$STR_CBA_Author";
+        authors[] = {"PabstMirror"};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
+
+        // this prevents any patched class from requiring XEH
+        addonRootClass = "A3_Characters_F";
+    };
+};
+
+#include "CfgVehicles.hpp"

--- a/addons/xeh/xeh_ws/config.cpp
+++ b/addons/xeh/xeh_ws/config.cpp
@@ -9,7 +9,7 @@ class CfgPatches {
         requiredAddons[] = {"cba_xeh", "data_f_lxWS"};
         skipWhenMissingDependencies = 1;
         author = "$STR_CBA_Author";
-        authors[] = {"PabstMirror"};
+        authors[] = {"Dahlgren"};
         url = "$STR_CBA_URL";
         VERSION_CONFIG;
 

--- a/addons/xeh/xeh_ws/script_component.hpp
+++ b/addons/xeh/xeh_ws/script_component.hpp
@@ -1,0 +1,2 @@
+#define SUBCOMPONENT ws
+#include "\x\cba\addons\xeh\script_component.hpp"

--- a/optionals/legacy_jr/legacy_jr_prep/config.cpp
+++ b/optionals/legacy_jr/legacy_jr_prep/config.cpp
@@ -1,9 +1,9 @@
 #include "script_component.hpp"
 
 class CfgPatches {
-    class ADDON {
+    class SUBADDON {
         author = "$STR_CBA_Author";
-        name = ECSTRING(legacy_jr,component);
+        name = CSTRING(component);
         url = "$STR_CBA_URL";
         units[] = {};
         weapons[] = {};

--- a/optionals/legacy_jr/legacy_jr_prep/script_component.hpp
+++ b/optionals/legacy_jr/legacy_jr_prep/script_component.hpp
@@ -1,3 +1,2 @@
-#define COMPONENT legacy_jr_prep
-#include "\x\cba\addons\main\script_mod.hpp"
-#include "\x\cba\addons\main\script_macros.hpp"
+#define SUBCOMPONENT prep
+#include "\x\cba\addons\legacy_jr\script_component.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- Add `SUBCOMPONENT` support with `SUBADDON` and `SUBGVAR` family.
- Add nicer support for subcomponents/subconfigs.
- Retain easy use of parent data by not changing any other macros. Instead we will be adding more as necessary for use in sub-components. Minimal need is expected beyond the ones this PR adds.

Example subcomponent setup with this PR:
```sqf
// xeh/subcomponent/script_component.hpp
// define SUBCOMPONENT and include parent component's macros
#define SUBCOMPONENT ws
#include "\x\cba\addons\xeh_ws\script_component.hpp"

// xeh/subcomponent/config.cpp
// standard with addition of
class CfgPatches {
    class SUBADDON {
        requiredAddons[] = {"cba_xeh", ...};
    };
};
```

ACE3 would also include `SUBCOMPONENT_BEAUTIFIED` which does the same for beautified names. I didn't add this here as CBA uses stringtable component names, and no subcomponent adds additional classes that would cause them to add a mission dependency.

---

Tested with:
```diff
diff --git a/addons/xeh/xeh_ws/CfgVehicles.hpp b/addons/xeh/xeh_ws/CfgVehicles.hpp
index a39cf7f6..8d0cfa7b 100644
--- a/addons/xeh/xeh_ws/CfgVehicles.hpp
+++ b/addons/xeh/xeh_ws/CfgVehicles.hpp
@@ -57,4 +57,9 @@ class CfgVehicles {
     class Truck_02_aa_base_lxWS: Truck_02_base_F {
         XEH_ENABLED;
     };
+
+    // Test SUBCOMPONENT setup
+    class CBA_Test_Unit_XEH_WS: I_SFIA_Said_lxWS {
+        dlc = "cba";
+    };
 };
diff --git a/addons/xeh/xeh_ws/config.cpp b/addons/xeh/xeh_ws/config.cpp
index e986b47a..1692da1c 100644
--- a/addons/xeh/xeh_ws/config.cpp
+++ b/addons/xeh/xeh_ws/config.cpp
@@ -3,7 +3,7 @@
 class CfgPatches {
     class SUBADDON {
         name = CSTRING(component);
-        units[] = {};
+        units[] = {"CBA_Test_Unit_XEH_WS"};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cba_xeh", "data_f_lxWS"};
@@ -14,7 +14,7 @@ class CfgPatches {
         VERSION_CONFIG;
 
         // this prevents any patched class from requiring XEH
-        addonRootClass = "A3_Characters_F";
+        //addonRootClass = "A3_Characters_F";
     };
 };
```

![image](https://github.com/CBATeam/CBA_A3/assets/7935003/986eacab-8b0c-43ad-a7db-971235bb0904)

```cpp
addons[]=
{
	"cba_xeh_ws"
};
class AddonsMetaData
{
	class List
	{
		items=1;
		class Item0
		{
			className="cba_xeh_ws";
			name="Community Base Addons - Extended Event Handlers";
			author="CBA Team";
			url="https://www.github.com/CBATeam/CBA_A3";
		};
	};
};
```