### PR TITLE
UI - Add password fill compatiblity for "connectToServer" (2.19+)

### DIFF
--- a/addons/ui/fnc_initDisplayPassword.sqf
+++ b/addons/ui/fnc_initDisplayPassword.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 // since 2.19 "server:port" is stored on the display in "guid" variable, makes password filling compatible with "connectToServer" command
-#define GET_SERVER (if (productVersion#2 > 218) then {_display getVariable "guid"} else {_ctrlServerList lbData lbCurSel _ctrlServerList})
+#define GET_SERVER (_display getVariable ["guid", _ctrlServerList lbData lbCurSel _ctrlServerList])
 
 if (profileNamespace getVariable [QGVAR(StorePasswords), 1] < 1) exitWith {};
 

--- a/addons/ui/fnc_initDisplayPassword.sqf
+++ b/addons/ui/fnc_initDisplayPassword.sqf
@@ -1,4 +1,6 @@
 #include "script_component.hpp"
+// since 2.19 "server:port" is stored on the display in "guid" variable, makes password filling compatible with "connectToServer" command
+#define GET_SERVER (if (productVersion#2 > 218) then {_display getVariable "guid"} else {_ctrlServerList lbData lbCurSel _ctrlServerList})
 
 if (profileNamespace getVariable [QGVAR(StorePasswords), 1] < 1) exitWith {};
 
@@ -13,7 +15,7 @@ _ctrlConfirm ctrlAddEventHandler ["ButtonClick", {
     private _ctrlPassword = _display displayCtrl IDC_PASSWORD;
     private _ctrlServerList = (uiNamespace getVariable "RscDisplayMultiplayer") displayCtrl IDC_MULTI_SESSIONS;
 
-    private _server = _ctrlServerList lbData lbCurSel _ctrlServerList;
+    private _server = GET_SERVER;
     private _password = ctrlText _ctrlPassword;
     //diag_log ["write", _server, _password];
 
@@ -28,7 +30,7 @@ _ctrlConfirm ctrlAddEventHandler ["ButtonClick", {
     saveProfileNamespace;
 }];
 
-private _server = _ctrlServerList lbData lbCurSel _ctrlServerList;
+private _server = GET_SERVER;
 
 // read password from cache
 private _passwordCache = profileNamespace getVariable [QGVAR(ServerPasswords), [[], []]];


### PR DESCRIPTION
**When merged this pull request will:**
- title
- [Info](https://discord.com/channels/976165959041679380/976224730422063214/1326863533446529024) from @dedmen 

```
https://github.com/CBATeam/CBA_A3/blob/master/addons/ui/fnc_initDisplayPassword.sqf#L6
`_targetServer = _display getVariable "guid"; // 127.0.0.1:2302 always the resolved IP address, not the domain`
Starting with next week dev, and profiling branch v20
The variable is set before the init event, it should always be present

`diag_log [_display, _display getVariable ["guid", "?"]];`
`11:39:47 [Display #64,"164.152.123.222:2331"]`
```