### PR TITLE
Common - Improve remove magazine functions

### DIFF
--- a/addons/common/fnc_removeMagazine.sqf
+++ b/addons/common/fnc_removeMagazine.sqf
@@ -22,6 +22,7 @@ Examples:
     (end)
 
 Author:
+    esteldunedain, johnb43 (from ACE)
 
 ---------------------------------------------------------------------------- */
 SCRIPT(removeMagazine);
@@ -47,76 +48,49 @@ if (!isClass _config || {getNumber (_config >> "scope") < 2}) exitWith {
     _return
 };
 
-if !(configName _config in magazines _unit) exitWith {
+// Make sure magazine is in config case
+_item = configName _config;
+
+if !(_item in magazines _unit) exitWith {
     TRACE_2("Item not available on Unit",_unit,_item);
     _return
 };
 
+// Ensure proper ammo
+_ammo = round _ammo;
+
 if (_ammo < 0) then {
-    _unit removeMagazineGlobal _item; // removeMagazine fails on remote units
+    if (_unit isKindOf "CAManBase") then {
+        _unit removeMagazineGlobal _item; // removeMagazine fails on remote units
+    } else {
+        _unit addMagazineCargoGlobal [_item, -1];
+    };
+
     _return = true;
 } else {
-    private _uniformMagazines = [];
-    private _vestMagazines = [];
-    private _backpackMagazines = [];
+    private _magArray = [_item, _ammo];
 
-    private _uniform = uniformContainer _unit;
-    private _vest = vestContainer _unit;
-    private _backpack = backpackContainer _unit;
+    private _fnc_removeMagazine = {
+        params ["_container"];
 
-    // magazinesAmmoCargo bugged. returns nil for objNull.
-    if (!isNull _uniform) then {
-        _uniformMagazines = magazinesAmmoCargo _uniform select {_x select 0 == _item};
+        if (_magArray in (magazinesAmmoCargo _container)) exitWith {
+            _container addMagazineAmmoCargo [_item, -1, _ammo];
+
+            true
+        };
+
+        false
     };
 
-    if (!isNull _vest) then {
-        _vestMagazines = magazinesAmmoCargo _vest select {_x select 0 == _item};
-    };
-
-    if (!isNull _backpack) then {
-        _backpackMagazines = magazinesAmmoCargo _backpack select {_x select 0 == _item};
+    private _containerArray = if (_unit isKindOf "CAManBase") then {
+        [uniformContainer _unit, vestContainer _unit, backpackContainer _unit]
+    } else {
+        [_unit]
     };
 
     {
-        if (_x select 1 == _ammo) exitWith {
-            _uniformMagazines deleteAt _forEachIndex;
-            _return = true;
-        };
-    } forEach _uniformMagazines;
-
-    if !(_return) then {
-        {
-            if (_x select 1 == _ammo) exitWith {
-                _vestMagazines deleteAt _forEachIndex;
-                _return = true;
-            };
-        } forEach _vestMagazines;
-    };
-
-    if !(_return) then {
-        {
-            if (_x select 1 == _ammo) exitWith {
-                _backpackMagazines deleteAt _forEachIndex;
-                _return = true;
-            };
-        } forEach _backpackMagazines;
-    };
-
-    if (_return) then {
-        _unit removeMagazines _item; // doc wrong. works on remote units
-
-        {
-            _uniform addMagazineAmmoCargo [_item, 1, _x select 1];
-        } forEach _uniformMagazines;
-
-        {
-            _vest addMagazineAmmoCargo [_item, 1, _x select 1];
-        } forEach _vestMagazines;
-
-        {
-            _backpack addMagazineAmmoCargo [_item, 1, _x select 1];
-        } forEach _backpackMagazines;
-    };
+        if (_x call _fnc_removeMagazine) exitWith {_return = true};
+    } forEach _containerArray;
 };
 
 _return

--- a/addons/common/fnc_removeMagazine.sqf
+++ b/addons/common/fnc_removeMagazine.sqf
@@ -51,22 +51,27 @@ if (!isClass _config || {getNumber (_config >> "scope") < 2}) exitWith {
 // Make sure magazine is in config case
 _item = configName _config;
 
-if !(_item in magazines _unit) exitWith {
-    TRACE_2("Item not available on Unit",_unit,_item);
-    _return
-};
-
 // Ensure proper ammo
 _ammo = round _ammo;
 
 if (_ammo < 0) then {
     if (_unit isKindOf "CAManBase") then {
-        _unit removeMagazineGlobal _item; // removeMagazine fails on remote units
-    } else {
-        _unit addMagazineCargoGlobal [_item, -1];
-    };
+        if !(_item in magazines _unit) exitWith {
+            TRACE_2("Item not available on Unit",_unit,_item);
+        };
 
-    _return = true;
+        _unit removeMagazineGlobal _item; // removeMagazine fails on remote units
+
+        _return = true;
+    } else {
+        if !(_item in magazineCargo _unit) exitWith {
+            TRACE_2("Item not available on Unit",_unit,_item);
+        };
+
+        _unit addMagazineCargoGlobal [_item, -1];
+
+        _return = true;
+    };
 } else {
     private _magArray = [_item, _ammo];
 

--- a/addons/common/fnc_removeMagazineCargo.sqf
+++ b/addons/common/fnc_removeMagazineCargo.sqf
@@ -72,7 +72,9 @@ if (_ammo < 0) then {
 
     private _index = _magazines find _item;
 
-    if (_index == -1) exitWith {};
+    if (_index == -1) exitWith {
+        false // return
+    };
 
     _container addMagazineCargoGlobal [_item, -_count];
 

--- a/addons/common/test_inventory.sqf
+++ b/addons/common/test_inventory.sqf
@@ -209,8 +209,8 @@ _result = [_container, "30Rnd_556x45_Stanag", 5] call CBA_fnc_addMagazineCargo;
 TEST_TRUE(_result,_funcName);
 TEST_TRUE(count (magazineCargo _container) == 5,_funcName);
 
-_result = [_container, "30Rnd_556x45_Stanag", 1000, false, 1] call CBA_fnc_addMagazineCargo;
-TEST_FALSE(_result,_funcName);
+_result = [_container, "30Rnd_556x45_Stanag", 10, false, 1] call CBA_fnc_addMagazineCargo;
+TEST_TRUE(_result,_funcName);
 
 
 _funcName = "CBA_fnc_removeMagazineCargo";
@@ -228,12 +228,16 @@ TEST_TRUE(_result,_funcName);
 _result = [_container, "30Rnd_556x45_Stanag", 1, 2] call CBA_fnc_removeMagazineCargo;
 TEST_FALSE(_result,_funcName);
 
-_result = [_container, "30Rnd_556x45_Stanag", 1, 1] call CBA_fnc_removeMagazineCargo;
+_result = [_container, "30Rnd_556x45_Stanag", 2, 1] call CBA_fnc_removeMagazineCargo;
+TEST_TRUE(_result,_funcName);
+
+_result = [_container, "30Rnd_556x45_Stanag", 10] call CBA_fnc_removeMagazineCargo;
+TEST_TRUE(_result,_funcName);
+
+_result = [_container, "30Rnd_556x45_Stanag"] call CBA_fnc_removeMagazineCargo;
 TEST_FALSE(_result,_funcName);
 
-_result = [_container, "30Rnd_556x45_Stanag", 1000] call CBA_fnc_removeMagazineCargo;
-TEST_FALSE(_result,_funcName);
-
+// No mags of "30Rnd_556x45_Stanag" left at this point
 _container addMagazineCargoGlobal ["30Rnd_556x45_Stanag", 5];
 _result = [_container, "30Rnd_556x45_Stanag", 3] call CBA_fnc_removeMagazineCargo;
 TEST_TRUE(_result,_funcName);

--- a/addons/common/test_inventory.sqf
+++ b/addons/common/test_inventory.sqf
@@ -45,13 +45,19 @@ LOG("Testing " + _funcName);
 
 TEST_DEFINED("CBA_fnc_addMagazine","");
 
-_result = [objNull, "SmokeShell"] call CBA_fnc_addMagazine;
+_result = [objNull, "30Rnd_556x45_Stanag"] call CBA_fnc_addMagazine;
 TEST_FALSE(_result,_funcName);
 
 _result = [player, ""] call CBA_fnc_addMagazine;
 TEST_FALSE(_result,_funcName);
 
-_result = [player, "SmokeShell"] call CBA_fnc_addMagazine;
+_result = [player, "30Rnd_556x45_Stanag"] call CBA_fnc_addMagazine;
+TEST_TRUE(_result,_funcName);
+
+_result = [player, "30Rnd_556x45_Stanag", 1, true] call CBA_fnc_addMagazine;
+TEST_TRUE(_result,_funcName);
+
+_result = [player, "30Rnd_556x45_Stanag", 1, true] call CBA_fnc_addMagazine;
 TEST_TRUE(_result,_funcName);
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -59,18 +65,21 @@ TEST_TRUE(_result,_funcName);
 _funcName = "CBA_fnc_removeMagazine";
 LOG("Testing " + _funcName);
 
-_result = [objNull, "SmokeShell"] call CBA_fnc_removeMagazine;
+_result = [objNull, "30Rnd_556x45_Stanag"] call CBA_fnc_removeMagazine;
 TEST_FALSE(_result,_funcName);
 
 _result = [player, ""] call CBA_fnc_removeMagazine;
 TEST_FALSE(_result,_funcName);
 
-_result = [player, "SmokeShell"] call CBA_fnc_removeMagazine;
+_result = [player, "30Rnd_556x45_Stanag"] call CBA_fnc_removeMagazine;
 TEST_TRUE(_result,_funcName);
 
-player removeMagazines "SmokeShell";
+_result = [player, "30Rnd_556x45_Stanag", 1] call CBA_fnc_removeMagazine;
+TEST_TRUE(_result,_funcName);
 
-_result = [player, "SmokeShell"] call CBA_fnc_removeMagazine;
+player removeMagazines "30Rnd_556x45_Stanag";
+
+_result = [player, "30Rnd_556x45_Stanag"] call CBA_fnc_removeMagazine;
 TEST_FALSE(_result,_funcName);
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -160,10 +169,69 @@ TEST_TRUE(count (itemCargo _container) == 5,_funcName);
 clearItemCargoGlobal _container;
 
 
+_funcName = "CBA_fnc_removeMagazine";
+LOG("Testing " + _funcName);
+
+_result = [objNull, "30Rnd_556x45_Stanag"] call CBA_fnc_removeMagazine;
+TEST_FALSE(_result,_funcName);
+
+_result = [_container, ""] call CBA_fnc_removeMagazine;
+TEST_FALSE(_result,_funcName);
+
+_result = [_container, "30Rnd_556x45_Stanag"] call CBA_fnc_removeMagazine;
+TEST_FALSE(_result,_funcName);
+
+_container addMagazineAmmoCargo ["30Rnd_556x45_Stanag", 2, 1];
+
+_result = [_container, "30Rnd_556x45_Stanag"] call CBA_fnc_removeMagazine;
+TEST_TRUE(_result,_funcName);
+
+_result = [_container, "30Rnd_556x45_Stanag", 2] call CBA_fnc_removeMagazine;
+TEST_FALSE(_result,_funcName);
+
+_result = [_container, "30Rnd_556x45_Stanag", 1] call CBA_fnc_removeMagazine;
+TEST_TRUE(_result,_funcName);
+
+_result = [_container, "30Rnd_556x45_Stanag"] call CBA_fnc_removeMagazine;
+TEST_FALSE(_result,_funcName);
+
+
+_funcName = "CBA_fnc_addMagazineCargo";
+LOG("Testing " + _funcName);
+
+_result = [objNull, "30Rnd_556x45_Stanag"] call CBA_fnc_addMagazineCargo;
+TEST_FALSE(_result,_funcName);
+
+_result = [_container, ""] call CBA_fnc_addMagazineCargo;
+TEST_FALSE(_result,_funcName);
+
+_result = [_container, "30Rnd_556x45_Stanag", 5] call CBA_fnc_addMagazineCargo;
+TEST_TRUE(_result,_funcName);
+TEST_TRUE(count (magazineCargo _container) == 5,_funcName);
+
+_result = [_container, "30Rnd_556x45_Stanag", 1000, false, 1] call CBA_fnc_addMagazineCargo;
+TEST_FALSE(_result,_funcName);
+
+
 _funcName = "CBA_fnc_removeMagazineCargo";
 LOG("Testing " + _funcName);
 
-_result = [objNull, "SmokeShell"] call CBA_fnc_removeMagazineCargo;
+_result = [objNull, "30Rnd_556x45_Stanag"] call CBA_fnc_removeMagazineCargo;
+TEST_FALSE(_result,_funcName);
+
+_result = [_container, "30Rnd_556x45_Stanag"] call CBA_fnc_removeMagazineCargo;
+TEST_TRUE(_result,_funcName);
+
+_result = [_container, "30Rnd_556x45_Stanag", 2] call CBA_fnc_removeMagazineCargo;
+TEST_TRUE(_result,_funcName);
+
+_result = [_container, "30Rnd_556x45_Stanag", 1, 2] call CBA_fnc_removeMagazineCargo;
+TEST_FALSE(_result,_funcName);
+
+_result = [_container, "30Rnd_556x45_Stanag", 1, 1] call CBA_fnc_removeMagazineCargo;
+TEST_FALSE(_result,_funcName);
+
+_result = [_container, "30Rnd_556x45_Stanag", 1000] call CBA_fnc_removeMagazineCargo;
 TEST_FALSE(_result,_funcName);
 
 _container addMagazineCargoGlobal ["30Rnd_556x45_Stanag", 5];


### PR DESCRIPTION
**When merged this pull request will:**
- `FUNC(removeMagazine)`:
  - No longer config case sensitive.
  - Round the ammo count before treating request.
  - Because the description states that it can be run on units or vehicles, I have added vehicle support, as previously it did not support vehicles at all.
  - Code improvement brought over from ACE `ace_common_fnc_removeMagazineSpecific`
- `FUNC(removeMagazineCargo)`
  - No longer config case sensitive.
  - Round the ammo count before treating request.
  - Only removes the necessary magazines.