### PR TITLE
Help - Sort addons, credits and keybindings alphabetically

### DIFF
--- a/addons/help/XEH_preInit.sqf
+++ b/addons/help/XEH_preInit.sqf
@@ -10,38 +10,4 @@ if (!hasInterface) exitWith {
 // bwc
 FUNC(help) = BIS_fnc_help;
 
-// keys
-private _keys = "";
-
-private _config = configFile >> "CfgSettings" >> "CBA" >> "events";
-
-{
-    private _addon = configName _x;
-
-    _keys = _keys + format ["%1:<br/>", _addon];
-
-    {
-        private _action = configName _x;
-
-        private _keybind = if (isNumber _x) then {
-            [getNumber _x, false, false, false]
-        } else {
-            [
-                getNumber (_x >> "key"),
-                getNumber (_x >> "shift") > 0,
-                getNumber (_x >> "ctrl") > 0,
-                getNumber (_x >> "alt") > 0
-            ]
-        };
-
-        private _keyName = _keybind call CBA_fnc_localizeKey;
-
-        _keys = _keys + format ["    %1: <font color='#c48214'>%2</font><br/>", _action, _keyName];
-    } forEach configProperties [_x, "isNumber _x || isClass _x"];
-
-    _keys = _keys + "<br/>";
-} forEach ("true" configClasses _config);
-
-GVAR(keys) = _keys;
-
 ADDON = true;

--- a/addons/help/XEH_preStart.sqf
+++ b/addons/help/XEH_preStart.sqf
@@ -38,31 +38,37 @@ private _credits = [];
     _credits pushBack format ["<font color='#bdcc9c'>%1%2 by %3</font>", _name, _version, _author];
 } forEach _addons;
 
-_credits = (_credits arrayIntersect _credits) joinString "<br/>";
+_credits = _credits arrayIntersect _credits;
+
+_credits sort true;
+
+_credits = _credits joinString "<br/>";
 
 uiNamespace setVariable [QGVAR(credits), compileFinal str _credits];
 
 // mods
 private _mods = "true" configClasses (configFile >> "CfgPatches") apply {configSourceMod _x};
-_mods = (_mods arrayIntersect _mods select {!isNumber (configfile >> "CfgMods" >> _x >> "appId")}) - [""];
+_mods = ((_mods arrayIntersect _mods) select {!isNumber (configfile >> "CfgMods" >> _x >> "appId")}) - [""];
 
 _mods = _mods apply {
     private _entry = configfile >> "CfgMods" >> _x;
 
-    private _name = getText (_entry >> "name") call CBA_fnc_sanitizeHTML;
+    private _name = getText (_entry >> "name");
 
     if (isClass _entry) then {
         _x = format ["    <font color='#cc9cbd'>%1 - %2</font>", configName _entry, _name];
 
         if (isText (_entry >> "description")) then {
-            private _description = getText (_entry >> "description") call CBA_fnc_sanitizeHTML;
+            private _description = getText (_entry >> "description");
 
             _x = _x + format ["<br/>%1<br/>", _description];
         };
     };
 
-    _x
+    _x call CBA_fnc_sanitizeHTML
 };
+
+_mods sort true;
 
 _mods = _mods joinString "<br/>";
 

--- a/addons/help/XEH_preStart.sqf
+++ b/addons/help/XEH_preStart.sqf
@@ -47,25 +47,27 @@ _credits = _credits joinString "<br/>";
 uiNamespace setVariable [QGVAR(credits), compileFinal str _credits];
 
 // mods
-private _mods = "true" configClasses (configFile >> "CfgPatches") apply {configSourceMod _x};
+private _mods = ("true" configClasses (configFile >> "CfgPatches")) apply {configSourceMod _x};
 _mods = ((_mods arrayIntersect _mods) select {!isNumber (configfile >> "CfgMods" >> _x >> "appId")}) - [""];
 
 _mods = _mods apply {
     private _entry = configfile >> "CfgMods" >> _x;
 
-    private _name = getText (_entry >> "name");
-
     if (isClass _entry) then {
-        _x = format ["    <font color='#cc9cbd'>%1 - %2</font>", configName _entry, _name];
+        private _name = getText (_entry >> "name") call CBA_fnc_sanitizeHTML;
+
+        _name = format ["    <font color='#cc9cbd'>%1 - %2</font>", configName _entry, _name];
 
         if (isText (_entry >> "description")) then {
-            private _description = getText (_entry >> "description");
+            private _description = getText (_entry >> "description") call CBA_fnc_sanitizeHTML;
 
-            _x = _x + format ["<br/>%1<br/>", _description];
+            _name = _name + format ["<br/>%1<br/>", _description];
         };
-    };
 
-    _x call CBA_fnc_sanitizeHTML
+        _name
+    } else {
+        _x call CBA_fnc_sanitizeHTML
+    };
 };
 
 _mods sort true;

--- a/addons/help/XEH_preStart.sqf
+++ b/addons/help/XEH_preStart.sqf
@@ -51,23 +51,22 @@ private _mods = ("true" configClasses (configFile >> "CfgPatches")) apply {confi
 _mods = ((_mods arrayIntersect _mods) select {!isNumber (configfile >> "CfgMods" >> _x >> "appId")}) - [""];
 
 _mods = _mods apply {
-    private _entry = configfile >> "CfgMods" >> _x;
+    (modParams [_x, ["name"]]) params ["_name"];
+    if (_name == "") then { _name = _x };
 
+    private _mod = _x call CBA_fnc_sanitizeHTML;
+    _name = _name call CBA_fnc_sanitizeHTML;
+    _name = format ["    <font color='#cc9cbd'>%1 - %2</font>", _mod, _name];
+
+    private _entry = configfile >> "CfgMods" >> _x; // _x may be "@CBA_A3"
     if (isClass _entry) then {
-        private _name = getText (_entry >> "name") call CBA_fnc_sanitizeHTML;
-
-        _name = format ["    <font color='#cc9cbd'>%1 - %2</font>", configName _entry, _name];
-
         if (isText (_entry >> "description")) then {
             private _description = getText (_entry >> "description") call CBA_fnc_sanitizeHTML;
-
             _name = _name + format ["<br/>%1<br/>", _description];
         };
-
-        _name
-    } else {
-        _x call CBA_fnc_sanitizeHTML
     };
+
+    _name
 };
 
 _mods sort true;


### PR DESCRIPTION
**When merged this pull request will:**
- Title.
- Fixes mods such as `O&T Expansion Eden` breaking the Addons diary entry, because of the `&` not being sanitised.
- I haven't tested if this works with keybinds that are added via config - I don't know of any mods that use that.
