### PR TITLE
Common - Fix UUID generation

### DIFF
--- a/addons/common/fnc_createUUID.sqf
+++ b/addons/common/fnc_createUUID.sqf
@@ -35,6 +35,6 @@ for "_i" from 0 to 29 do {
 
 _uuid insert [8, ["-"]];
 _uuid insert [13, ["-", _versionByte]];
-_uuid insert [17, ["-", _variantByte]];
-_uuid insert [22, ["-"]];
+_uuid insert [18, ["-", _variantByte]];
+_uuid insert [23, ["-"]];
 _uuid joinString ""


### PR DESCRIPTION
**When merged this pull request will:**
- Fit UUIDv4 generation to fit spec
- Respect the [Submitting Content Guidelines](https://github.com/CBATeam/CBA_A3/wiki/Submitting%20content)

original implementation was off by 1 for a few bits, leading to an invalid UUID. This brings the generation up to spec.

As per the RFC, 
```
UUID=      4hexOctet "-"
           2hexOctet "-"
           2hexOctet "-"
           2hexOctet "-"
           6hexOctet
```

Current implementation ends up with the format
```
UUID=      4hexOctet "-"
           2hexOctet "-"
         1.5hexOctet "-"
           2hexOctet "-"
         6.5hexOctet
```

More simply, output from current generation compared with a fixed example
```
Old, Fixed:
44f4634c-3376-478-94de-4d1800953c423
44f4634c-3376-478d-94de-4d1800953423
```