### PR TITLE
Optics - Add scripted optics index config entry

### DIFF
--- a/addons/optics/fnc_setOpticMagnification.sqf
+++ b/addons/optics/fnc_setOpticMagnification.sqf
@@ -24,8 +24,6 @@ Author:
 if (!isNil {parsingNamespace getVariable QGVAR(magnification)}) exitWith {};
 
 params ["_unit", "_magnification"];
-private _weapon = currentWeapon _unit;
-private _optic = _unit call FUNC(currentOptic);
 
 // store zeroing
 private _zeroing = GVAR(ZeroingDistances) find currentZeroing _unit;
@@ -36,14 +34,14 @@ if (_zeroing isEqualTo -1) then {
 
 parsingNamespace setVariable [QGVAR(magnification), _magnification];
 parsingNamespace setVariable [QGVAR(zeroing), _zeroing];
-_unit addWeaponItem [_weapon, _optic];
+_unit setOpticsMode GVAR(scriptedOpticsIndex);
 
 [{
-    params ["_unit", "_weapon", "_optic"];
+    params ["_unit", "_opticsMode"];
 
     parsingNamespace setVariable [QGVAR(magnification), nil];
-    _unit addWeaponItem [_weapon, _optic];
+    _unit setOpticsMode _opticsMode;
     parsingNamespace setVariable [QGVAR(zeroing), nil];
-}, [_unit, _weapon, _optic]] call CBA_fnc_execNextFrame;
+}, [_unit, GVAR(scriptedOpticsIndex)]] call CBA_fnc_execNextFrame;
 
 // @todo, rifle, pistol, launcher, plus optics

--- a/addons/optics/fnc_updateOpticInfo.sqf
+++ b/addons/optics/fnc_updateOpticInfo.sqf
@@ -114,6 +114,8 @@ GVAR(ppEffects) = getArray (_config >> "opticsPPEffects") apply {
 GVAR(hideMagnification) = getNumber (_config >> "hideMagnification") != 0;
 GVAR(disableTilt) = getNumber (_config >> "disableTilt") != 0;
 
+GVAR(scriptedOpticsIndex) = getNumber (_config >> "scriptedOpticsIndex");
+
 [uiNamespace getVariable QGVAR(ScriptedOpticDisplay), false] call FUNC(loadScriptedOptic);
 
 //INFO_1("Updated optic info %1.",_optic);


### PR DESCRIPTION
**When merged this pull request will:**
- This allows one to set which optics index should be used for the scripted optic.
  I'm continuing the work on making ACE scopes use CBA optics (https://github.com/acemod/ACE3/pull/7273), but came across the limitation that the scripted optic needed to be the first optics mode of the optic. This PR changes that so that you can specify which optics mode is the scripted one.
  E.g. you can now have the primary optics mode be a collimator and the secondary optics mode be the optics using CBA optics.
- This PR assumes that you can't have more than 1 scripted optic mode per optic.
- Documentation needs to be added.
- Tested with samples from ACE (https://github.com/acemod/ACE3/pull/7273), CUP, RKSL and BWMod scopes: it doesn't seem to affect existing scopes negatively.
