### PR TITLE
Settings - Fix setting showing up in unicode subcategories

### DIFF
--- a/addons/settings/XEH_preInit.sqf
+++ b/addons/settings/XEH_preInit.sqf
@@ -35,6 +35,14 @@ if (isNil QFUNC(init)) then {
     ["Test_6", "EDITBOX", "setting 6", ["Test Category", "Evens"], "null",   2, {systemChat str [6, _this]}] call CBA_fnc_addSetting;
     ["Test_7", "EDITBOX", "setting 7", ["Test Category", "Seven"], "null",   2, {systemChat str [7, _this]}] call CBA_fnc_addSetting;
 
+    ["Test_b1", "CHECKBOX", "setting b1", ["Test йййй"], false, 2, {systemChat str ["b1", _this]}] call CBA_fnc_addSetting;
+    ["Test_b2", "CHECKBOX", "setting b2л", ["Test йййй", "ллл"], false, 2, {systemChat str ["b2", _this]}] call CBA_fnc_addSetting;
+    ["Test_b3", "CHECKBOX", "setting b3ф", ["Test йййй", "ффф"], true, 2, {systemChat str ["b3", _this]}] call CBA_fnc_addSetting;
+
+    ["Test_c1", "CHECKBOX", "setting c1", ["Test nnnn"], false, 2, {systemChat str ["c1", _this]}] call CBA_fnc_addSetting;
+    ["Test_c2", "CHECKBOX", "setting c2r", ["Test nnnn", "rrr"], false, 2, {systemChat str ["c2", _this]}] call CBA_fnc_addSetting;
+    ["Test_c3", "CHECKBOX", "setting c3o", ["Test nnnn", "ooo"], true, 2, {systemChat str ["c3", _this]}] call CBA_fnc_addSetting;
+
     ["Test_A", "EDITBOX", "setting 1", "Test Category 1", "a", nil, {systemChat str [1, _this]}] call CBA_fnc_addSetting;
     ["Test_B", "EDITBOX", "setting 2", "Test Category 1", "b", nil, {systemChat str [2, _this]}] call CBA_fnc_addSetting;
     ["Test_C", "EDITBOX", "setting 3", "Test Category 3", "c", nil, {systemChat str [3, _this]}] call CBA_fnc_addSetting;

--- a/addons/settings/gui_createCategory.inc.sqf
+++ b/addons/settings/gui_createCategory.inc.sqf
@@ -29,7 +29,8 @@ private _categorySettings = [];
         if (isLocalized _subCategory) then {
             _subCategory = localize _subCategory;
         };
-        _categorySettings pushBack [_subCategory, _forEachIndex, _setting];
+        // Make sure empty-subcategory is always sorted first (fixing unicode)
+        _categorySettings pushBack [parseNumber (_subCategory != ""), _subCategory, _forEachIndex, _setting];
     };
 } forEach GVAR(allSettings);
 
@@ -37,7 +38,7 @@ _categorySettings sort true;
 private _lastSubCategory = "$START";
 
 {
-    _x params ["_subCategory", "", "_setting"];
+    _x params ["", "_subCategory", "", "_setting"];
     private _createHeader = false;
     if (_subCategory != _lastSubCategory) then {
         _lastSubCategory = _subCategory;


### PR DESCRIPTION
Before fix (Setting C1 showed up under a subcategory, instead of at the top by itself)
![image](https://github.com/user-attachments/assets/77c156dd-7ead-4044-b16f-adfcef84dcc9)

due to `sort` putting unicode above empty string
```
x = [["n", 1], ["й", 2], ["", 3]];
x sort true
[["й",2],["",3],["n",1]]
```