### PR TITLE
Joint Rails - Add GM compat

### DIFF
--- a/addons/jr/CfgWeapons.hpp
+++ b/addons/jr/CfgWeapons.hpp
@@ -34,6 +34,15 @@ class CfgWeapons {
         };
     };
 
+    class launch_RPG7_F: Launcher_Base_F {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            class CowsSlot: asdg_OpticSideRail_RPG7 {
+                iconPosition[] = {0.45,0.38};
+                iconScale = 0.2;
+            };
+        };
+    };
+
     class EBR_base_F: Rifle_Long_Base_F {
         class WeaponSlotsInfo;
     };

--- a/addons/jr/compat_gm/config.cpp
+++ b/addons/jr/compat_gm/config.cpp
@@ -1,0 +1,31 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class SUBADDON {
+        name = CSTRING(component);
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "cba_jr",
+            "gm_weapons_attachments_optics_feroz24",
+            "gm_weapons_attachments_optics_c79",
+            "gm_weapons_attachments_optics_lsscope",
+            "gm_weapons_attachments_optics_lightscope",
+            "gm_weapons_attachments_optics_rv",
+            "gm_weapons_attachments_optics_zf10x42",
+            "gm_weapons_attachments_optics_nspu",
+            "gm_weapons_attachments_optics_pgo7",
+            "gm_weapons_attachments_optics_pka",
+            "gm_weapons_attachments_optics_zfk4x25",
+            "gm_weapons_attachments_optics_zln1k"
+        };
+        author = "$STR_CBA_Author";
+        authors[] = {};
+        url = "$STR_CBA_URL";
+        skipWhenMissingDependencies = 1;
+        VERSION_CONFIG;
+    };
+};
+
+#include "jr_classes.hpp"

--- a/addons/jr/compat_gm/config.cpp
+++ b/addons/jr/compat_gm/config.cpp
@@ -18,7 +18,8 @@ class CfgPatches {
             "gm_weapons_attachments_optics_pgo7",
             "gm_weapons_attachments_optics_pka",
             "gm_weapons_attachments_optics_zfk4x25",
-            "gm_weapons_attachments_optics_zln1k"
+            "gm_weapons_attachments_optics_zln1k",
+            "gm_weapons_attachments_optics_pso1"
         };
         author = "$STR_CBA_Author";
         authors[] = {};

--- a/addons/jr/compat_gm/jr_classes.hpp
+++ b/addons/jr/compat_gm/jr_classes.hpp
@@ -1,7 +1,6 @@
 class asdg_OpticRail;
 
-// Picatinny rails for optic mounts
-class asdg_OpticRail1913: asdg_OpticRail { // the "medium" rail, long enough to fit any optic, but not enough to attach a clip-on NVS in front of a long scope.
+class asdg_OpticRail1913: asdg_OpticRail {
     class compatibleItems {
         gm_blits_ris_blk = 1;
         gm_c79a1_blk = 1;

--- a/addons/jr/compat_gm/jr_classes.hpp
+++ b/addons/jr/compat_gm/jr_classes.hpp
@@ -1,0 +1,61 @@
+class asdg_OpticRail;
+
+// Picatinny rails for optic mounts
+class asdg_OpticRail1913: asdg_OpticRail { // the "medium" rail, long enough to fit any optic, but not enough to attach a clip-on NVS in front of a long scope.
+    class compatibleItems {
+        gm_blits_ris_blk = 1;
+        gm_c79a1_blk = 1;
+        gm_c79a1_oli = 1;
+        gm_feroz24_ris_blk = 1;
+        gm_feroz51_ris_oli = 1;
+        gm_ls1500_ir_ris_blk = 1;
+        gm_ls1500_red_ris_blk = 1;
+        gm_ls45_ir_ris_blk = 1;
+        gm_ls45_red_ris_blk = 1;
+        gm_lsminiv_ir_ris_blk = 1;
+        gm_lsminiv_red_ris_blk = 1;
+        gm_maglite_3d_ris_blk = 1;
+        gm_rv_ris_blk = 1;
+        gm_streamlight_sl20_ris_blk = 1;
+        gm_streamlight_sl20_ris_brn = 1;
+        gm_zf10x42_ris_blk = 1;
+        gm_zf10x42_ris_oli = 1;
+    };
+};
+
+class asdg_OpticSideMount: asdg_OpticRail {
+    class compatibleItems {};
+};
+
+class asdg_OpticSideRail_AK: asdg_OpticSideMount {
+    class compatibleItems: compatibleItems {
+        gm_nspu_dovetail_blk = 1;
+        gm_nspu_dovetail_gry = 1;
+        gm_pgo7v_blk = 1;
+        gm_pka_dovetail_blk = 1;
+        gm_pka_dovetail_gry = 1;
+        gm_zfk4x25_blk = 1;
+        gm_zln1k_grn_dovetail_blk = 1;
+        gm_zln1k_grn_dovetail_gry = 1;
+        gm_zln1k_ir_dovetail_blk = 1;
+        gm_zln1k_ir_dovetail_gry = 1;
+    };
+};
+class asdg_OpticSideRail_SVD: asdg_OpticSideMount {
+    class compatibleItems: compatibleItems {
+        gm_nspu_dovetail_blk = 1;
+        gm_nspu_dovetail_gry = 1;
+        gm_pka_dovetail_blk = 1;
+        gm_pka_dovetail_gry = 1;
+        gm_pso6x36_1_dovetail_blk = 1;
+        gm_pso6x36_1_dovetail_gry = 1;
+        gm_pso1_dovetail_blk = 1;
+        gm_pso1_dovetail_gry = 1;
+    };
+};
+
+class asdg_OpticSideRail_RPG7: asdg_OpticSideMount {
+    class compatibleItems: compatibleItems {
+        gm_pgo7v_blk = 1;
+    };
+};

--- a/addons/jr/compat_gm/script_component.hpp
+++ b/addons/jr/compat_gm/script_component.hpp
@@ -1,0 +1,2 @@
+#define SUBCOMPONENT gm
+#include "..\script_component.hpp"

--- a/addons/jr/jr_classes.hpp
+++ b/addons/jr/jr_classes.hpp
@@ -194,6 +194,12 @@ class asdg_OpticSideRail_AKSVD: asdg_OpticSideMount {
     };
 };
 
+class asdg_OpticSideRail_RPG7: asdg_OpticSideMount {
+    class compatibleItems: compatibleItems {
+        // side plate that fits RPG-7
+    };
+};
+
 // Muzzle slots
 
 class asdg_MuzzleSlot_762: asdg_MuzzleSlot { // for 7.62x51 universal mount suppressors


### PR DESCRIPTION
**When merged this pull request will:**
- Add GM RIS mount weapons to JR
- Add GM AK dovetail mounts to JR
- Add a JR class for RPG-7 optics and add GM's to it
  - This may be less useful due to model differences, but they added their own and I thought it would be better if it was easier to add
- Added GM optics to SVD JR
  - This could stay or go, they're attached slightly higher than some other mod's dovetails
  
This PR fixes CBA overriding the GM team's attempts to add their optics to vanilla weapons. Another PR will follow (soon TM) adding JR to GM weapons.