### PR TITLE
CI - Update actions/checkout to v4 and remove release drafter description

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -26,8 +26,6 @@ exclude-labels:
 
 change-template: '- $TITLE (#$NUMBER) **$AUTHOR**'
 template: |
-  DESCRIPTION HERE
-
   $CHANGES
 
   Change log for [CBA v$NEXT_PATCH_VERSION](https://github.com/CBATeam/CBA_A3/milestone/00?closed=1)

--- a/.github/workflows/arma.yml
+++ b/.github/workflows/arma.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the source code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Validate SQF
       run: python3 tools/sqf_validator.py
     - name: Validate Config
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the source code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Lint (sqflint)
       uses: arma-actions/sqflint@master
       continue-on-error: true # No failure due to many false-positives
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the source code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup HEMTT
       uses: arma-actions/hemtt@v1
     - name: Run HEMTT build

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the source code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install Python packages
       run: |
         pip3 install wheel

--- a/.github/workflows/pboproject.yml
+++ b/.github/workflows/pboproject.yml
@@ -27,12 +27,12 @@ jobs:
       env:
         ARMA3_DATA_URL: ${{ secrets.ARMA3_DATA_URL }}
     - name: Checkout CBA A3
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: x\cba
         persist-credentials: false
     - name: Checkout pull request
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       if: ${{ github.event_name == 'pull_request_target' }}
       with:
         path: pullrequest


### PR DESCRIPTION
**When merged this pull request will:**
- Update actions/checkout to v4
- Remove description from release drafter template