### PR TITLE
Tools - Add `requiredVersion` to all sub configs

### DIFF
--- a/addons/accessory/MRT_AccFncs/config.cpp
+++ b/addons/accessory/MRT_AccFncs/config.cpp
@@ -1,6 +1,9 @@
+#include "..\script_component.hpp"
+
 class CfgPatches {
     class MRT_AccFncs {
         units[] = {};
         requiredAddons[] = {"cba_accessory"};
+        requiredVersion = REQUIRED_VERSION;
     };
 };

--- a/addons/jr/asdg_jointmuzzles/config.cpp
+++ b/addons/jr/asdg_jointmuzzles/config.cpp
@@ -1,6 +1,9 @@
+#include "..\script_component.hpp"
+
 class CfgPatches {
     class asdg_jointmuzzles {
         requiredAddons[] = {"cba_jr"};
         units[] = {};
+        requiredVersion = REQUIRED_VERSION;
     };
 };

--- a/addons/jr/asdg_jointrails/config.cpp
+++ b/addons/jr/asdg_jointrails/config.cpp
@@ -1,6 +1,9 @@
+#include "..\script_component.hpp"
+
 class CfgPatches {
     class asdg_jointrails {
         requiredAddons[] = {"cba_jr"};
         units[] = {};
+        requiredVersion = REQUIRED_VERSION;
     };
 };

--- a/addons/ui/ui_helper/config.cpp
+++ b/addons/ui/ui_helper/config.cpp
@@ -4,5 +4,6 @@ class CfgPatches {
     class SUBADDON {
         requiredAddons[] = {"cba_ui"};
         units[] = {};
+        requiredVersion = REQUIRED_VERSION;
     };
 };

--- a/addons/xeh/CBA_Extended_EventHandlers/config.cpp
+++ b/addons/xeh/CBA_Extended_EventHandlers/config.cpp
@@ -1,6 +1,9 @@
+#include "..\script_component.hpp"
+
 class CfgPatches {
     class CBA_Extended_EventHandlers {
         requiredAddons[] = {"cba_xeh"};
         units[] = {};
+        requiredVersion = REQUIRED_VERSION;
     };
 };

--- a/addons/xeh/Extended_EventHandlers/config.cpp
+++ b/addons/xeh/Extended_EventHandlers/config.cpp
@@ -1,6 +1,9 @@
+#include "..\script_component.hpp"
+
 class CfgPatches {
     class Extended_EventHandlers {
         requiredAddons[] = {"cba_xeh"};
         units[] = {};
+        requiredVersion = REQUIRED_VERSION;
     };
 };

--- a/addons/xeh/ee/config.cpp
+++ b/addons/xeh/ee/config.cpp
@@ -1,6 +1,9 @@
+#include "..\script_component.hpp"
+
 class CfgPatches {
     class cba_ee {
         requiredAddons[] = {"cba_xeh"};
         units[] = {};
+        requiredVersion = REQUIRED_VERSION;
     };
 };

--- a/addons/xeh/xeh_a3/config.cpp
+++ b/addons/xeh/xeh_a3/config.cpp
@@ -5,5 +5,6 @@ class CfgPatches {
     class SUBADDON {
         requiredAddons[] = {"cba_xeh"};
         units[] = {};
+        requiredVersion = REQUIRED_VERSION;
     };
 };


### PR DESCRIPTION
```
ERROR [SAE1] Error: command `createHashMap` requires version 2.2
   ╭─[/addons/accessory/XEH_preInit.sqf:7:19]
   │
 7 │ GVAR(usageHash) = createHashMap;
   │                   ──────┬──────
   │                         ╰──────── requires version 2.2
   │
   ├─[/addons/accessory/MRT_AccFncs/config.cpp:1:1]
   │
 1 │ class CfgPatches {
   │ │
   │ ╰─ CfgPatch only requires version 0.0
```