### PR TITLE
XEH - Fix GM XEH changes

### DIFF
--- a/addons/xeh/CfgVehicles.hpp
+++ b/addons/xeh/CfgVehicles.hpp
@@ -332,6 +332,10 @@ class CfgVehicles {
     class gm_deployablebridge_base: gm_logistics_object_base {
         XEH_ENABLED;
     };
+    class gm_pallet_base: gm_logistics_object_base {};
+    class gm_fuelpallet_01_base: gm_pallet_base {
+        XEH_ENABLED;
+    };
 
     class gm_staticWeapon_base: StaticWeapon {};
     class gm_staticMG_base: gm_staticWeapon_base {};


### PR DESCRIPTION
Fix
```
[CBA] (xeh) WARNING: gm_fuelpallet_01_base does not support Extended Event Handlers! Addon: gm
```
also fixes ace's warning
```
[ACE] (refuel) WARNING: Class gm_fuelpallet_01: gm_fuelpallet_01_base [gm] needs XEH
```