### PR TITLE
Settings - Fix comment removal and deleting // in strings when not wanted

### DIFF
--- a/addons/settings/fnc_import.sqf
+++ b/addons/settings/fnc_import.sqf
@@ -18,7 +18,7 @@ Author:
 
 params [["_info", "", [""]], ["_source", "client", [""]]];
 
-_info = [_info, true, _source] call FUNC(parse);
+_info = [_info, true, _source, false] call FUNC(parse);
 
 {
     _x params ["_setting", "_value", "_priority"];

--- a/addons/settings/fnc_parse.sqf
+++ b/addons/settings/fnc_parse.sqf
@@ -6,9 +6,10 @@ Description:
     Convert settings in file format into array.
 
 Parameters:
-    _info     - Content of file or clipboard to parse. <STRING>
-    _validate - Check if settings are valid. (optional, default: false) <BOOL>
-    _source   - Can be "client", "mission" or "server" (optional, default: "") <STRING>
+    _info           - Content of file or clipboard to parse. <STRING>
+    _validate       - Check if settings are valid. (optional, default: false) <BOOL>
+    _source         - Can be "client", "mission" or "server" (optional, default: "") <STRING>
+    _isPreprocessed - If the contents have already been preprocessed or not (optional, default: true) <BOOL>
 
 Returns:
     Settings with values and priority states. <ARRAY>
@@ -17,7 +18,7 @@ Author:
     commy2, johnb43
 ---------------------------------------------------------------------------- */
 
-params [["_info", "", [""]], ["_validate", false, [false]], ["_source", "", [""]]];
+params [["_info", "", [""]], ["_validate", false, [false]], ["_source", "", [""]], ["_isPreprocessed", true, [false]]];
 
 // Parses bools, numbers, strings
 private _fnc_parseAny = {
@@ -27,11 +28,10 @@ private _fnc_parseAny = {
 };
 
 // If string comes from the "import" button, it is not preprocessed
-// Therefore, remove single line comments (//)
-_info = _info regexReplace ["/{2}[^\n\r]*((\n|\r)?)", ""];
-
-// Remove multiline comments too (/* */)
-_info = _info regexReplace ["/\*[^(\*/)]*((\*/)?)", ""];
+if (!_isPreprocessed) then {
+    // Remove single line and multiline comments, ignoring comments in strings
+    _info = _info regexReplace ["(""(?:\\.|[^""\\])*""|'(?:\\.|[^'\\])*')|(\/{2}.*?$)|(\/\*[\s\S]*?(\*\/))|(\/\*[\s\S]*$)", "$1"];
+};
 
 // Remove whitespaces at the start and end of each statement, a statement being defined by the ";" at its end
 private _parsed = [];

--- a/addons/settings/test_parse.sqf
+++ b/addons/settings/test_parse.sqf
@@ -57,35 +57,38 @@ TEST_TRUE(_result,_funcName);
 
 _settings = (preprocessFile "x\cba\addons\settings\test_settings_strings.inc.sqf") call FUNC(parse);
 _result = _settings isEqualTo [
-	["test1", "", 0],
-	["test2", "", 0],
-	["test3", "  T E S T  " , 0],
-	["test4", "  T E S T  ", 0],
-	["test5", "[ '  t e s t  ' , ""  T E S T  "" ]", 0],
-	["test6", "[ ""  t e s t  "" ,
+    ["test1", "", 0],
+    ["test2", "", 0],
+    ["test3", "  T E S T  " , 0],
+    ["test4", "  T E S T  ", 0],
+    ["test5", "[ '  t e s t  ' , ""  T E S T  "" ]", 0],
+    ["test6", "[ ""  t e s t  "" ,
 
 """"  T E S T  """" ]", 0],
-	["test7", "[ true, false ]", 0],
-	["test8", "[ ""  item_1  "" , ""  item_2  "" ]", 0],
-	["test9", "[ '  item_1  ' , '  item_2  ' ]", 0],
-	["test10", "[ '  item_1  ' , ""  item_2  "" ]", 0],
-	["test11", "[ '""  item_1  ""' , '  item_2  ' ]", 0],
-	["test12", "[ '  item_1  ' , ""'  item_2  '"" ]", 0]
+    ["test7", "[ true, false ]", 0],
+    ["test8", "[ ""  item_1  "" , ""  item_2  "" ]", 0],
+    ["test9", "[ '  item_1  ' , '  item_2  ' ]", 0],
+    ["test10", "[ '  item_1  ' , ""  item_2  "" ]", 0],
+    ["test11", "[ '""  item_1  ""' , '  item_2  ' ]", 0],
+    ["test12", "[ '  item_1  ' , ""'  item_2  '"" ]", 0],
+    ["test13", "'", 0],
+    ["test14", "''", 0]
 ];
 TEST_TRUE(_result,_funcName);
 
 // Don't preprocess for testing comments
-_settings = (loadFile "x\cba\addons\settings\test_settings_comments.inc.sqf") call FUNC(parse);
+_settings = [loadFile "x\cba\addons\settings\test_settings_comments.inc.sqf", false, "", false] call FUNC(parse);
 _result = _settings isEqualTo [
     ["test2", "[true,false]", 1],
     ["test4", "[ '  t e s t  ' , ""  T E S T  "" ]", 0],
+    ["test8", "https://github.com/CBATeam/CBA_A3", 0],
     ["ace_advanced_ballistics_ammoTemperatureEnabled", true, 0],
     ["ace_advanced_ballistics_barrelLengthInfluenceEnabled", true, 2],
     ["ace_advanced_ballistics_bulletTraceEnabled", true, 1]
 ];
 TEST_TRUE(_result,_funcName);
 
-_settings = (loadFile "x\cba\addons\settings\test_settings_comments_eof.inc.sqf") call FUNC(parse);
+_settings = [loadFile "x\cba\addons\settings\test_settings_comments_eof.inc.sqf", false, "", false] call FUNC(parse);
 _result = _settings isEqualTo [
     ["test1", "[""item_1"",""item_2""]", 1]
 ];

--- a/addons/settings/test_parse.sqf
+++ b/addons/settings/test_parse.sqf
@@ -82,6 +82,8 @@ _result = _settings isEqualTo [
     ["test2", "[true,false]", 1],
     ["test4", "[ '  t e s t  ' , ""  T E S T  "" ]", 0],
     ["test8", "https://github.com/CBATeam/CBA_A3", 0],
+    ["test11", "/* test */", 0],
+    ["test14", "/* test /", 0],
     ["ace_advanced_ballistics_ammoTemperatureEnabled", true, 0],
     ["ace_advanced_ballistics_barrelLengthInfluenceEnabled", true, 2],
     ["ace_advanced_ballistics_bulletTraceEnabled", true, 1]

--- a/addons/settings/test_settings_comments.inc.sqf
+++ b/addons/settings/test_settings_comments.inc.sqf
@@ -24,6 +24,15 @@ test8 = "https://github.com/CBATeam/CBA_A3";
 test10 = "https://github.com/CBATeam/CBA_A3";
 */
 
+test11 = "/* test */";
+// test12 = "/* test */";
+
+/*
+test13 = "/* test /";
+*/
+
+test14 = "/* test /";
+
 // ACE Advanced Ballistics
 ace_advanced_ballistics_ammoTemperatureEnabled = true;
 force force ace_advanced_ballistics_barrelLengthInfluenceEnabled = true;

--- a/addons/settings/test_settings_comments.inc.sqf
+++ b/addons/settings/test_settings_comments.inc.sqf
@@ -17,6 +17,12 @@ test6 =  '';       // "settings,";
 test7 = "  T S T  ";
         */
 
+test8 = "https://github.com/CBATeam/CBA_A3";
+// test9 = "https://github.com/CBATeam/CBA_A3";
+
+/*
+test10 = "https://github.com/CBATeam/CBA_A3";
+*/
 
 // ACE Advanced Ballistics
 ace_advanced_ballistics_ammoTemperatureEnabled = true;

--- a/addons/settings/test_settings_strings.inc.sqf
+++ b/addons/settings/test_settings_strings.inc.sqf
@@ -23,3 +23,7 @@ test10 = "[ '  item_1  ' , ""  item_2  "" ]";
 test11 = "[ '""  item_1  ""' , '  item_2  ' ]";
 
 test12 = "[ '  item_1  ' , ""'  item_2  '"" ]";
+
+test13 = "'";
+
+test14 = "''";


### PR DESCRIPTION
**When merged this pull request will:**
- See https://discord.com/channels/105462288051380224/141866231362879488/1270343373223362683.
  TLDR: When trying to import `ctab_irl_connect_uri = "https://ctab.plan-ops.fr/hub";`, it would cut off the part after `//` because it thought it was a comment. With some help from ChatGPT (I know, yikes, but I'm not good at regex), I have implemented an improved regex for replacing comments.
- It passes all existing and new tests.