### PR TITLE
Disposables - Fix check if floating point mass are roughly the same

### DIFF
--- a/addons/disposable/XEH_preInit.sqf
+++ b/addons/disposable/XEH_preInit.sqf
@@ -84,7 +84,7 @@ private _cfgMagazines = configFile >> "CfgMagazines";
         WARNING_4("Mass of launcher %1 (%2) is different from mass of used launcher %3 (%4).",_launcher,_massLauncher,_usedLauncher,_massUsedLauncher);
     };
 
-    if (_massLauncher + _massMagazine != _massLoadedLauncher) then {
+    if ((abs(_massLauncher + _massMagazine - _massLoadedLauncher)) > 0.001) then {
         WARNING_7("Sum of mass of launcher %1 and mass of magazine %2 (%3+%4=%5) is different from mass of loaded launcher %6 (%7).",_launcher,_magazine,_massLauncher,_massMagazine,_massLauncher + _massMagazine,_loadedLauncher,_massLoadedLauncher);
     };
 } forEach configProperties [configFile >> "CBA_DisposableLaunchers", "isArray _x"];

--- a/addons/disposable/XEH_preInit.sqf
+++ b/addons/disposable/XEH_preInit.sqf
@@ -84,7 +84,7 @@ private _cfgMagazines = configFile >> "CfgMagazines";
         WARNING_4("Mass of launcher %1 (%2) is different from mass of used launcher %3 (%4).",_launcher,_massLauncher,_usedLauncher,_massUsedLauncher);
     };
 
-    if ((abs(_massLauncher + _massMagazine - _massLoadedLauncher)) > 0.001) then {
+    if ((abs(_massLauncher + _massMagazine - _massLoadedLauncher)) > 0.011) then {
         WARNING_7("Sum of mass of launcher %1 and mass of magazine %2 (%3+%4=%5) is different from mass of loaded launcher %6 (%7).",_launcher,_magazine,_massLauncher,_massMagazine,_massLauncher + _massMagazine,_loadedLauncher,_massLoadedLauncher);
     };
 } forEach configProperties [configFile >> "CBA_DisposableLaunchers", "isArray _x"];


### PR DESCRIPTION
```
Sum of mass of launcher PSZ_RPG76_Base and mass of magazine PSZ_PG76_HEAT (7.04+39.16=46.2) 
is different from mass of loaded launcher PSZ_RPG76 (46.19).
```

Their numbers are still off by a hundredth
but the diff comes out to `0.0100021` because of floating point

