### PR TITLE
Update magazine wells for CSLA CDLC

### DIFF
--- a/addons/jam/jam_csla/CfgMagazineWells.hpp
+++ b/addons/jam/jam_csla/CfgMagazineWells.hpp
@@ -97,6 +97,13 @@ class CfgMagazineWells {
         };
     };
 
+    class CBA_9x19_CZ75_Full {
+        CSLA_mags[] = {
+            "CSLA_Pi75_15Rnd_9Cv48",
+            "CSLA_Pi75_15Rnd_9Luger"
+        };
+    };
+
     class CBA_9x19_M9 {
         CSLA_mags[] = {
             "US85_M9_15Rnd_9Luger"

--- a/addons/jam/jam_csla/CfgMagazineWells.hpp
+++ b/addons/jam/jam_csla/CfgMagazineWells.hpp
@@ -31,11 +31,13 @@ class CfgMagazineWells {
         };
     };
 
+    /* CSLA magazines do not define a modelSpecial
     class CBA_556x45_MINIMI {
         CSLA_boxes[] = {
             "US85_200Rnd_556x45"
         };
     };
+    */
 
     class CBA_556x45_STANAG {
         CSLA_mags[] = {
@@ -50,6 +52,7 @@ class CfgMagazineWells {
         };
     };
 
+    /* CSLA magazines do not define a modelSpecial
     class CBA_762x39_AK {
         CSLA_mags[] = {
             "CSLA_Sa58_30rnd_7_62Cv43",
@@ -57,13 +60,18 @@ class CfgMagazineWells {
             "CSLA_Sa58_30rnd_7_62vz43"
         };
     };
+    */
 
-    class CBA_762x51_AICS {
+    /* CSLA proxy is different compared to CUP proxy
+    class CBA_762x51_FAL {
         CSLA_mags[] = {
-            "US85_10Rnd_762x51"
+            "US85_20Rnd_762M61",
+            "US85_20Rnd_762x51"
         };
     };
+    */
 
+    /* CSLA magazines do not define a modelSpecial
     class CBA_762x51_LINKS {
         CSLA_belts[] = {
             "US85_50Rnd_762x51",
@@ -71,6 +79,7 @@ class CfgMagazineWells {
             "US85_200Rnd_762x51"
         };
     };
+    */
 
     class CBA_762x54R_SVD {
         CSLA_mags[] = {
@@ -110,11 +119,13 @@ class CfgMagazineWells {
         };
     };
 
+    /* CSLA magazines do not define a modelSpecial
     class CBA_9x19_MP5 {
         CSLA_mags[] = {
             "US85_MPV_30Rnd_9Luger"
         };
     };
+    */
 
     class CBA_SMAW {
         CSLA_rounds[] = {

--- a/addons/jam/jam_csla/CfgWeapons.hpp
+++ b/addons/jam/jam_csla/CfgWeapons.hpp
@@ -36,9 +36,9 @@ class CfgWeapons {
         magazineWell[] += {"CBA_32ACP_Vz61"};
     };
 
-    class CSLA_LauncherBase;
+    class CSLA_Launcher_AT;
 
-    class CSLA_RPG7: CSLA_LauncherBase {
+    class CSLA_RPG7: CSLA_Launcher_AT {
         magazineWell[] += {"CBA_RPG7"};
     };
 
@@ -52,7 +52,7 @@ class CfgWeapons {
         magazineWell[] += {"CBA_556x45_STANAG","CBA_556x45_STANAG_L","CBA_556x45_STANAG_XL","CBA_556x45_STANAG_2D","CBA_556x45_STANAG_2D_XL"};
     };
 
-    class US85_M21_Base: US85_weaponBase {
+    class US85_M14_M21_Base: US85_weaponBase {
         magazineWell[] += {"CBA_762x51_M14", "CBA_762x51_M14_L"};
     };
 
@@ -82,9 +82,9 @@ class CfgWeapons {
         magazineWell[] += {"CBA_9x19_M9"};
     };
 
-    class US85_launcherBase;
+    class US85_Launcher_AT;
 
-    class US85_MAAWS: US85_launcherBase {
+    class US85_MAAWS: US85_Launcher_AT {
         magazineWell[] += {"CBA_Carl_Gustaf"};
     };
 

--- a/addons/jam/jam_csla/CfgWeapons.hpp
+++ b/addons/jam/jam_csla/CfgWeapons.hpp
@@ -29,11 +29,11 @@ class CfgWeapons {
     };
 
     class CSLA_Pi82: CSLA_Pi52 {
-        magazineWell[] += {"CBA_9x18_CZ82"};
+        magazineWell[] = {"CBA_9x18_CZ82"};
     };
 
     class CSLA_Sa61: CSLA_Pi52 {
-        magazineWell[] += {"CBA_32ACP_Vz61"};
+        magazineWell[] = {"CBA_32ACP_Vz61"};
     };
 
     class CSLA_Launcher_AT;

--- a/addons/jam/jam_csla/CfgWeapons.hpp
+++ b/addons/jam/jam_csla/CfgWeapons.hpp
@@ -26,6 +26,10 @@ class CfgWeapons {
         magazineWell[] += {"CBA_762x25_TT"};
     };
 
+    class CSLA_Pi75sr: CSLA_PistolBase {
+        magazineWell[] += {"CBA_9x19_CZ75_Full"};
+    };
+
     class CSLA_Pi82: CSLA_Pi52 {
         magazineWell[] = {"CBA_9x18_CZ82"};
     };

--- a/addons/jam/jam_csla/CfgWeapons.hpp
+++ b/addons/jam/jam_csla/CfgWeapons.hpp
@@ -14,9 +14,7 @@ class CfgWeapons {
         magazineWell[] += {"CBA_762x39_AK"};
     };
 
-    class CSLA_MachinegunBase_5_56: CSLA_baseWeapon {};
-
-    class CSLA_MachinegunBase_7_62: CSLA_MachinegunBase_5_56 {};
+    class CSLA_MachinegunBase_7_62;
 
     class CSLA_UK59L: CSLA_MachinegunBase_7_62 {
         magazineWell[] += {"CBA_762x54R_Vz59_LINKS"};


### PR DESCRIPTION
**When merged this pull request will:**
- Fix UBC issues with `CSLA_RPG7`, `US85_M14_M21_Base` and `US85_MAAWS`
- Fix wrongly inherited magazine wells for `CSLA_Pi82` and `CSLA_Sa61`
- Add support for CSLA Cz75 magazines and weapons
- Disable magazines with bad modelSpecial