### PR TITLE
Fixed russian translation for AI Building Position object

### DIFF
--- a/addons/ai/stringtable.xml
+++ b/addons/ai/stringtable.xml
@@ -25,7 +25,7 @@
             <Chinese>AI在建築物內位置</Chinese>
             <Chinesesimp>AI在建筑内部位置</Chinesesimp>
             <French>Position IA bâtiment</French>
-            <Russian>ИИ Место строительства</Russian>
+            <Russian>ИИ Позиция в здании</Russian>
             <Polish>Pozycja AI w budynku</Polish>
             <Italian>Posizione edificio AI</Italian>
             <Korean>인공지능 건물 위치</Korean>


### PR DESCRIPTION
**When merged this pull request will:**
- Fixes russian translation for AI Building Position object (currently it named 'ai construction position')