### PR TITLE
ci: Mikero Tools 2024-10-11

### DIFF
--- a/.github/workflows/pboproject.yml
+++ b/.github/workflows/pboproject.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         toolsUrl: ${{ secrets.ARMA3_TOOLS_URL }}
     - name: Install Mikero Tools
-      uses: arma-actions/mikero-tools@2023-01-04
+      uses: arma-actions/mikero-tools@2024-10-11
     - name: Download game data
       run: |
         Invoke-WebRequest "$env:ARMA3_DATA_URL" -OutFile arma3.zip

--- a/tools/make.py
+++ b/tools/make.py
@@ -1327,9 +1327,9 @@ See the make.cfg file for additional build options.
                         cmd = [makepboTool, "-P","-A","-X=*.backup", os.path.join(work_drive, prefix, module),os.path.join(module_root, release_dir, project,"addons")]
                     elif skipPreprocessing:
                         print_green("addon.toml set [preprocess.enabled = false]. Proceeding with non-binerized config build!")
-                        cmd = [pboproject, "-B", "-P", os.path.join(work_drive, prefix, module), "+Engine=Arma3", "-S", "+Noisy", "+Clean", "-Warnings", "+Mod="+os.path.join(module_root, release_dir, project), "-Key"]
+                        cmd = [pboproject, "-B", "-P", os.path.join(work_drive, prefix, module), "+Engine=Arma3", "+Noisy", "+Clean", "-Warnings", "+Mod="+os.path.join(module_root, release_dir, project), "-Key"]
                     else:
-                        cmd = [pboproject, "+B", "-P", os.path.join(work_drive, prefix, module), "+Engine=Arma3", "-S", "+Noisy", "+Clean", "-Warnings", "+Mod="+os.path.join(module_root, release_dir, project), "-Key"]
+                        cmd = [pboproject, "+B", "-P", os.path.join(work_drive, prefix, module), "+Engine=Arma3", "+Noisy", "+Clean", "-Warnings", "+Mod="+os.path.join(module_root, release_dir, project), "-Key"]
 
                     color("grey")
                     if quiet:


### PR DESCRIPTION
**When merged this pull request will:**
- Add support for Arma 3 Tools 1.040 released together with Arma 3 2.18
- Remove no longer supported `-S` argument causing pboproject to fail at startup
- Fix broken build, new mikero tools won't be used until after merge due to `pull_request_target` trigger
  - Test build: https://github.com/Dahlgren/CBA_A3/actions/runs/11305399099