### PR TITLE
Update scope check from 2 to 1 on magazine add/remove functions

### DIFF
--- a/addons/common/fnc_addMagazine.sqf
+++ b/addons/common/fnc_addMagazine.sqf
@@ -43,7 +43,7 @@ if (_item isEqualTo "") exitWith {
 
 private _config = configFile >> "CfgMagazines" >> _item;
 
-if (!isClass _config || {getNumber (_config >> "scope") < 2}) exitWith {
+if (!isClass _config || {getNumber (_config >> "scope") < 1}) exitWith {
     TRACE_2("Item does not exist in Config",_unit,_item);
     _return
 };

--- a/addons/common/fnc_addMagazineCargo.sqf
+++ b/addons/common/fnc_addMagazineCargo.sqf
@@ -48,7 +48,7 @@ if (_item isEqualTo "") exitWith {
 
 private _config = configFile >> "CfgMagazines" >> _item;
 
-if (isNull _config || {getNumber (_config >> "scope") < 2}) exitWith {
+if (isNull _config || {getNumber (_config >> "scope") < 1}) exitWith {
     TRACE_2("Item not exist in Config",_container,_item);
     _return
 };

--- a/addons/common/fnc_removeMagazine.sqf
+++ b/addons/common/fnc_removeMagazine.sqf
@@ -43,7 +43,7 @@ if (_item isEqualTo "") exitWith {
 
 private _config = configFile >> "CfgMagazines" >> _item;
 
-if (!isClass _config || {getNumber (_config >> "scope") < 2}) exitWith {
+if (!isClass _config || {getNumber (_config >> "scope") < 1}) exitWith {
     TRACE_2("Item does not exist in Config",_unit,_item);
     _return
 };

--- a/addons/common/fnc_removeMagazineCargo.sqf
+++ b/addons/common/fnc_removeMagazineCargo.sqf
@@ -50,7 +50,7 @@ if (_item isEqualTo "") exitWith {
 
 private _config = configFile >> "CfgMagazines" >> _item;
 
-if (isNull _config || {getNumber (_config >> "scope") < 2}) exitWith {
+if (isNull _config || {getNumber (_config >> "scope") < 1}) exitWith {
     TRACE_2("Item does not exist in Config",_container,_item);
     false
 };


### PR DESCRIPTION
**When merged this pull request will:**
Some functions do a scope < 2 check instead of a scope < 1 check. This will hinder certain magazine items, which aren't accessible in Virtual Arsenal but in the game, to not properly removed from inventories.