### PR TITLE
Joint Rails - Fix `CBA_fnc_compatibleItems` undefined variable

### DIFF
--- a/addons/jr/fnc_compatibleItems.sqf
+++ b/addons/jr/fnc_compatibleItems.sqf
@@ -23,7 +23,7 @@ Author:
 ---------------------------------------------------------------------------- */
 SCRIPT(compatibleItems);
 
-params [["_weapon", "", [""]], ["_typefilter", nil, ["", 0]]];
+params [["_weapon", "", [""]], ["_typefilter", "", ["", 0]]];
 
 if (_weapon == "") exitWith {[]};
 
@@ -37,11 +37,11 @@ if !(isClass _weaponConfig) exitWith {
     []
 };
 
-private _typeFilterExists = !isNil "_typefilter";
+private _typeFilterExists = _typefilter isNotEqualTo "";
 
 // Convert filter into number (if string)
 if (_typeFilterExists && {_typefilter isEqualType ""}) then {
-    _typefilter = [-1, 101, 201, 301, 302] param [["", "muzzle", "optic", "pointer", "bipod"] find _typefilter, -1];
+    _typefilter = [101, 201, 301, 302] param [["muzzle", "optic", "pointer", "bipod"] find _typefilter, -1];
 };
 
 // Check if valid type filter


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #1653

I don't see a downside in doing `""` as default value, but maybe I am missing something.