### PR TITLE
CI - Fix HEMTT artifacts not uploaded

### DIFF
--- a/.github/workflows/arma.yml
+++ b/.github/workflows/arma.yml
@@ -46,3 +46,4 @@ jobs:
       with:
         name: CBA_A3_${{ github.sha }}-nobin
         path: .hemttout/@*
+        include-hidden-files: true # Because .hemttout is a hidden directory


### PR DESCRIPTION
**When merged this pull request will:**
- Fix HEMTT artifacts not uploaded. `actions/upload-artifact` v4.4 changed the behavior of hidden files. They're now excluded by default [[Source]](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes).
