### PR TITLE
quicktime - fix undefined maxDistance

### DIFF
--- a/.hemtt/lints.toml
+++ b/.hemtt/lints.toml
@@ -10,3 +10,6 @@ options.ignore = [
 options.ignore = [
     "SLX_*"
 ]
+
+[stringtables.usage]
+options.ignore_unused = true

--- a/addons/quicktime/fnc_runQTE.sqf
+++ b/addons/quicktime/fnc_runQTE.sqf
@@ -70,7 +70,6 @@ private _qteArgsArray = [
     ["onDisplay", _onDisplay],
     ["onFinish", _onFinish],
     ["onFail", _onFail],
-    ["maxDistance", _maxDistance],
     ["qteSequence", _qteSequence],
     ["startTime", _startTime]
 ];


### PR DESCRIPTION
`_maxDistance` not defined
can't find anything else that uses `maxDistance` hash value