### PR TITLE
JAM - Fix incorrect magwells on some SPE CDLC weapons

### DIFF
--- a/addons/jam/jam_spe/CfgWeapons.hpp
+++ b/addons/jam/jam_spe/CfgWeapons.hpp
@@ -19,7 +19,7 @@ class CfgWeapons {
     };
 
     class SPE_M1903A3_Springfield: SPE_RIFLE {
-        magazineWell[] += {"CBA_3006_Garand"};
+        magazineWell[] += {"CBA_3006_Spring"};
     };
 
     class SPE_STG44: SPE_RIFLE {
@@ -29,7 +29,7 @@ class CfgWeapons {
     class SPE_SRIFLE;
 
     class SPE_K98ZF39: SPE_SRIFLE {
-        magazineWell[] += {"CBA_3006_Spring"};
+        magazineWell[] += {"CBA_792x57_K98"};
     };
 
     class SPE_LMG;

--- a/addons/jam/jam_spe/CfgWeapons.hpp
+++ b/addons/jam/jam_spe/CfgWeapons.hpp
@@ -53,7 +53,7 @@ class CfgWeapons {
     class SPE_SMG;
 
     class SPE_M1A1_Thompson: SPE_SMG {
-        magazineWell[] += {"CBA_45ACP_Thompson_Stick", "CBA_45ACP_Thompson_Drum"};
+        magazineWell[] += {"CBA_45ACP_Thompson_Stick"};
     };
 
     class SPE_M3_GreaseGun: SPE_SMG {


### PR DESCRIPTION
**When merged this pull request will:**
- Fix Springfield rifles having M1 Garand clips available
- Fix K98k Sniper having 30-06 clips available
- Fix M1A1 thompson having access to Drum magazines (M1A1s cant use drums)

