### PR TITLE
Common - New Function: cba_fnc_getCfgDataRandom

### DIFF
--- a/addons/common/CfgFunctions.hpp
+++ b/addons/common/CfgFunctions.hpp
@@ -3,6 +3,7 @@ class CfgFunctions {
     class CBA {
         class Config {
             PATHTO_FNC(getConfigEntry);
+            PATHTO_FNC(getCfgDataRandom);
             PATHTO_FNC(getObjectConfig);
             PATHTO_FNC(getItemConfig);
             PATHTO_FNC(getMuzzles);

--- a/addons/common/fnc_getCfgDataRandom.sqf
+++ b/addons/common/fnc_getCfgDataRandom.sqf
@@ -4,7 +4,7 @@ Function: CBA_fnc_getCfgDataRandom
 
 Description:
     This function extracts data from a config property.
-    If it is an Array, it will select a random entry from the array, otherwise it will simply return the provided data.
+    If it is an Array, it will select a random entry from the array (nil if empty), otherwise it will simply return the provided data.
 
     Will check if _cfg exists, if not, returns nil.
 

--- a/addons/common/fnc_getCfgDataRandom.sqf
+++ b/addons/common/fnc_getCfgDataRandom.sqf
@@ -1,0 +1,36 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_getCfgDataRandom
+
+Description:
+    This function extracts data from a config property.
+    If it is an Array, it will select a random entry from the array, otherwise it will simply return the provided data.
+
+    Will check if _cfg exists, if not, returns nil.
+
+Parameters:
+    _cfg  - Entry to get value of <CONFIG>
+
+Returns:
+    Value found <STRING or NUMBER>
+
+Examples:
+    (begin example)
+        [configFile >> "CfgJellies" >> "soundEffects"] call CBA_fnc_getCfgDataRandom
+    (end)
+
+Author:
+    OverlordZorn
+---------------------------------------------------------------------------- */
+
+
+params [
+    [ "_cfg", configNull, [configNull] ]
+];
+
+if (_cfg isEqualTo configNull) exitWith {nil};
+
+private _data = [_cfg] call BIS_fnc_getCfgData;
+if (_data isEqualType []) then { _data = selectRandom _data };
+
+_data


### PR DESCRIPTION
## New Function: cba_fnc_getCfgDataRandom
This function extracts data from a config property.
If it is an Array, it will select a random entry from the array, otherwise it will simply return the provided data.
Will check if _cfg exists, if not, returns nil.

