### PR TITLE
HEMTT - Support 1.13 lints

### DIFF
--- a/.hemtt/lints.toml
+++ b/.hemtt/lints.toml
@@ -1,0 +1,4 @@
+[sqf.banned_commands]
+options.ignore = [
+    "addPublicVariableEventHandler", # Alt syntax is broken, we are using main syntax
+]


### PR DESCRIPTION
**When merged this pull request will:**
- Safe to merge before HEMTT 1.13.0 releases, will have no effect on previous versions
- Allows `addPublicVariableEventHandler` since CBA is not using the broken alt syntax
