### PR TITLE
ItemContextMenu - New Function: removeItemContextMenuOption

### DIFF
--- a/addons/ui/CfgFunctions.hpp
+++ b/addons/ui/CfgFunctions.hpp
@@ -56,6 +56,7 @@ class CfgFunctions {
 
         class ItemContextMenu {
             PATHTO_FNC(addItemContextMenuOption);
+            PATHTO_FNC(removeItemContextMenuOption);
             PATHTO_FNC(consumeItem);
         };
     };

--- a/addons/ui/fnc_addItemContextMenuOption.sqf
+++ b/addons/ui/fnc_addItemContextMenuOption.sqf
@@ -107,9 +107,14 @@ Parameters:
 
     _params                 - Arguments passed as '_this select 4' to condition and
                               statement (optional, default: []) <ANY>
+    
+    _ident                  - ID of the option. Can be used to remove an option.
+                              If none provided, generic ID will be generated.
+                              An already existing ID will overwrite the previous settings.
+                              (optional, default: "") <STRING>
 
 Returns:
-    Nothing/Undefined.
+    ID <STRING>.
 
 Examples:
     (begin example)
@@ -121,7 +126,7 @@ Examples:
     (end)
 
 Author:
-    commy2
+    commy2, Zorn
 ---------------------------------------------------------------------------- */
 
 // Force unscheduled environment to prevent race conditions.
@@ -133,7 +138,7 @@ if (!hasInterface) exitWith {};
 
 // Initialize system on first execution.
 if (isNil QGVAR(ItemContextMenuOptions)) then {
-    GVAR(ItemContextMenuOptions) = false call CBA_fnc_createNamespace;
+    GVAR(ItemContextMenuOptions) = createHashMap;
 
     ["CAManBase", "InventoryOpened", {
         params ["_unit", "_container1", "_container2"];
@@ -157,7 +162,8 @@ params [
     ["_condition", [], [{}, []]],
     ["_statement", {}, [{}]],
     ["_consume", false, [false]],
-    ["_params", []]
+    ["_params", []],
+    ["_ident", "", [""]]
 ];
 
 if (_item isEqualTo "") exitWith {};
@@ -222,11 +228,24 @@ _condition params [
     ["_conditionShow", {true}, [{}]]
 ];
 
-private _options = GVAR(ItemContextMenuOptions) getVariable _item;
+private _options = GVAR(ItemContextMenuOptions) get _item;
 
 if (isNil "_options") then {
-    _options = [];
-    GVAR(ItemContextMenuOptions) setVariable [_item, _options];
+    _options = createHashMap;
+    GVAR(ItemContextMenuOptions) set [_item, _options];
 };
 
-_options pushBack [_slots, _displayName, _tooltip, _color, _icon, _conditionEnable, _conditionShow, _statement, _consume, _params];
+if (_ident isEqualTo "") then {
+    private _keys = keys _options;
+    private _index = count _keys;
+
+    while { str _index in _keys } do { _index = _index + 1; };
+    _ident = _item + "_" + str _index;
+};
+
+_options set [
+    _ident,
+    [_slots, _displayName, _tooltip, _color, _icon, _conditionEnable, _conditionShow, _statement, _consume, _params]
+];
+
+_ident

--- a/addons/ui/fnc_openItemContextMenu.sqf
+++ b/addons/ui/fnc_openItemContextMenu.sqf
@@ -18,7 +18,7 @@ Examples:
     (end)
 
 Author:
-    commy2
+    commy2, Zorn
 ---------------------------------------------------------------------------- */
 
 params ["_display", "_container", "_item", "_slot"];
@@ -28,17 +28,17 @@ if (_item isEqualTo "") exitWith {};
 // Read context menu options.
 private _config = _item call CBA_fnc_getItemConfig;
 
-private _options = [];
+private _options = createHashMap;
 while {
-    _options append (GVAR(ItemContextMenuOptions) getVariable configName _config);
+    _options merge (GVAR(ItemContextMenuOptions) get configName _config);
     _config = inheritsFrom _config;
     !isNull _config
 } do {};
 
 _item call BIS_fnc_itemType params ["_itemType1", "_itemType2"];
-_options append (GVAR(ItemContextMenuOptions) getVariable [format ["##%1", _itemType2], []]);
-_options append (GVAR(ItemContextMenuOptions) getVariable [format ["#%1", _itemType1], []]);
-_options append (GVAR(ItemContextMenuOptions) getVariable ["#All", []]);
+_options merge (GVAR(ItemContextMenuOptions) getOrDefault [format ["##%1", _itemType2], createHashMap]);
+_options merge (GVAR(ItemContextMenuOptions) getOrDefault [format ["#%1", _itemType1], createHashMap]);
+_options merge (GVAR(ItemContextMenuOptions) getOrDefault ["#All", createHashMap]);
 
 // Skip menu if no options.
 if (_options isEqualTo []) exitWith {};
@@ -56,7 +56,7 @@ private _unit = call CBA_fnc_currentUnit;
 // ---
 // Populate context menu with options.
 {
-    _x params ["_slots", "_displayName", "_tooltip", "_color", "_icon", "_conditionEnable", "_conditionShow", "_statement", "_consume", "_params"];
+    _y params ["_slots", "_displayName", "_tooltip", "_color", "_icon", "_conditionEnable", "_conditionShow", "_statement", "_consume", "_params"];
 
     private _args = [_unit, _container, _item, _slot, _params];
     if (isLocalized _displayName) then {

--- a/addons/ui/fnc_removeItemContextMenuOption.sqf
+++ b/addons/ui/fnc_removeItemContextMenuOption.sqf
@@ -1,0 +1,59 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: CBA_fnc_removeItemContextMenuOption
+
+Description:
+    Removes context menu option.
+
+Parameters:
+    _item                   - Item classname <STRING>
+                              Can be base class.
+
+                              Can be item type as reported by BIS_fnc_itemType:
+                                ["Equipment","Headgear"]
+                                ->
+                                "#Equipment" and/or "##Headgear"
+
+                              Wildcard:
+                                #All
+
+    _ident                  - ID of the option. Can be used to remove an option.
+                              If none provided, generic ID will be generated.
+                              An already existing ID will overwrite the previous settings.
+                              (optional, default: "") <STRING>
+
+Returns:
+    Success <BOOL>.
+
+Examples:
+    (begin example)
+        ["#All", "Tag_myOption_3"] call CBA_fnc_removeItemContextMenuOption;
+    (end)
+
+Author:
+    Zorn
+---------------------------------------------------------------------------- */
+
+params [
+    ["_item", "All", [""]],
+    ["_ident", "", [""]]
+];
+
+// Force unscheduled environment to prevent race conditions.
+if (canSuspend) exitWith {
+    [CBA_fnc_removeItemContextMenuOption, _this] call CBA_fnc_directCall;
+};
+
+if (!hasInterface) exitWith {};
+
+// Initialize system on first execution.
+if (isNil QGVAR(ItemContextMenuOptions)) exitWith { false };
+
+if !(_item in keys GVAR(ItemContextMenuOptions)) exitWith { false };
+private _options = GVAR(ItemContextMenuOptions) get _item;
+
+if !(_ident in keys _options) exitWith { false };
+
+_options deleteAt _ident;
+
+true


### PR DESCRIPTION
**When merged this pull request will:**
## New Function
  - fnc_removeItemContextMenuOption.sqf
    - will remove ContextMenuOption based on class and identifier.

## Modified Functions
  - fnc_addItemContextMenuOption.sqf
    - New optional Parameter: "_ident"
    - GVAR(ItemContextMenuOptions) is now a hashmap instead of a cba namespace.
    - Individual "options" are now stored as hashmap with the _ident as the key while previous data array is now the value.
    - Returns "_ident" on completion
  - fnc_openItemContextMenu.sqf
    - Adapted to handle hashmaps instead of the namespace and array.