### PR TITLE
General - Fix missing `ADDON` variable

### DIFF
--- a/addons/accessory/XEH_preInit.sqf
+++ b/addons/accessory/XEH_preInit.sqf
@@ -2,6 +2,8 @@
 
 if (!hasInterface) exitWith {};
 
+ADDON = false;
+
 #include "XEH_PREP.hpp"
 
 GVAR(usageHash) = createHashMap;
@@ -41,3 +43,5 @@ GVAR(usageHash) = createHashMap;
         false
     }
 ] call CBA_fnc_addItemContextMenuOption;
+
+ADDON = true;

--- a/addons/accessory/XEH_preInit.sqf
+++ b/addons/accessory/XEH_preInit.sqf
@@ -1,8 +1,10 @@
 #include "script_component.hpp"
 
-if (!hasInterface) exitWith {};
-
 ADDON = false;
+
+if (!hasInterface) exitWith {
+    ADDON = true;
+};
 
 #include "XEH_PREP.hpp"
 

--- a/addons/diagnostic/XEH_preInit.sqf
+++ b/addons/diagnostic/XEH_preInit.sqf
@@ -17,8 +17,6 @@ GVAR(projectileMaxLines) = 20;
 GVAR(projectileStartedDrawing) = false;
 GVAR(projectileTrackedUnits) = [];
 
-ADDON = true;
-
 if (getMissionConfigValue ["EnableTargetDebug", 0] == 1 || {getNumber (configFile >> "EnableTargetDebug") == 1}) then {
     INFO("EnableTargetDebug is enabled.");
 
@@ -71,3 +69,5 @@ if (getMissionConfigValue ["EnableTargetDebug", 0] == 1 || {getNumber (configFil
         }];
     };
 };
+
+ADDON = true;

--- a/addons/disposable/XEH_preInit.sqf
+++ b/addons/disposable/XEH_preInit.sqf
@@ -4,7 +4,9 @@ ADDON = false;
 
 #include "initSettings.inc.sqf"
 
-if (configProperties [configFile >> "CBA_DisposableLaunchers"] isEqualTo []) exitWith {};
+if (configProperties [configFile >> "CBA_DisposableLaunchers"] isEqualTo []) exitWith {
+    ADDON = true;
+};
 
 #include "XEH_PREP.hpp"
 

--- a/addons/events/XEH_preInit.sqf
+++ b/addons/events/XEH_preInit.sqf
@@ -30,9 +30,10 @@ if (isServer) then {
 #include "backwards_comp.inc.sqf"
 #include "initSettings.inc.sqf"
 
-ADDON = true;
+if (!hasInterface) exitWith {
+    ADDON = true;
+};
 
-if (!hasInterface) exitWith {};
 PREP(playerEvent);
 
 GVAR(skipCheckingUserActions) = true;
@@ -95,3 +96,5 @@ GVAR(alt) = false;
 private _states = [];
 _states resize 20;
 GVAR(userKeyStates) = _states apply {false};
+
+ADDON = true;

--- a/addons/help/XEH_preInit.sqf
+++ b/addons/help/XEH_preInit.sqf
@@ -1,9 +1,11 @@
 //#define DEBUG_MODE_FULL
 #include "script_component.hpp"
 
-if (!hasInterface) exitWith {};
-
 ADDON = false;
+
+if (!hasInterface) exitWith {
+    ADDON = true;
+};
 
 // bwc
 FUNC(help) = BIS_fnc_help;

--- a/addons/keybinding/XEH_preInit.sqf
+++ b/addons/keybinding/XEH_preInit.sqf
@@ -1,11 +1,13 @@
 #include "script_component.hpp"
 SCRIPT(XEH_preInit);
 
-if (!hasInterface) exitWith {};
+ADDON = false;
+
+if (!hasInterface) exitWith {
+    ADDON = true;
+};
 
 #include "XEH_PREP.hpp"
-
-ADDON = false;
 
 // Load DIK to string conversion table.
 with uiNamespace do {

--- a/addons/optics/XEH_preInit.sqf
+++ b/addons/optics/XEH_preInit.sqf
@@ -6,11 +6,15 @@ ADDON = false;
 
 if (configProperties [configFile >> "CBA_PIPItems"] isEqualTo [] && {
     configProperties [configFile >> "CBA_CarryHandleTypes"] isEqualTo []
-}) exitWith {};
+}) exitWith {
+    ADDON = true;
+};
 
 #include "XEH_PREP.hpp"
 
-if (!hasInterface) exitWith {};
+if (!hasInterface) exitWith {
+    ADDON = true;
+};
 
 #include "initKeybinds.inc.sqf"
 


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- In its initial form this is limited only to `accessory`, but I want to fix all issues in all components with `ADDON`.
  - I've noticed stuff like https://github.com/CBATeam/CBA_A3/blob/4d29fdf198751625743a7a4c404eb871d227bdda/addons/help/XEH_preInit.sqf#L6
  where it's only set if the machine has an interface. In `ui`, it's defined regardless of interface presence or not.
  - I've notices other stuff like https://github.com/CBATeam/CBA_A3/blob/4d29fdf198751625743a7a4c404eb871d227bdda/addons/optics/XEH_preInit.sqf#L3
  where it's only set to `false` on every machine, but `true` only on select machines.
  
  This behaviour seems to be inconsistent and I was to address that in this PR. However, in order to better understand what solution might be the best: What is the purpose of `ADDON` exactly?
