### PR TITLE
Settings - Add missing setting type to header & wiki additions

### DIFF
--- a/addons/settings/fnc_addSetting.sqf
+++ b/addons/settings/fnc_addSetting.sqf
@@ -7,7 +7,7 @@ Description:
 
 Parameters:
     _setting     - Unique setting name. Matches resulting variable name <STRING>
-    _settingType - Type of setting. Can be "CHECKBOX", "EDITBOX", "LIST", "SLIDER" or "COLOR" <STRING>
+    _settingType - Type of setting. Can be "CHECKBOX", "EDITBOX", "LIST", "SLIDER", "COLOR" or "TIME" <STRING>
     _title       - Display name or display name + tooltip (optional, default: same as setting name) <STRING, ARRAY>
     _category    - Category for the settings menu + optional sub-category <STRING, ARRAY>
     _valueInfo   - Extra properties of the setting depending of _settingType. See examples below <ANY>

--- a/addons/settings/fnc_init.sqf
+++ b/addons/settings/fnc_init.sqf
@@ -7,7 +7,7 @@ Description:
 
 Parameters:
     _setting     - Unique setting name. Matches resulting variable name <STRING>
-    _settingType - Type of setting. Can be "CHECKBOX", "EDITBOX", "LIST", "SLIDER" or "COLOR" <STRING>
+    _settingType - Type of setting. Can be "CHECKBOX", "EDITBOX", "LIST", "SLIDER", "COLOR" or "TIME" <STRING>
     _title       - Display name or display name + tooltip (optional, default: same as setting name) <STRING, ARRAY>
     _category    - Category for the settings menu + optional sub-category <STRING, ARRAY>
     _valueInfo   - Extra properties of the setting depending of _settingType. See examples below <ANY>


### PR DESCRIPTION
**When merged this pull request will:**
- Add missing parameter type to header. No actual code edits.

Also wiki is missing Time param, so following line could be added.

https://github.com/CBATeam/CBA_A3/wiki/CBA-Settings-System#arguments-of-cba_fnc_addsetting
```
_settingType - Type of setting. Can be "CHECKBOX", "EDITBOX", "LIST", "SLIDER" or "COLOR" <STRING>
->
_settingType - Type of setting. Can be "CHECKBOX", "EDITBOX", "LIST", "SLIDER", "COLOR" or "TIME" <STRING>
```

https://github.com/CBATeam/CBA_A3/wiki/CBA-Settings-System#supported-setting-types-_settingtype
```
* **TIME:** Similar to a slider, but allows input in the HH:MM:SS format and returns the corresponding value in seconds.
```

https://github.com/CBATeam/CBA_A3/wiki/CBA-Settings-System#setting-type-specific-arguments-_valueinfo
```
### Time:
* 0: Minimum (lowest possible value) <NUMBER>
* 1: Maximum (highest possible value) <NUMBER>
* 2: Default value <NUMBER>```