### PR TITLE
UI - Show mission filename as tooltip for missions on mission select

### DIFF
--- a/addons/ui/fnc_initDisplayRemoteMissions.sqf
+++ b/addons/ui/fnc_initDisplayRemoteMissions.sqf
@@ -158,6 +158,7 @@ _display setVariable [QFUNC(filter), {
             _ctrlMissions lbSetColor [_index, _color];
             _ctrlMissions lbSetPicture [_index, _picture];
             _ctrlMissions lbSetPictureRight [_index, _pictureRight];
+            _ctrlMissions lbSetTooltip [_index, format ["%1", _data]];
         };
     } forEach _missions;
 


### PR DESCRIPTION
Close #1694

![cba](https://github.com/user-attachments/assets/0f767b5d-f33e-42e0-9015-b1639c772f72)
missing cursor in screenshot but u get the idea
on `<< new...` it shows no tooltip
