### PR TITLE
UI - Improve support of pictures in mission list filter

### DIFF
--- a/addons/ui/fnc_initDisplayRemoteMissions.sqf
+++ b/addons/ui/fnc_initDisplayRemoteMissions.sqf
@@ -113,8 +113,10 @@ private _fnc_storeMapMissions = {_this spawn {isNil { // delay a frame
         private _value = _ctrlMissions lbValue _i;
         private _data = _ctrlMissions lbData _i;
         private _color = _ctrlMissions lbColor _i;
+        private _picture = _ctrlMissions lbPicture _i;
+        private _pictureRight = _ctrlMissions lbPictureRight _i;
 
-        _missions pushBack [_name, _value, _data, _color];
+        _missions pushBack [_name, _value, _data, _color, _picture, _pictureRight];
     };
 
     _ctrlMissions setVariable [QGVAR(missions), _missions];
@@ -146,7 +148,7 @@ _display setVariable [QFUNC(filter), {
     lbClear _ctrlMissions;
 
     {
-        _x params ["_name", "_value", "_data", "_color"];
+        _x params ["_name", "_value", "_data", "_color", "_picture", "_pictureRight"];
         private _classname = _data splitString "." param [0, ""];
 
         if (toLower _name find _filter != -1 && {_showStockMissions || {!(_classname in _stockMissions)}}) then {
@@ -154,6 +156,8 @@ _display setVariable [QFUNC(filter), {
             _ctrlMissions lbSetValue [_index, _value];
             _ctrlMissions lbSetData [_index, _data];
             _ctrlMissions lbSetColor [_index, _color];
+            _ctrlMissions lbSetPicture [_index, _picture];
+            _ctrlMissions lbSetPictureRight [_index, _pictureRight];
         };
     } forEach _missions;
 


### PR DESCRIPTION
**When merged this pull request will:**
- title

Reaction Forces Creator DLC adds DLC pictures to mission lists, this will save and restore them during the filtering. Right picture is not used by anything but won't hurt to save/restore it in case some mod does.

Vanilla:
![image](https://github.com/CBATeam/CBA_A3/assets/4293906/639c8811-82b6-4169-8ce6-967681f6a74b)

Reaction Forces:
![image](https://github.com/CBATeam/CBA_A3/assets/4293906/e894998d-19af-4d6d-9dee-361171f84e7c)
