### PR TITLE
Quicktime - Replace unicode arrows and add information about reset

### DIFF
--- a/addons/quicktime/XEH_preInit.sqf
+++ b/addons/quicktime/XEH_preInit.sqf
@@ -8,19 +8,19 @@ ADDON = false;
 #include "initSettings.inc.sqf"
 
 [LSTRING(QTEKeybindGroup), QGVAR(qteUpKey), ["↑", LSTRING(QTEKeybindUpTooltip)], {
-    ["↑"] call CBA_fnc_keyPressedQTE // return
+    ["^"] call CBA_fnc_keyPressedQTE // return
 }, {}, [DIK_UP, [false, true, false]]] call CBA_fnc_addKeybind;
 
 [LSTRING(QTEKeybindGroup), QGVAR(qteDownKey), ["↓", LSTRING(QTEKeybindDownTooltip)], {
-    ["↓"] call CBA_fnc_keyPressedQTE // return
+    ["v"] call CBA_fnc_keyPressedQTE // return
 }, {}, [DIK_DOWN, [false, true, false]]] call CBA_fnc_addKeybind;
 
 [LSTRING(QTEKeybindGroup), QGVAR(qteLeftKey), ["←", LSTRING(QTEKeybindLeftTooltip)], {
-    ["←"] call CBA_fnc_keyPressedQTE // return
+    ["<"] call CBA_fnc_keyPressedQTE // return
 }, {}, [DIK_LEFT, [false, true, false]]] call CBA_fnc_addKeybind;
 
 [LSTRING(QTEKeybindGroup), QGVAR(qteRightKey), ["→", LSTRING(QTEKeybindRightTooltip)], {
-    ["→"] call CBA_fnc_keyPressedQTE // return
+    [">"] call CBA_fnc_keyPressedQTE // return
 }, {}, [DIK_RIGHT, [false, true, false]]] call CBA_fnc_addKeybind;
 
 ADDON = true;

--- a/addons/quicktime/fnc_generateQTESequence.sqf
+++ b/addons/quicktime/fnc_generateQTESequence.sqf
@@ -12,7 +12,7 @@ Example:
     [5] call CBA_fnc_generateQTESequence;
 
 Returns:
-    Quick-Time sequence of requested length made up of ["↑", "↓", "→", "←"] <ARRAY>
+    Quick-Time sequence of requested length made up of ["^", "v", ">", "<"] <ARRAY>
 
 Author:
     john681611
@@ -25,7 +25,7 @@ if (_length <= 0) exitWith {[]};
 private _code = [];
 
 for "_i" from 1 to _length do {
-    _code pushBack (selectRandom ["↑", "↓", "→", "←"]);
+    _code pushBack (selectRandom ["^", "v", ">", "<"]);
 };
 
 _code

--- a/addons/quicktime/fnc_getFormattedQTESequence.sqf
+++ b/addons/quicktime/fnc_getFormattedQTESequence.sqf
@@ -19,6 +19,12 @@ Author:
     john681611
 ---------------------------------------------------------------------------- */
 
-params ["_code"];
+params [["_code", [], [[]]]];
 
-_code joinString "     " // Arma doesn't know how to space ↑ so we need loads of spaces between
+_code = _code joinString "     "; // Arma doesn't know how to space ↑ so we need loads of spaces between
+
+{
+    _code = _code regexReplace [_x select 0, _x select 1];
+} forEach [["\^", "↑"], ["v", "↓"], [">", "→"], ["<", "←"]];
+
+_code

--- a/addons/quicktime/fnc_keyPressedQTE.sqf
+++ b/addons/quicktime/fnc_keyPressedQTE.sqf
@@ -9,7 +9,7 @@ Parameters:
     _eventQTE - Character to test against Quick-Time Event <STRING>
 
 Example:
-    ["↑"] call CBA_fnc_keyPressedQTE;
+    ["^"] call CBA_fnc_keyPressedQTE;
 
 Returns:
     True if QTE is running <BOOLEAN>
@@ -46,17 +46,25 @@ if (GVAR(QTEHistory) isEqualTo _qteSequence) exitWith {
     true
 };
 
+private _incorrectInput = false;
+
 // If the user failed an input, wipe the previous input from memory
 if (GVAR(QTEHistory) isNotEqualTo (_qteSequence select [0, count GVAR(QTEHistory)])) then {
-    GVAR(QTEHistory) = [];
-    GVAR(QTEResetCount) = GVAR(QTEResetCount) + 1;
+    if (GVAR(QTEArgs) get "resetUponIncorrectInput") then {
+        GVAR(QTEHistory) = [];
+        GVAR(QTEResetCount) = GVAR(QTEResetCount) + 1;
+    } else {
+        GVAR(QTEHistory) deleteAt [-1];
+    };
+
+    _incorrectInput = true;
 };
 
 private _onDisplay = GVAR(QTEArgs) get "onDisplay";
 if (_onDisplay isEqualType "") then {
-    [_onDisplay, [_args, _qteSequence, GVAR(QTEHistory), GVAR(QTEResetCount)]] call CBA_fnc_localEvent;
+    [_onDisplay, [_args, _qteSequence, GVAR(QTEHistory), GVAR(QTEResetCount), _incorrectInput]] call CBA_fnc_localEvent;
 } else {
-    [_args, _qteSequence, GVAR(QTEHistory), GVAR(QTEResetCount)] call _onDisplay;
+    [_args, _qteSequence, GVAR(QTEHistory), GVAR(QTEResetCount), _incorrectInput] call _onDisplay;
 };
 
 true


### PR DESCRIPTION
**When merged this pull request will:**
- Replace unicode arrows.
- Add `_resetUponIncorrectInput` to `CBA_fnc_runQTE`: If true, acts like current behaviour (QTE history is wiped and a reset is counted); if false, the QTE history remains (the incorrect input is removed, leaving a valid history only) and no resets are recorded.
- `_onDisplay`: Pass `_incorrectInput`, which informs if a wrong input was given.