### PR TITLE
JAM - Add "magwells" for loose ammunition.

### DIFF
--- a/addons/jam/CfgMagazineWells.hpp
+++ b/addons/jam/CfgMagazineWells.hpp
@@ -17,7 +17,7 @@ class CfgMagazineWells {
     #include "magwells_762x39.hpp"                  // 7.62x39mm | 7.62 Soviet | .30 Russian Short
     #include "magwells_762x51.hpp"                  // 7.62x51mm | .308
     #include "magwells_762x54.hpp"                  // 7.62x54mmR
-    #include "magwells_77x58.hpp"                   // 7.7x58mm Arisaka | Type 99 rimless 7.7mm | 7.7mm Japanese
+    #include "magwells_77x58.hpp"                   // 7.7x58mm Arisaka | Type 99 rimless 7.7 mm | 7.7mm Japanese
     #include "magwells_792x107mmDS.hpp"             // 7.92x107mm DS
     #include "magwells_792x33.hpp"                  // 7.92x33mm Kurz | 7.92 x 33 kurz | 7.9mm Kurz | 7.9 Kurz | 7.9mmK | 8x33 Polte
     #include "magwells_792x57.hpp"                  // 7.92x57mm Mauser | 8mm Mauser | 8x57mm | 8 x 57 IS
@@ -40,9 +40,9 @@ class CfgMagazineWells {
     #include "magwells_10mmAuto.hpp"                // 10mm Auto | 10mm Automatic | 10x25mm
     #include "magwells_57x28.hpp"                   // 5.7x28mm
     #include "magwells_762x25.hpp"                  // 7.62x25mm Tokarev
-    #include "magwells_762x38R.hpp"                 // 7.62x38mmR | 7.62mm Nagant
+    #include "magwells_762x38R.hpp"                 // 7.62x38mmR | 7.62 mm Nagant
     #include "magwells_763x25.hpp"                  // 7.63x25mm Mauser | .30 Mauser Automatic
-    #include "magwells_765x20Longue.hpp"            // 7.65x20mm Longue | 7.65mm French Longue | 7.65mm Long | 7.65mm MAS | 7.65x20mm | 7.65L | .30-18 Auto
+    #include "magwells_765x20Longue.hpp"            // 7.65x20mm Longue | 7.65mm French Longue | 7.65 mm Long | 7.65mm MAS | 7.65x20mm | 7.65L | .30-18 Auto
     #include "magwells_765x21.hpp"                  // 7.65x21mm Parabellum | 7,65 Parabellum | 7.65mm Luger | .30 Luger
     #include "magwells_8x22.hpp"                    // 8x22mm Nambu
     #include "magwells_9x18.hpp"                    // 9x18mm Makarov | 9mm Makarov | 9x18mm PM
@@ -51,10 +51,10 @@ class CfgMagazineWells {
 
     #include "magwells_22LR.hpp"                    // .22 LR | .22 Long Rifle | 5.6x15mmR
     #include "magwells_25ACP.hpp"                   // .25 ACP | 6.35x16mmSR
-    #include "magwells_32ACP.hpp"                   // .32 ACP | .32 Automatic | 7.65x17mmSR Browning | 7.65mm Browning Short
+    #include "magwells_32ACP.hpp"                   // .32 ACP | .32 Automatic | 7.65x17mmSR Browning | 7.65 mm Browning Short
     #include "magwells_357Mag.hpp"                  // .375 Magnum | .357 S&W Magnum | 9x33mmR
     #include "magwells_357SIG.hpp"                  // .357 SIG
-    #include "magwells_380ACP.hpp"                  // .380 ACP | .380 Auto | 9mm Browning | 9mm Corto | 9mm Kurz | 9mm Short | 9x17mm | 9mm Browning Court
+    #include "magwells_380ACP.hpp"                  // .380 ACP | .380 Auto | 9mm Browning | 9mm Corto | 9mm Kurz | 9mm Short | 9x17mm | 9 mm Browning Court
     #include "magwells_38Spec.hpp"                  // .38 Smith & Wesson Special | .38 Special | .38 Spl | .38 Spc | 9x29.5mmR | 9.1x29mmR
     #include "magwells_38_200.hpp"                  // .38/200 | 9x20mmR
     #include "magwells_40SW.hpp"                    // .40 S&W

--- a/addons/jam/CfgMagazineWells.hpp
+++ b/addons/jam/CfgMagazineWells.hpp
@@ -17,7 +17,7 @@ class CfgMagazineWells {
     #include "magwells_762x39.hpp"                  // 7.62x39mm | 7.62 Soviet | .30 Russian Short
     #include "magwells_762x51.hpp"                  // 7.62x51mm | .308
     #include "magwells_762x54.hpp"                  // 7.62x54mmR
-    #include "magwells_77x58.hpp"                   // 7.7x58mm Arisaka | Type 99 rimless 7.7 mm | 7.7mm Japanese
+    #include "magwells_77x58.hpp"                   // 7.7x58mm Arisaka | Type 99 rimless 7.7mm | 7.7mm Japanese
     #include "magwells_792x107mmDS.hpp"             // 7.92x107mm DS
     #include "magwells_792x33.hpp"                  // 7.92x33mm Kurz | 7.92 x 33 kurz | 7.9mm Kurz | 7.9 Kurz | 7.9mmK | 8x33 Polte
     #include "magwells_792x57.hpp"                  // 7.92x57mm Mauser | 8mm Mauser | 8x57mm | 8 x 57 IS
@@ -40,9 +40,9 @@ class CfgMagazineWells {
     #include "magwells_10mmAuto.hpp"                // 10mm Auto | 10mm Automatic | 10x25mm
     #include "magwells_57x28.hpp"                   // 5.7x28mm
     #include "magwells_762x25.hpp"                  // 7.62x25mm Tokarev
-    #include "magwells_762x38R.hpp"                 // 7.62x38mmR | 7.62 mm Nagant
+    #include "magwells_762x38R.hpp"                 // 7.62x38mmR | 7.62mm Nagant
     #include "magwells_763x25.hpp"                  // 7.63x25mm Mauser | .30 Mauser Automatic
-    #include "magwells_765x20Longue.hpp"            // 7.65x20mm Longue | 7.65mm French Longue | 7.65 mm Long | 7.65mm MAS | 7.65x20mm | 7.65L | .30-18 Auto
+    #include "magwells_765x20Longue.hpp"            // 7.65x20mm Longue | 7.65mm French Longue | 7.65mm Long | 7.65mm MAS | 7.65x20mm | 7.65L | .30-18 Auto
     #include "magwells_765x21.hpp"                  // 7.65x21mm Parabellum | 7,65 Parabellum | 7.65mm Luger | .30 Luger
     #include "magwells_8x22.hpp"                    // 8x22mm Nambu
     #include "magwells_9x18.hpp"                    // 9x18mm Makarov | 9mm Makarov | 9x18mm PM
@@ -51,10 +51,10 @@ class CfgMagazineWells {
 
     #include "magwells_22LR.hpp"                    // .22 LR | .22 Long Rifle | 5.6x15mmR
     #include "magwells_25ACP.hpp"                   // .25 ACP | 6.35x16mmSR
-    #include "magwells_32ACP.hpp"                   // .32 ACP | .32 Automatic | 7.65x17mmSR Browning | 7.65 mm Browning Short
+    #include "magwells_32ACP.hpp"                   // .32 ACP | .32 Automatic | 7.65x17mmSR Browning | 7.65mm Browning Short
     #include "magwells_357Mag.hpp"                  // .375 Magnum | .357 S&W Magnum | 9x33mmR
     #include "magwells_357SIG.hpp"                  // .357 SIG
-    #include "magwells_380ACP.hpp"                  // .380 ACP | .380 Auto | 9mm Browning | 9mm Corto | 9mm Kurz | 9mm Short | 9x17mm | 9 mm Browning Court
+    #include "magwells_380ACP.hpp"                  // .380 ACP | .380 Auto | 9mm Browning | 9mm Corto | 9mm Kurz | 9mm Short | 9x17mm | 9mm Browning Court
     #include "magwells_38Spec.hpp"                  // .38 Smith & Wesson Special | .38 Special | .38 Spl | .38 Spc | 9x29.5mmR | 9.1x29mmR
     #include "magwells_38_200.hpp"                  // .38/200 | 9x20mmR
     #include "magwells_40SW.hpp"                    // .40 S&W

--- a/addons/jam/magwells_10gauge.hpp
+++ b/addons/jam/magwells_10gauge.hpp
@@ -1,9 +1,11 @@
-    class CBA_10g_9rnds {};         // 9 loose rounds
-    class CBA_10g_8rnds {};         // 8 loose rounds
-    class CBA_10g_7rnds {};         // 7 loose rounds
-    class CBA_10g_6rnds {};         // 6 loose rounds
-    class CBA_10g_5rnds {};         // 5 loose rounds
-    class CBA_10g_4rnds {};         // 4 loose rounds
-    class CBA_10g_3rnds {};         // 3 loose rounds
-    class CBA_10g_2rnds {};         // 2 loose rounds
     class CBA_10g_1rnd {};          // 1 loose round
+    class CBA_10g_2rnds {};         // 2 loose rounds
+    class CBA_10g_3rnds {};         // 3 loose rounds
+    class CBA_10g_4rnds {};         // 4 loose rounds
+    class CBA_10g_5rnds {};         // 5 loose rounds
+    class CBA_10g_6rnds {};         // 6 loose rounds
+    class CBA_10g_7rnds {};         // 7 loose rounds
+    class CBA_10g_8rnds {};         // 8 loose rounds
+    class CBA_10g_9rnds {};         // 9 loose rounds
+    class CBA_10g_10rnds {};        // 10 loose rounds
+

--- a/addons/jam/magwells_10mmAuto.hpp
+++ b/addons/jam/magwells_10mmAuto.hpp
@@ -1,3 +1,14 @@
+    class CBA_10mmAuto_1rnd {};       // 1 loose round of 10mm Auto
+    class CBA_10mmAuto_2rnds {};      // 2 loose rounds of 10mm Auto
+    class CBA_10mmAuto_3rnds {};      // 3 loose rounds of 10mm Auto
+    class CBA_10mmAuto_4rnds {};      // 4 loose rounds of 10mm Auto
+    class CBA_10mmAuto_5rnds {};      // 5 loose rounds of 10mm Auto
+    class CBA_10mmAuto_6rnds {};      // 6 loose rounds of 10mm Auto
+    class CBA_10mmAuto_7rnds {};      // 7 loose rounds of 10mm Auto
+    class CBA_10mmAuto_8rnds {};      // 8 loose rounds of 10mm Auto
+    class CBA_10mmAuto_9rnds {};      // 9 loose rounds of 10mm Auto
+    class CBA_10mmAuto_10rnds {};     // 10 loose rounds of 10mm Auto
+
     class CBA_10mmAuto_Glock_Cpct {};    // Compact Glock in 10mm Auto (Glock 29)
     class CBA_10mmAuto_Glock_Full {};    // Fullsize Glock in 10mm Auto (Glock 20, 40)
     class CBA_10mmAuto_MP5 {};           // H&K MP5/10 10mm Auto

--- a/addons/jam/magwells_11x59R.hpp
+++ b/addons/jam/magwells_11x59R.hpp
@@ -1,1 +1,12 @@
+    class CBA_11mm_Vickers_1rnd {};       // 1 loose round of 11mm Vickers
+    class CBA_11mm_Vickers_2rnds {};      // 2 loose rounds of 11mm Vickers
+    class CBA_11mm_Vickers_3rnds {};      // 3 loose rounds of 11mm Vickers
+    class CBA_11mm_Vickers_4rnds {};      // 4 loose rounds of 11mm Vickers
+    class CBA_11mm_Vickers_5rnds {};      // 5 loose rounds of 11mm Vickers
+    class CBA_11mm_Vickers_6rnds {};      // 6 loose rounds of 11mm Vickers
+    class CBA_11mm_Vickers_7rnds {};      // 7 loose rounds of 11mm Vickers
+    class CBA_11mm_Vickers_8rnds {};      // 8 loose rounds of 11mm Vickers
+    class CBA_11mm_Vickers_9rnds {};      // 9 loose rounds of 11mm Vickers
+    class CBA_11mm_Vickers_10rnds {};     // 10 loose rounds of 11mm Vickers
+
     class CBA_11mm_Vickers {};      // Vickers machine gun in 11mm Vickers

--- a/addons/jam/magwells_127x108.hpp
+++ b/addons/jam/magwells_127x108.hpp
@@ -1,1 +1,12 @@
+    class CBA_127x108_1rnd {};       // 1 loose round of 12.7x108mm
+    class CBA_127x108_2rnds {};      // 2 loose rounds of 12.7x108mm
+    class CBA_127x108_3rnds {};      // 3 loose rounds of 12.7x108mm
+    class CBA_127x108_4rnds {};      // 4 loose rounds of 12.7x108mm
+    class CBA_127x108_5rnds {};      // 5 loose rounds of 12.7x108mm
+    class CBA_127x108_6rnds {};      // 6 loose rounds of 12.7x108mm
+    class CBA_127x108_7rnds {};      // 7 loose rounds of 12.7x108mm
+    class CBA_127x108_8rnds {};      // 8 loose rounds of 12.7x108mm
+    class CBA_127x108_9rnds {};      // 9 loose rounds of 12.7x108mm
+    class CBA_127x108_10rnds {};     // 10 loose rounds of 12.7x108mm
+
     class CBA_127x108_KSVK  {};     // KSVK

--- a/addons/jam/magwells_12gauge.hpp
+++ b/addons/jam/magwells_12gauge.hpp
@@ -1,12 +1,13 @@
-    class CBA_12g_9rnds {};         // 9 loose rounds
-    class CBA_12g_8rnds {};         // 8 loose rounds
-    class CBA_12g_7rnds {};         // 7 loose rounds
-    class CBA_12g_6rnds {};         // 6 loose rounds
-    class CBA_12g_5rnds {};         // 5 loose rounds
-    class CBA_12g_4rnds {};         // 4 loose rounds
-    class CBA_12g_3rnds {};         // 3 loose rounds
-    class CBA_12g_2rnds {};         // 2 loose rounds
     class CBA_12g_1rnd {};          // 1 loose round
+    class CBA_12g_2rnds {};         // 2 loose rounds
+    class CBA_12g_3rnds {};         // 3 loose rounds
+    class CBA_12g_4rnds {};         // 4 loose rounds
+    class CBA_12g_5rnds {};         // 5 loose rounds
+    class CBA_12g_6rnds {};         // 6 loose rounds
+    class CBA_12g_7rnds {};         // 7 loose rounds
+    class CBA_12g_8rnds {};         // 8 loose rounds
+    class CBA_12g_9rnds {};         // 9 loose rounds
+    class CBA_12g_10rnds {};        // 10 loose rounds
 
     class CBA_12g_AA12 {};          // AA-12 Stick Magazines
     class CBA_12g_AA12_XL {};       // AA-12 Drum Magazines

--- a/addons/jam/magwells_145x114.hpp
+++ b/addons/jam/magwells_145x114.hpp
@@ -1,2 +1,13 @@
+    class CBA_145x114_1rnd {};       // 1 loose round of 14.5x114mm
+    class CBA_145x114_2rnds {};      // 2 loose rounds of 14.5x114mm
+    class CBA_145x114_3rnds {};      // 3 loose rounds of 14.5x114mm
+    class CBA_145x114_4rnds {};      // 4 loose rounds of 14.5x114mm
+    class CBA_145x114_5rnds {};      // 5 loose rounds of 14.5x114mm
+    class CBA_145x114_6rnds {};      // 6 loose rounds of 14.5x114mm
+    class CBA_145x114_7rnds {};      // 7 loose rounds of 14.5x114mm
+    class CBA_145x114_8rnds {};      // 8 loose rounds of 14.5x114mm
+    class CBA_145x114_9rnds {};      // 9 loose rounds of 14.5x114mm
+    class CBA_145x114_10rnds {};     // 10 loose rounds of 14.5x114mm
+
     class CBA_145x114_PTRD {};      // PTRD-41
     class CBA_145x114_PTRS {};      // PTRS-41

--- a/addons/jam/magwells_16gauge.hpp
+++ b/addons/jam/magwells_16gauge.hpp
@@ -1,9 +1,10 @@
-    class CBA_16g_9rnds {};         // 9 loose rounds
-    class CBA_16g_8rnds {};         // 8 loose rounds
-    class CBA_16g_7rnds {};         // 7 loose rounds
-    class CBA_16g_6rnds {};         // 6 loose rounds
-    class CBA_16g_5rnds {};         // 5 loose rounds
-    class CBA_16g_4rnds {};         // 4 loose rounds
-    class CBA_16g_3rnds {};         // 3 loose rounds
-    class CBA_16g_2rnds {};         // 2 loose rounds
     class CBA_16g_1rnd {};          // 1 loose round
+    class CBA_16g_2rnds {};         // 2 loose rounds
+    class CBA_16g_3rnds {};         // 3 loose rounds
+    class CBA_16g_4rnds {};         // 4 loose rounds
+    class CBA_16g_5rnds {};         // 5 loose rounds
+    class CBA_16g_6rnds {};         // 6 loose rounds
+    class CBA_16g_7rnds {};         // 7 loose rounds
+    class CBA_16g_8rnds {};         // 8 loose rounds
+    class CBA_16g_9rnds {};         // 9 loose rounds
+    class CBA_16g_10rnds {};        // 10 loose rounds

--- a/addons/jam/magwells_20gauge.hpp
+++ b/addons/jam/magwells_20gauge.hpp
@@ -1,9 +1,10 @@
-    class CBA_20g_9rnds {};         // 9 loose rounds
-    class CBA_20g_8rnds {};         // 8 loose rounds
-    class CBA_20g_7rnds {};         // 7 loose rounds
-    class CBA_20g_6rnds {};         // 6 loose rounds
-    class CBA_20g_5rnds {};         // 5 loose rounds
-    class CBA_20g_4rnds {};         // 4 loose rounds
-    class CBA_20g_3rnds {};         // 3 loose rounds
-    class CBA_20g_2rnds {};         // 2 loose rounds
     class CBA_20g_1rnd {};          // 1 loose round
+    class CBA_20g_2rnds {};         // 2 loose rounds
+    class CBA_20g_3rnds {};         // 3 loose rounds
+    class CBA_20g_4rnds {};         // 4 loose rounds
+    class CBA_20g_5rnds {};         // 5 loose rounds
+    class CBA_20g_6rnds {};         // 6 loose rounds
+    class CBA_20g_7rnds {};         // 7 loose rounds
+    class CBA_20g_8rnds {};         // 8 loose rounds
+    class CBA_20g_9rnds {};         // 9 loose rounds
+    class CBA_20g_10rnds {};        // 10 loose rounds

--- a/addons/jam/magwells_22LR.hpp
+++ b/addons/jam/magwells_22LR.hpp
@@ -1,3 +1,14 @@
-    class CBA_9x19_CZP09Kadet {};   // CZ P-09 Kadet in .22LR
+    class CBA_22LR_1rnd {};       // 1 loose round of .22 Long Rifle
+    class CBA_22LR_2rnds {};      // 2 loose rounds of .22 Long Rifle
+    class CBA_22LR_3rnds {};      // 3 loose rounds of .22 Long Rifle
+    class CBA_22LR_4rnds {};      // 4 loose rounds of .22 Long Rifle
+    class CBA_22LR_5rnds {};      // 5 loose rounds of .22 Long Rifle
+    class CBA_22LR_6rnds {};      // 6 loose rounds of .22 Long Rifle
+    class CBA_22LR_7rnds {};      // 7 loose rounds of .22 Long Rifle
+    class CBA_22LR_8rnds {};      // 8 loose rounds of .22 Long Rifle
+    class CBA_22LR_9rnds {};      // 9 loose rounds of .22 Long Rifle
+    class CBA_22LR_10rnds {};     // 10 loose rounds of .22 Long Rifle
+
+    class CBA_22LR_CZP09Kadet {};   // CZ P-09 Kadet in .22LR
     class CBA_22LR_PP {};           // Walther PP in .22LR
     class CBA_22LR_PPK {};          // Walther PPK in .22LR

--- a/addons/jam/magwells_25ACP.hpp
+++ b/addons/jam/magwells_25ACP.hpp
@@ -1,1 +1,12 @@
+    class CBA_25ACP_1rnd {};       // 1 loose round of .25 ACP
+    class CBA_25ACP_2rnds {};      // 2 loose rounds of .25 ACP
+    class CBA_25ACP_3rnds {};      // 3 loose rounds of .25 ACP
+    class CBA_25ACP_4rnds {};      // 4 loose rounds of .25 ACP
+    class CBA_25ACP_5rnds {};      // 5 loose rounds of .25 ACP
+    class CBA_25ACP_6rnds {};      // 6 loose rounds of .25 ACP
+    class CBA_25ACP_7rnds {};      // 7 loose rounds of .25 ACP
+    class CBA_25ACP_8rnds {};      // 8 loose rounds of .25 ACP
+    class CBA_25ACP_9rnds {};      // 9 loose rounds of .25 ACP
+    class CBA_25ACP_10rnds {};     // 10 loose rounds of .25 ACP
+
     class CBA_25ACP_vz36 {};          // vz. 36

--- a/addons/jam/magwells_3006.hpp
+++ b/addons/jam/magwells_3006.hpp
@@ -1,3 +1,14 @@
+    class CBA_3006_1rnd {};       // 1 loose round of .30-06
+    class CBA_3006_2rnds {};      // 2 loose rounds of .30-06
+    class CBA_3006_3rnds {};      // 3 loose rounds of .30-06
+    class CBA_3006_4rnds {};      // 4 loose rounds of .30-06
+    class CBA_3006_5rnds {};      // 5 loose rounds of .30-06
+    class CBA_3006_6rnds {};      // 6 loose rounds of .30-06
+    class CBA_3006_7rnds {};      // 7 loose rounds of .30-06
+    class CBA_3006_8rnds {};      // 8 loose rounds of .30-06
+    class CBA_3006_9rnds {};      // 9 loose rounds of .30-06
+    class CBA_3006_10rnds {};     // 10 loose rounds of .30-06
+
     class CBA_3006_BAR {};          // M1918 BAR
     class CBA_3006_Belt {};         // M1917/M1919 Browning Machine Gun
     class CBA_3006_Garand {};       // M1 Garand

--- a/addons/jam/magwells_300BLK.hpp
+++ b/addons/jam/magwells_300BLK.hpp
@@ -1,3 +1,14 @@
+    class CBA_300BLK_1rnd {};       // 1 loose round of .300 Blackout
+    class CBA_300BLK_2rnds {};      // 2 loose rounds of .300 Blackout
+    class CBA_300BLK_3rnds {};      // 3 loose rounds of .300 Blackout
+    class CBA_300BLK_4rnds {};      // 4 loose rounds of .300 Blackout
+    class CBA_300BLK_5rnds {};      // 5 loose rounds of .300 Blackout
+    class CBA_300BLK_6rnds {};      // 6 loose rounds of .300 Blackout
+    class CBA_300BLK_7rnds {};      // 7 loose rounds of .300 Blackout
+    class CBA_300BLK_8rnds {};      // 8 loose rounds of .300 Blackout
+    class CBA_300BLK_9rnds {};      // 9 loose rounds of .300 Blackout
+    class CBA_300BLK_10rnds {};     // 10 loose rounds of .300 Blackout
+
     class CBA_300BLK_STANAG {};         // .300 Blackout in a normal length STANAG mag, including small drums
     class CBA_300BLK_STANAG_L {};       // .300 Blackout in a long STANAG stick or coffin
     class CBA_300BLK_STANAG_XL {};      // .300 Blackout in an extra long STANAG stick or coffin mag

--- a/addons/jam/magwells_300WM.hpp
+++ b/addons/jam/magwells_300WM.hpp
@@ -1,3 +1,14 @@
+    class CBA_300WM_1rnd {};       // 1 loose round of .300 Winchester Magnum
+    class CBA_300WM_2rnds {};      // 2 loose rounds of .300 Winchester Magnum
+    class CBA_300WM_3rnds {};      // 3 loose rounds of .300 Winchester Magnum
+    class CBA_300WM_4rnds {};      // 4 loose rounds of .300 Winchester Magnum
+    class CBA_300WM_5rnds {};      // 5 loose rounds of .300 Winchester Magnum
+    class CBA_300WM_6rnds {};      // 6 loose rounds of .300 Winchester Magnum
+    class CBA_300WM_7rnds {};      // 7 loose rounds of .300 Winchester Magnum
+    class CBA_300WM_8rnds {};      // 8 loose rounds of .300 Winchester Magnum
+    class CBA_300WM_9rnds {};      // 9 loose rounds of .300 Winchester Magnum
+    class CBA_300WM_10rnds {};     // 10 loose rounds of .300 Winchester Magnum
+
     class CBA_300WM_AICS {};        // AICS long action mag (5 rounds)
 
     //Deprecated classes do not use

--- a/addons/jam/magwells_303B.hpp
+++ b/addons/jam/magwells_303B.hpp
@@ -1,3 +1,14 @@
+    class CBA_303B_1rnd {};       // 1 loose round of .303 British
+    class CBA_303B_2rnds {};      // 2 loose rounds of .303 British
+    class CBA_303B_3rnds {};      // 3 loose rounds of .303 British
+    class CBA_303B_4rnds {};      // 4 loose rounds of .303 British
+    class CBA_303B_5rnds {};      // 5 loose rounds of .303 British
+    class CBA_303B_6rnds {};      // 6 loose rounds of .303 British
+    class CBA_303B_7rnds {};      // 7 loose rounds of .303 British
+    class CBA_303B_8rnds {};      // 8 loose rounds of .303 British
+    class CBA_303B_9rnds {};      // 9 loose rounds of .303 British
+    class CBA_303B_10rnds {};     // 10 loose rounds of .303 British
+
     class CBA_303B_BREN {};         // BREN gun
     class CBA_303B_LeeEn {};        // Lee Enfield
     class CBA_303B_Maxim {};        // Maxim gun in .303 British

--- a/addons/jam/magwells_30Carbine.hpp
+++ b/addons/jam/magwells_30Carbine.hpp
@@ -1,1 +1,12 @@
-    class CBA_30Carbine_M1Carbine {};        // M1 Carbine, M2 Carbine
+    class CBA_30Carbine_1rnd {};       // 1 loose round of .30 Carbine
+    class CBA_30Carbine_2rnds {};      // 2 loose rounds of .30 Carbine
+    class CBA_30Carbine_3rnds {};      // 3 loose rounds of .30 Carbine
+    class CBA_30Carbine_4rnds {};      // 4 loose rounds of .30 Carbine
+    class CBA_30Carbine_5rnds {};      // 5 loose rounds of .30 Carbine
+    class CBA_30Carbine_6rnds {};      // 6 loose rounds of .30 Carbine
+    class CBA_30Carbine_7rnds {};      // 7 loose rounds of .30 Carbine
+    class CBA_30Carbine_8rnds {};      // 8 loose rounds of .30 Carbine
+    class CBA_30Carbine_9rnds {};      // 9 loose rounds of .30 Carbine
+    class CBA_30Carbine_10rnds {};     // 10 loose rounds of .30 Carbine
+
+    class CBA_30Carbine_M1Carbine {};        // M1 Carbine, M2 Carbine, M3 Carbine

--- a/addons/jam/magwells_32ACP.hpp
+++ b/addons/jam/magwells_32ACP.hpp
@@ -1,3 +1,14 @@
+    class CBA_32ACP_1rnd {};       // 1 loose round of .32 ACP
+    class CBA_32ACP_2rnds {};      // 2 loose rounds of .32 ACP
+    class CBA_32ACP_3rnds {};      // 3 loose rounds of .32 ACP
+    class CBA_32ACP_4rnds {};      // 4 loose rounds of .32 ACP
+    class CBA_32ACP_5rnds {};      // 5 loose rounds of .32 ACP
+    class CBA_32ACP_6rnds {};      // 6 loose rounds of .32 ACP
+    class CBA_32ACP_7rnds {};      // 7 loose rounds of .32 ACP
+    class CBA_32ACP_8rnds {};      // 8 loose rounds of .32 ACP
+    class CBA_32ACP_9rnds {};      // 9 loose rounds of .32 ACP
+    class CBA_32ACP_10rnds {};     // 10 loose rounds of .32 ACP
+
     class CBA_32ACP_CZ82 {};        // CZ 82, CZ 83
     class CBA_32ACP_P83 {};         // FB P-83 Wanad
     class CBA_32ACP_PA63 {};        // FEG PA-63

--- a/addons/jam/magwells_338LM.hpp
+++ b/addons/jam/magwells_338LM.hpp
@@ -1,3 +1,14 @@
+    class CBA_338LM_1rnd {};       // 1 loose round of .338 Lapua Magnum
+    class CBA_338LM_2rnds {};      // 2 loose rounds of .338 Lapua Magnum
+    class CBA_338LM_3rnds {};      // 3 loose rounds of .338 Lapua Magnum
+    class CBA_338LM_4rnds {};      // 4 loose rounds of .338 Lapua Magnum
+    class CBA_338LM_5rnds {};      // 5 loose rounds of .338 Lapua Magnum
+    class CBA_338LM_6rnds {};      // 6 loose rounds of .338 Lapua Magnum
+    class CBA_338LM_7rnds {};      // 7 loose rounds of .338 Lapua Magnum
+    class CBA_338LM_8rnds {};      // 8 loose rounds of .338 Lapua Magnum
+    class CBA_338LM_9rnds {};      // 9 loose rounds of .338 Lapua Magnum
+    class CBA_338LM_10rnds {};     // 10 loose rounds of .338 Lapua Magnum
+
     class CBA_338LM_AI {};          // AI .338 Lapua Magnum
     class CBA_338LM_RS9 {};         // Haenel RS9, G29
     class CBA_338LM_T5000 {};       // ORSIS T-5000

--- a/addons/jam/magwells_338NM.hpp
+++ b/addons/jam/magwells_338NM.hpp
@@ -1,5 +1,16 @@
-class CBA_338NM_LINKS {
-    BI_mags[] = {
-        "130Rnd_338_Mag"
+    class CBA_338NM_1rnd {};       // 1 loose round of .338 Norma Magnum
+    class CBA_338NM_2rnds {};      // 2 loose rounds of .338 Norma Magnum
+    class CBA_338NM_3rnds {};      // 3 loose rounds of .338 Norma Magnum
+    class CBA_338NM_4rnds {};      // 4 loose rounds of .338 Norma Magnum
+    class CBA_338NM_5rnds {};      // 5 loose rounds of .338 Norma Magnum
+    class CBA_338NM_6rnds {};      // 6 loose rounds of .338 Norma Magnum
+    class CBA_338NM_7rnds {};      // 7 loose rounds of .338 Norma Magnum
+    class CBA_338NM_8rnds {};      // 8 loose rounds of .338 Norma Magnum
+    class CBA_338NM_9rnds {};      // 9 loose rounds of .338 Norma Magnum
+    class CBA_338NM_10rnds {};     // 10 loose rounds of .338 Norma Magnum
+
+    class CBA_338NM_LINKS {
+        BI_mags[] = {
+            "130Rnd_338_Mag"
+        };
     };
-};

--- a/addons/jam/magwells_357Mag.hpp
+++ b/addons/jam/magwells_357Mag.hpp
@@ -1,5 +1,13 @@
+    class CBA_357_1rnd {};       // 1 loose round of .357 Magnum
+    class CBA_357_2rnds {};      // 2 loose rounds of .357 Magnum
+    class CBA_357_3rnds {};      // 3 loose rounds of .357 Magnum
+    class CBA_357_4rnds {};      // 4 loose rounds of .357 Magnum
+    class CBA_357_5rnds {};      // 5 loose rounds of .357 Magnum
+    class CBA_357_6rnds {};      // 6 loose rounds of .357 Magnum
+    class CBA_357_7rnds {};      // 7 loose rounds of .357 Magnum
+    class CBA_357_8rnds {};      // 8 loose rounds of .357 Magnum
+    class CBA_357_9rnds {};      // 9 loose rounds of .357 Magnum
+    class CBA_357_10rnds {};     // 10 loose rounds of .357 Magnum
+
     class CBA_357_Clip_6rnds {};        // 6 round .357 Magnum moon clip
     class CBA_357_Clip_5rnds {};        // 5 round .357 Magnum moon clip
-
-    class CBA_357_6rnds {};             // 6 loose rounds of .357 Magnum
-    class CBA_357_5rnds {};             // 5 loose rounds of .357 Magnum

--- a/addons/jam/magwells_357SIG.hpp
+++ b/addons/jam/magwells_357SIG.hpp
@@ -1,3 +1,14 @@
+    class CBA_357SIG_1rnd {};       // 1 loose round of .357 SIG
+    class CBA_357SIG_2rnds {};      // 2 loose rounds of .357 SIG
+    class CBA_357SIG_3rnds {};      // 3 loose rounds of .357 SIG
+    class CBA_357SIG_4rnds {};      // 4 loose rounds of .357 SIG
+    class CBA_357SIG_5rnds {};      // 5 loose rounds of .357 SIG
+    class CBA_357SIG_6rnds {};      // 6 loose rounds of .357 SIG
+    class CBA_357SIG_7rnds {};      // 7 loose rounds of .357 SIG
+    class CBA_357SIG_8rnds {};      // 8 loose rounds of .357 SIG
+    class CBA_357SIG_9rnds {};      // 9 loose rounds of .357 SIG
+    class CBA_357SIG_10rnds {};     // 10 loose rounds of .357 SIG
+
     class CBA_375SIG_Glock_SubC {};     // Subcompact Glock in .357 SIG (Glock 33)
     class CBA_375SIG_Glock_Cpct {};     // Compact Glock in .357 SIG (Glock 32)
     class CBA_375SIG_Glock_Full {};     // Fullsize Glock in .357 SIG (Glock 31)

--- a/addons/jam/magwells_380ACP.hpp
+++ b/addons/jam/magwells_380ACP.hpp
@@ -1,3 +1,14 @@
+    class CBA_380ACP_1rnd {};       // 1 loose round of .380 ACP
+    class CBA_380ACP_2rnds {};      // 2 loose rounds of .380 ACP
+    class CBA_380ACP_3rnds {};      // 3 loose rounds of .380 ACP
+    class CBA_380ACP_4rnds {};      // 4 loose rounds of .380 ACP
+    class CBA_380ACP_5rnds {};      // 5 loose rounds of .380 ACP
+    class CBA_380ACP_6rnds {};      // 6 loose rounds of .380 ACP
+    class CBA_380ACP_7rnds {};      // 7 loose rounds of .380 ACP
+    class CBA_380ACP_8rnds {};      // 8 loose rounds of .380 ACP
+    class CBA_380ACP_9rnds {};      // 9 loose rounds of .380 ACP
+    class CBA_380ACP_10rnds {};     // 10 loose rounds of .380 ACP
+
     class CBA_380ACP_CZ82 {};           // CZ 82, CZ-83
     class CBA_380ACP_Fort12 {};         // Fort-12
     class CBA_380ACP_Glock_Slim {};     // Slimline Glock in .380 ACP (Glock 42)

--- a/addons/jam/magwells_38Spec.hpp
+++ b/addons/jam/magwells_38Spec.hpp
@@ -1,5 +1,14 @@
+    class CBA_38_Special_1rnd {};       // 1 loose round of .38 Special
+    class CBA_38_Special_2rnds {};      // 2 loose rounds of .38 Special
+    class CBA_38_Special_3rnds {};      // 3 loose rounds of .38 Special
+    class CBA_38_Special_4rnds {};      // 4 loose rounds of .38 Special
+    class CBA_38_Special_5rnds {};      // 5 loose rounds of .38 Special
+    class CBA_38_Special_6rnds {};      // 6 loose rounds of .38 Special
+    class CBA_38_Special_7rnds {};      // 7 loose rounds of .38 Special
+    class CBA_38_Special_8rnds {};      // 8 loose rounds of .38 Special
+    class CBA_38_Special_9rnds {};      // 9 loose rounds of .38 Special
+    class CBA_38_Special_10rnds {};     // 10 loose rounds of .38 Special
+
     class CBA_38_Special_Clip_6rnds {}; // 6 round .38 Special moon clip
     class CBA_38_Special_Clip_5rnds {}; // 5 round .38 Special moon clip
 
-    class CBA_38_Special_6rnds {};      // 6 loose rounds of .38 Special
-    class CBA_38_Special_5rnds {};      // 5 loose rounds of .38 Special

--- a/addons/jam/magwells_38_200.hpp
+++ b/addons/jam/magwells_38_200.hpp
@@ -1,1 +1,12 @@
+    class CBA_38_200_Webley_1rnd {};       // 1 loose round of .38/200 Webley
+    class CBA_38_200_Webley_2rnds {};      // 2 loose rounds of .38/200 Webley
+    class CBA_38_200_Webley_3rnds {};      // 3 loose rounds of .38/200 Webley
+    class CBA_38_200_Webley_4rnds {};      // 4 loose rounds of .38/200 Webley
+    class CBA_38_200_Webley_5rnds {};      // 5 loose rounds of .38/200 Webley
+    class CBA_38_200_Webley_6rnds {};      // 6 loose rounds of .38/200 Webley
+    class CBA_38_200_Webley_7rnds {};      // 7 loose rounds of .38/200 Webley
+    class CBA_38_200_Webley_8rnds {};      // 8 loose rounds of .38/200 Webley
+    class CBA_38_200_Webley_9rnds {};      // 9 loose rounds of .38/200 Webley
+    class CBA_38_200_Webley_10rnds {};     // 10 loose rounds of .38/200 Webley
+
     class CBA_38_200_Webley {};     // Webley Revolver in .38/200

--- a/addons/jam/magwells_408CT.hpp
+++ b/addons/jam/magwells_408CT.hpp
@@ -1,1 +1,12 @@
+    class CBA_408CT_1rnd {};       // 1 loose round of .408 Chey Tac
+    class CBA_408CT_2rnds {};      // 2 loose rounds of .408 Chey Tac
+    class CBA_408CT_3rnds {};      // 3 loose rounds of .408 Chey Tac
+    class CBA_408CT_4rnds {};      // 4 loose rounds of .408 Chey Tac
+    class CBA_408CT_5rnds {};      // 5 loose rounds of .408 Chey Tac
+    class CBA_408CT_6rnds {};      // 6 loose rounds of .408 Chey Tac
+    class CBA_408CT_7rnds {};      // 7 loose rounds of .408 Chey Tac
+    class CBA_408CT_8rnds {};      // 8 loose rounds of .408 Chey Tac
+    class CBA_408CT_9rnds {};      // 9 loose rounds of .408 Chey Tac
+    class CBA_408CT_10rnds {};     // 10 loose rounds of .408 Chey Tac
+
     class CBA_408CT_Inter {};           // CheyTac Intervention in .408 Chey Tac

--- a/addons/jam/magwells_40SW.hpp
+++ b/addons/jam/magwells_40SW.hpp
@@ -1,3 +1,14 @@
+    class CBA_40SW_1rnd {};       // 1 loose round of .40 S&W
+    class CBA_40SW_2rnds {};      // 2 loose rounds of .40 S&W
+    class CBA_40SW_3rnds {};      // 3 loose rounds of .40 S&W
+    class CBA_40SW_4rnds {};      // 4 loose rounds of .40 S&W
+    class CBA_40SW_5rnds {};      // 5 loose rounds of .40 S&W
+    class CBA_40SW_6rnds {};      // 6 loose rounds of .40 S&W
+    class CBA_40SW_7rnds {};      // 7 loose rounds of .40 S&W
+    class CBA_40SW_8rnds {};      // 8 loose rounds of .40 S&W
+    class CBA_40SW_9rnds {};      // 9 loose rounds of .40 S&W
+    class CBA_40SW_10rnds {};     // 10 loose rounds of .40 S&W
+
     class CBA_40SW_CZ2075 {};       // Subcompact CZ 2075 in .40 S&W
     class CBA_40SW_CZ75_Cpct {};    // Compact CZ 75, CZ 85 in .40 S&W
     class CBA_40SW_CZ75_Full {};    // Fullsize CZ 75, CZ 85 in .40 S&W

--- a/addons/jam/magwells_455W.hpp
+++ b/addons/jam/magwells_455W.hpp
@@ -1,1 +1,12 @@
+    class CBA_455_Webley_1rnd {};       // 1 loose round of .455 Webley
+    class CBA_455_Webley_2rnds {};      // 2 loose rounds of .455 Webley
+    class CBA_455_Webley_3rnds {};      // 3 loose rounds of .455 Webley
+    class CBA_455_Webley_4rnds {};      // 4 loose rounds of .455 Webley
+    class CBA_455_Webley_5rnds {};      // 5 loose rounds of .455 Webley
+    class CBA_455_Webley_6rnds {};      // 6 loose rounds of .455 Webley
+    class CBA_455_Webley_7rnds {};      // 7 loose rounds of .455 Webley
+    class CBA_455_Webley_8rnds {};      // 8 loose rounds of .455 Webley
+    class CBA_455_Webley_9rnds {};      // 9 loose rounds of .455 Webley
+    class CBA_455_Webley_10rnds {};     // 10 loose rounds of .455 Webley
+
     class CBA_455_Webley {};        // Webley Revolver in .455 Webley

--- a/addons/jam/magwells_45ACP.hpp
+++ b/addons/jam/magwells_45ACP.hpp
@@ -1,9 +1,17 @@
+    class CBA_45ACP_1rnd {};       // 1 loose round of .45 ACP
+    class CBA_45ACP_2rnds {};      // 2 loose rounds of .45 ACP
+    class CBA_45ACP_3rnds {};      // 3 loose rounds of .45 ACP
+    class CBA_45ACP_4rnds {};      // 4 loose rounds of .45 ACP
+    class CBA_45ACP_5rnds {};      // 5 loose rounds of .45 ACP
+    class CBA_45ACP_6rnds {};      // 6 loose rounds of .45 ACP
+    class CBA_45ACP_7rnds {};      // 7 loose rounds of .45 ACP
+    class CBA_45ACP_8rnds {};      // 8 loose rounds of .45 ACP
+    class CBA_45ACP_9rnds {};      // 9 loose rounds of .45 ACP
+    class CBA_45ACP_10rnds {};     // 10 loose rounds of .45 ACP
+
     class CBA_45ACP_Clip_6rnds {};      // 6 round .45 ACP moon clip or speed loader
     class CBA_45ACP_Clip_5rnds {};      // 5 round .45 ACP moon clip or speed loader
 
-    class CBA_45ACP_6rnds {};           // 6 loose rounds of .45 ACP
-    class CBA_45ACP_5rnds {};           // 5 loose rounds of .45 ACP
- 
     class CBA_45ACP_1911 {              // Colt M1911
         BI_mags[] = {
             "9Rnd_45ACP_Mag"

--- a/addons/jam/magwells_45GAP.hpp
+++ b/addons/jam/magwells_45GAP.hpp
@@ -1,3 +1,14 @@
+    class CBA_45_GAP_1rnd {};       // 1 loose round of .45 GAP
+    class CBA_45_GAP_2rnds {};      // 2 loose rounds of .45 GAP
+    class CBA_45_GAP_3rnds {};      // 3 loose rounds of .45 GAP
+    class CBA_45_GAP_4rnds {};      // 4 loose rounds of .45 GAP
+    class CBA_45_GAP_5rnds {};      // 5 loose rounds of .45 GAP
+    class CBA_45_GAP_6rnds {};      // 6 loose rounds of .45 GAP
+    class CBA_45_GAP_7rnds {};      // 7 loose rounds of .45 GAP
+    class CBA_45_GAP_8rnds {};      // 8 loose rounds of .45 GAP
+    class CBA_45_GAP_9rnds {};      // 9 loose rounds of .45 GAP
+    class CBA_45_GAP_10rnds {};     // 10 loose rounds of .45 GAP
+
     class CBA_45GAP_Glock_SubC {};      // Subcompact Glock in .45 GAP (Glock 39)
     class CBA_45GAP_Glock_Cpct {};      // Compact Glock in .45 GAP (Glock 38)
     class CBA_45GAP_Glock_Full {};      // Fullsize Glock in .45 GAP (Glock 37)

--- a/addons/jam/magwells_46x30.hpp
+++ b/addons/jam/magwells_46x30.hpp
@@ -1,1 +1,12 @@
+    class CBA_46x30_1rnd {};       // 1 loose round of 4.6x30mm
+    class CBA_46x30_2rnds {};      // 2 loose rounds of 4.6x30mm
+    class CBA_46x30_3rnds {};      // 3 loose rounds of 4.6x30mm
+    class CBA_46x30_4rnds {};      // 4 loose rounds of 4.6x30mm
+    class CBA_46x30_5rnds {};      // 5 loose rounds of 4.6x30mm
+    class CBA_46x30_6rnds {};      // 6 loose rounds of 4.6x30mm
+    class CBA_46x30_7rnds {};      // 7 loose rounds of 4.6x30mm
+    class CBA_46x30_8rnds {};      // 8 loose rounds of 4.6x30mm
+    class CBA_46x30_9rnds {};      // 9 loose rounds of 4.6x30mm
+    class CBA_46x30_10rnds {};     // 10 loose rounds of 4.6x30mm
+
     class CBA_46x30_MP7 {};         // H&K MP7

--- a/addons/jam/magwells_50BMG.hpp
+++ b/addons/jam/magwells_50BMG.hpp
@@ -1,3 +1,14 @@
+    class CBA_50BMG_1rnd {};       // 1 loose round of .50 BMG
+    class CBA_50BMG_2rnds {};      // 2 loose rounds of .50 BMG
+    class CBA_50BMG_3rnds {};      // 3 loose rounds of .50 BMG
+    class CBA_50BMG_4rnds {};      // 4 loose rounds of .50 BMG
+    class CBA_50BMG_5rnds {};      // 5 loose rounds of .50 BMG
+    class CBA_50BMG_6rnds {};      // 6 loose rounds of .50 BMG
+    class CBA_50BMG_7rnds {};      // 7 loose rounds of .50 BMG
+    class CBA_50BMG_8rnds {};      // 8 loose rounds of .50 BMG
+    class CBA_50BMG_9rnds {};      // 9 loose rounds of .50 BMG
+    class CBA_50BMG_10rnds {};     // 10 loose rounds of .50 BMG
+
     class CBA_50BMG_AS50 {};            // Accuracy International AS50
     class CBA_50BMG_M107 {};            // M82, M107, G82
     class CBA_50BMG_PGM_Hecate_II {};   // PGM Hécate II, PGM Hecate II

--- a/addons/jam/magwells_545x39.hpp
+++ b/addons/jam/magwells_545x39.hpp
@@ -1,3 +1,14 @@
+    class CBA_545x39_1rnd {};       // 1 loose round of 5.45x39mm
+    class CBA_545x39_2rnds {};      // 2 loose rounds of 5.45x39mm
+    class CBA_545x39_3rnds {};      // 3 loose rounds of 5.45x39mm
+    class CBA_545x39_4rnds {};      // 4 loose rounds of 5.45x39mm
+    class CBA_545x39_5rnds {};      // 5 loose rounds of 5.45x39mm
+    class CBA_545x39_6rnds {};      // 6 loose rounds of 5.45x39mm
+    class CBA_545x39_7rnds {};      // 7 loose rounds of 5.45x39mm
+    class CBA_545x39_8rnds {};      // 8 loose rounds of 5.45x39mm
+    class CBA_545x39_9rnds {};      // 9 loose rounds of 5.45x39mm
+    class CBA_545x39_10rnds {};     // 10 loose rounds of 5.45x39mm
+
     class CBA_545x39_AK {       // Standard AK-74 magazines
         BI_mags[] = {
             "30Rnd_545x39_Mag_F",

--- a/addons/jam/magwells_556x45.hpp
+++ b/addons/jam/magwells_556x45.hpp
@@ -1,3 +1,14 @@
+    class CBA_556x45_1rnd {};       // 1 loose round of 5.56x45mm
+    class CBA_556x45_2rnds {};      // 2 loose rounds of 5.56x45mm
+    class CBA_556x45_3rnds {};      // 3 loose rounds of 5.56x45mm
+    class CBA_556x45_4rnds {};      // 4 loose rounds of 5.56x45mm
+    class CBA_556x45_5rnds {};      // 5 loose rounds of 5.56x45mm
+    class CBA_556x45_6rnds {};      // 6 loose rounds of 5.56x45mm
+    class CBA_556x45_7rnds {};      // 7 loose rounds of 5.56x45mm
+    class CBA_556x45_8rnds {};      // 8 loose rounds of 5.56x45mm
+    class CBA_556x45_9rnds {};      // 9 loose rounds of 5.56x45mm
+    class CBA_556x45_10rnds {};     // 10 loose rounds of 5.56x45mm
+
     class CBA_556x45_AK {};             // AK mags for 5.56 AK type rifles, AK-101, AK-102, etc.
     class CBA_556x45_RPK {};            // 45rnd RPK mags for 5.56 RPK-201
     class CBA_556x45_FAMAS {};          // FAMAS F1

--- a/addons/jam/magwells_57x28.hpp
+++ b/addons/jam/magwells_57x28.hpp
@@ -1,4 +1,15 @@
-    class CBA_57x28_FN57 {};        // FN Five-Seven  
+    class CBA_57x28_1rnd {};       // 1 loose round of 5.7x28mm
+    class CBA_57x28_2rnds {};      // 2 loose rounds of 5.7x28mm
+    class CBA_57x28_3rnds {};      // 3 loose rounds of 5.7x28mm
+    class CBA_57x28_4rnds {};      // 4 loose rounds of 5.7x28mm
+    class CBA_57x28_5rnds {};      // 5 loose rounds of 5.7x28mm
+    class CBA_57x28_6rnds {};      // 6 loose rounds of 5.7x28mm
+    class CBA_57x28_7rnds {};      // 7 loose rounds of 5.7x28mm
+    class CBA_57x28_8rnds {};      // 8 loose rounds of 5.7x28mm
+    class CBA_57x28_9rnds {};      // 9 loose rounds of 5.7x28mm
+    class CBA_57x28_10rnds {};     // 10 loose rounds of 5.7x28mm
+
+    class CBA_57x28_FN57 {};        // FN Five-Seven
     class CBA_57x28_P90 {           // FN P90, also 5.7x28 AR-57
         BI_mags[] = {
             "50Rnd_570x28_SMG_03"

--- a/addons/jam/magwells_580x42.hpp
+++ b/addons/jam/magwells_580x42.hpp
@@ -1,3 +1,14 @@
+    class CBA_580x42_1rnd {};       // 1 loose round of 5.80x42mm
+    class CBA_580x42_2rnds {};      // 2 loose rounds of 5.80x42mm
+    class CBA_580x42_3rnds {};      // 3 loose rounds of 5.80x42mm
+    class CBA_580x42_4rnds {};      // 4 loose rounds of 5.80x42mm
+    class CBA_580x42_5rnds {};      // 5 loose rounds of 5.80x42mm
+    class CBA_580x42_6rnds {};      // 6 loose rounds of 5.80x42mm
+    class CBA_580x42_7rnds {};      // 7 loose rounds of 5.80x42mm
+    class CBA_580x42_8rnds {};      // 8 loose rounds of 5.80x42mm
+    class CBA_580x42_9rnds {};      // 9 loose rounds of 5.80x42mm
+    class CBA_580x42_10rnds {};     // 10 loose rounds of 5.80x42mm
+
     class CBA_580x42_TYPE95 {           // QBZ-95 Stick Mags
         BI_mags[] = {
             "30Rnd_580x42_Mag_F",

--- a/addons/jam/magwells_65C.hpp
+++ b/addons/jam/magwells_65C.hpp
@@ -1,1 +1,12 @@
+    class CBA_65C_1rnd {};       // 1 loose round of 6.5mm Creedmoor
+    class CBA_65C_2rnds {};      // 2 loose rounds of 6.5mm Creedmoor
+    class CBA_65C_3rnds {};      // 3 loose rounds of 6.5mm Creedmoor
+    class CBA_65C_4rnds {};      // 4 loose rounds of 6.5mm Creedmoor
+    class CBA_65C_5rnds {};      // 5 loose rounds of 6.5mm Creedmoor
+    class CBA_65C_6rnds {};      // 6 loose rounds of 6.5mm Creedmoor
+    class CBA_65C_7rnds {};      // 7 loose rounds of 6.5mm Creedmoor
+    class CBA_65C_8rnds {};      // 8 loose rounds of 6.5mm Creedmoor
+    class CBA_65C_9rnds {};      // 9 loose rounds of 6.5mm Creedmoor
+    class CBA_65C_10rnds {};     // 10 loose rounds of 6.5mm Creedmoor
+
     class CBA_65C_AR10 {};       // AR-10 in 6.5 Creedmoor standard mag (20 rounds)

--- a/addons/jam/magwells_65G.hpp
+++ b/addons/jam/magwells_65G.hpp
@@ -1,3 +1,14 @@
+    class CBA_65G_1rnd {};       // 1 loose round of 6.5mm Grendel
+    class CBA_65G_2rnds {};      // 2 loose rounds of 6.5mm Grendel
+    class CBA_65G_3rnds {};      // 3 loose rounds of 6.5mm Grendel
+    class CBA_65G_4rnds {};      // 4 loose rounds of 6.5mm Grendel
+    class CBA_65G_5rnds {};      // 5 loose rounds of 6.5mm Grendel
+    class CBA_65G_6rnds {};      // 6 loose rounds of 6.5mm Grendel
+    class CBA_65G_7rnds {};      // 7 loose rounds of 6.5mm Grendel
+    class CBA_65G_8rnds {};      // 8 loose rounds of 6.5mm Grendel
+    class CBA_65G_9rnds {};      // 9 loose rounds of 6.5mm Grendel
+    class CBA_65G_10rnds {};     // 10 loose rounds of 6.5mm Grendel
+
     class CBA_65G_STANAG {};            // 6.5mm Grendel in a normal length STANAG mag, including small drums
     class CBA_65G_STANAG_L {};          // 6.5mm Grendel in a long STANAG stick or coffin
     class CBA_65G_STANAG_XL {};         // 6.5mm Grendel in an extra long STANAG stick or coffin mag

--- a/addons/jam/magwells_65x39.hpp
+++ b/addons/jam/magwells_65x39.hpp
@@ -1,3 +1,14 @@
+    class CBA_65x39_1rnd {};       // 1 loose round of 6.5x39mm Caseless
+    class CBA_65x39_2rnds {};      // 2 loose rounds of 6.5x39mm Caseless
+    class CBA_65x39_3rnds {};      // 3 loose rounds of 6.5x39mm Caseless
+    class CBA_65x39_4rnds {};      // 4 loose rounds of 6.5x39mm Caseless
+    class CBA_65x39_5rnds {};      // 5 loose rounds of 6.5x39mm Caseless
+    class CBA_65x39_6rnds {};      // 6 loose rounds of 6.5x39mm Caseless
+    class CBA_65x39_7rnds {};      // 7 loose rounds of 6.5x39mm Caseless
+    class CBA_65x39_8rnds {};      // 8 loose rounds of 6.5x39mm Caseless
+    class CBA_65x39_9rnds {};      // 9 loose rounds of 6.5x39mm Caseless
+    class CBA_65x39_10rnds {};     // 10 loose rounds of 6.5x39mm Caseless
+
     class CBA_65x39_MX {
         BI_mags[] = {
             "30Rnd_65x39_caseless_mag",

--- a/addons/jam/magwells_68SPC.hpp
+++ b/addons/jam/magwells_68SPC.hpp
@@ -1,3 +1,14 @@
+    class CBA_68SPC_1rnd {};       // 1 loose round of 6.8mm Remington SPC
+    class CBA_68SPC_2rnds {};      // 2 loose rounds of 6.8mm Remington SPC
+    class CBA_68SPC_3rnds {};      // 3 loose rounds of 6.8mm Remington SPC
+    class CBA_68SPC_4rnds {};      // 4 loose rounds of 6.8mm Remington SPC
+    class CBA_68SPC_5rnds {};      // 5 loose rounds of 6.8mm Remington SPC
+    class CBA_68SPC_6rnds {};      // 6 loose rounds of 6.8mm Remington SPC
+    class CBA_68SPC_7rnds {};      // 7 loose rounds of 6.8mm Remington SPC
+    class CBA_68SPC_8rnds {};      // 8 loose rounds of 6.8mm Remington SPC
+    class CBA_68SPC_9rnds {};      // 9 loose rounds of 6.8mm Remington SPC
+    class CBA_68SPC_10rnds {};     // 10 loose rounds of 6.8mm Remington SPC
+
     class CBA_68SPC_STANAG {};          // 6.8 SPC in a normal length STANAG mag, including small drums
     class CBA_68SPC_STANAG_L {};        // 6.8 SPC in a long STANAG stick or coffin
     class CBA_68SPC_STANAG_XL {};       // 6.8 SPC in an extra long STANAG stick or coffin mag

--- a/addons/jam/magwells_75x54mmFrench.hpp
+++ b/addons/jam/magwells_75x54mmFrench.hpp
@@ -1,1 +1,12 @@
+    class CBA_75x54_1rnd {};       // 1 loose round of 7.5x54mm French
+    class CBA_75x54_2rnds {};      // 2 loose rounds of 7.5x54mm French
+    class CBA_75x54_3rnds {};      // 3 loose rounds of 7.5x54mm French
+    class CBA_75x54_4rnds {};      // 4 loose rounds of 7.5x54mm French
+    class CBA_75x54_5rnds {};      // 5 loose rounds of 7.5x54mm French
+    class CBA_75x54_6rnds {};      // 6 loose rounds of 7.5x54mm French
+    class CBA_75x54_7rnds {};      // 7 loose rounds of 7.5x54mm French
+    class CBA_75x54_8rnds {};      // 8 loose rounds of 7.5x54mm French
+    class CBA_75x54_9rnds {};      // 9 loose rounds of 7.5x54mm French
+    class CBA_75x54_10rnds {};     // 10 loose rounds of 7.5x54mm French
+
     class CBA_75x54mmFrench_MAS36 {};          // MAS 36

--- a/addons/jam/magwells_75x55.hpp
+++ b/addons/jam/magwells_75x55.hpp
@@ -1,1 +1,12 @@
+    class CBA_75x55_1rnd {};       // 1 loose round of 7.5x55mm Swiss
+    class CBA_75x55_2rnds {};      // 2 loose rounds of 7.5x55mm Swiss
+    class CBA_75x55_3rnds {};      // 3 loose rounds of 7.5x55mm Swiss
+    class CBA_75x55_4rnds {};      // 4 loose rounds of 7.5x55mm Swiss
+    class CBA_75x55_5rnds {};      // 5 loose rounds of 7.5x55mm Swiss
+    class CBA_75x55_6rnds {};      // 6 loose rounds of 7.5x55mm Swiss
+    class CBA_75x55_7rnds {};      // 7 loose rounds of 7.5x55mm Swiss
+    class CBA_75x55_8rnds {};      // 8 loose rounds of 7.5x55mm Swiss
+    class CBA_75x55_9rnds {};      // 9 loose rounds of 7.5x55mm Swiss
+    class CBA_75x55_10rnds {};     // 10 loose rounds of 7.5x55mm Swiss
+
     class CBA_75x55_STGW57 {};      // SIG SG 510-1, Stgw. 57

--- a/addons/jam/magwells_762x25.hpp
+++ b/addons/jam/magwells_762x25.hpp
@@ -1,3 +1,14 @@
+    class CBA_762x25_1rnd {};       // 1 loose round of 7.62x25mm
+    class CBA_762x25_2rnds {};      // 2 loose rounds of 7.62x25mm
+    class CBA_762x25_3rnds {};      // 3 loose rounds of 7.62x25mm
+    class CBA_762x25_4rnds {};      // 4 loose rounds of 7.62x25mm
+    class CBA_762x25_5rnds {};      // 5 loose rounds of 7.62x25mm
+    class CBA_762x25_6rnds {};      // 6 loose rounds of 7.62x25mm
+    class CBA_762x25_7rnds {};      // 7 loose rounds of 7.62x25mm
+    class CBA_762x25_8rnds {};      // 8 loose rounds of 7.62x25mm
+    class CBA_762x25_9rnds {};      // 9 loose rounds of 7.62x25mm
+    class CBA_762x25_10rnds {};     // 10 loose rounds of 7.62x25mm
+
     class CBA_762x25_CZ52 {};       // CZ 52, vz. 52, CZ 482
     class CBA_762x25_Ots27 {};      // OTs-27 Berdysh
     class CBA_762x25_PM63 {};       // FB PM-63 RAK

--- a/addons/jam/magwells_762x38R.hpp
+++ b/addons/jam/magwells_762x38R.hpp
@@ -1,1 +1,12 @@
+    class CBA_762x38R_1rnd {};       // 1 loose round of 7.62x38mmR
+    class CBA_762x38R_2rnds {};      // 2 loose rounds of 7.62x38mmR
+    class CBA_762x38R_3rnds {};      // 3 loose rounds of 7.62x38mmR
+    class CBA_762x38R_4rnds {};      // 4 loose rounds of 7.62x38mmR
+    class CBA_762x38R_5rnds {};      // 5 loose rounds of 7.62x38mmR
+    class CBA_762x38R_6rnds {};      // 6 loose rounds of 7.62x38mmR
+    class CBA_762x38R_7rnds {};      // 7 loose rounds of 7.62x38mmR
+    class CBA_762x38R_8rnds {};      // 8 loose rounds of 7.62x38mmR
+    class CBA_762x38R_9rnds {};      // 9 loose rounds of 7.62x38mmR
+    class CBA_762x38R_10rnds {};     // 10 loose rounds of 7.62x38mmR
+
     class CBA_762x38R_Nagant {};    // Nagant M1895 Revolver

--- a/addons/jam/magwells_762x39.hpp
+++ b/addons/jam/magwells_762x39.hpp
@@ -1,3 +1,14 @@
+    class CBA_762x39_1rnd {};       // 1 loose round of 7.62x39mm
+    class CBA_762x39_2rnds {};      // 2 loose rounds of 7.62x39mm
+    class CBA_762x39_3rnds {};      // 3 loose rounds of 7.62x39mm
+    class CBA_762x39_4rnds {};      // 4 loose rounds of 7.62x39mm
+    class CBA_762x39_5rnds {};      // 5 loose rounds of 7.62x39mm
+    class CBA_762x39_6rnds {};      // 6 loose rounds of 7.62x39mm
+    class CBA_762x39_7rnds {};      // 7 loose rounds of 7.62x39mm
+    class CBA_762x39_8rnds {};      // 8 loose rounds of 7.62x39mm
+    class CBA_762x39_9rnds {};      // 9 loose rounds of 7.62x39mm
+    class CBA_762x39_10rnds {};     // 10 loose rounds of 7.62x39mm
+
     class CBA_762x39_AK {               // Standard AK-47/AKM magazines
         BI_mags[] = {
             "30Rnd_762x39_Mag_F",

--- a/addons/jam/magwells_762x51.hpp
+++ b/addons/jam/magwells_762x51.hpp
@@ -3,6 +3,11 @@
     class CBA_762x51_3rnds {};      // 3 loose rounds of 7.62x51mm NATO
     class CBA_762x51_4rnds {};      // 4 loose rounds of 7.62x51mm NATO
     class CBA_762x51_5rnds {};      // 5 loose rounds of 7.62x51mm NATO
+    class CBA_762x51_6rnds {};      // 6 loose rounds of 7.62x51mm NATO
+    class CBA_762x51_7rnds {};      // 7 loose rounds of 7.62x51mm NATO
+    class CBA_762x51_8rnds {};      // 8 loose rounds of 7.62x51mm NATO
+    class CBA_762x51_9rnds {};      // 9 loose rounds of 7.62x51mm NATO
+    class CBA_762x51_10rnds {};     // 10 loose rounds of 7.62x51mm NATO
 
     class CBA_762x51_AICS {};       // AICS short action mag (5/10 rounds)
 
@@ -41,7 +46,7 @@
 
     class CBA_762x51_MG3 {};        // MG3 DM1 link belts
 
-    class CBA_762x51_MkI_EMR {      // Mk-I EMR 7.62 mm magazines
+    class CBA_762x51_MkI_EMR {      // Mk-I EMR 7.62mm magazines
         BI_mags[] = {
             "20Rnd_762x51_Mag"
         };

--- a/addons/jam/magwells_762x54.hpp
+++ b/addons/jam/magwells_762x54.hpp
@@ -1,3 +1,14 @@
+    class CBA_762x54R_1rnd {};       // 1 loose round of 7.62x54mmR
+    class CBA_762x54R_2rnds {};      // 2 loose rounds of 7.62x54mmR
+    class CBA_762x54R_3rnds {};      // 3 loose rounds of 7.62x54mmR
+    class CBA_762x54R_4rnds {};      // 4 loose rounds of 7.62x54mmR
+    class CBA_762x54R_5rnds {};      // 5 loose rounds of 7.62x54mmR
+    class CBA_762x54R_6rnds {};      // 6 loose rounds of 7.62x54mmR
+    class CBA_762x54R_7rnds {};      // 7 loose rounds of 7.62x54mmR
+    class CBA_762x54R_8rnds {};      // 8 loose rounds of 7.62x54mmR
+    class CBA_762x54R_9rnds {};      // 9 loose rounds of 7.62x54mmR
+    class CBA_762x54R_10rnds {};     // 10 loose rounds of 7.62x54mmR
+
     class CBA_762x54R_DPM {};           // DP-27, DP-28, DPM, Degtyaryov LMG
     class CBA_762x54R_DT {};            // DT, DTM LMG
 

--- a/addons/jam/magwells_763x25.hpp
+++ b/addons/jam/magwells_763x25.hpp
@@ -1,3 +1,14 @@
+    class CBA_763x25_1rnd {};       // 1 loose round of 7.63x25mm
+    class CBA_763x25_2rnds {};      // 2 loose rounds of 7.63x25mm
+    class CBA_763x25_3rnds {};      // 3 loose rounds of 7.63x25mm
+    class CBA_763x25_4rnds {};      // 4 loose rounds of 7.63x25mm
+    class CBA_763x25_5rnds {};      // 5 loose rounds of 7.63x25mm
+    class CBA_763x25_6rnds {};      // 6 loose rounds of 7.63x25mm
+    class CBA_763x25_7rnds {};      // 7 loose rounds of 7.63x25mm
+    class CBA_763x25_8rnds {};      // 8 loose rounds of 7.63x25mm
+    class CBA_763x25_9rnds {};      // 9 loose rounds of 7.63x25mm
+    class CBA_763x25_10rnds {};     // 10 loose rounds of 7.63x25mm
+
     class CBA_763x25_C96 {};            // Mauser C-96 in 7.63x25mm
     class CBA_763x25_C96_Compact {};    // Compact Mauser C-96 in 7.63x25mm (6 rounds)
     class CBA_763x25_C96_Extended {};   // Extended Mauser C-96 in 7.63x25mm (20 rounds)

--- a/addons/jam/magwells_765x20Longue.hpp
+++ b/addons/jam/magwells_765x20Longue.hpp
@@ -1,1 +1,12 @@
+    class CBA_765x20mmLongue_1rnd {};       // 1 loose round of 7.65x20mm French Longue
+    class CBA_765x20mmLongue_2rnds {};      // 2 loose rounds of 7.65x20mm French Longue
+    class CBA_765x20mmLongue_3rnds {};      // 3 loose rounds of 7.65x20mm French Longue
+    class CBA_765x20mmLongue_4rnds {};      // 4 loose rounds of 7.65x20mm French Longue
+    class CBA_765x20mmLongue_5rnds {};      // 5 loose rounds of 7.65x20mm French Longue
+    class CBA_765x20mmLongue_6rnds {};      // 6 loose rounds of 7.65x20mm French Longue
+    class CBA_765x20mmLongue_7rnds {};      // 7 loose rounds of 7.65x20mm French Longue
+    class CBA_765x20mmLongue_8rnds {};      // 8 loose rounds of 7.65x20mm French Longue
+    class CBA_765x20mmLongue_9rnds {};      // 9 loose rounds of 7.65x20mm French Longue
+    class CBA_765x20mmLongue_10rnds {};     // 10 loose rounds of 7.65x20mm French Longue
+
     class CBA_765x20mmLongue_MAS38 {};          // MAS 38

--- a/addons/jam/magwells_765x21.hpp
+++ b/addons/jam/magwells_765x21.hpp
@@ -1,1 +1,12 @@
+    class CBA_765x21_1rnd {};       // 1 loose round of 7.65x21mm
+    class CBA_765x21_2rnds {};      // 2 loose rounds of 7.65x21mm
+    class CBA_765x21_3rnds {};      // 3 loose rounds of 7.65x21mm
+    class CBA_765x21_4rnds {};      // 4 loose rounds of 7.65x21mm
+    class CBA_765x21_5rnds {};      // 5 loose rounds of 7.65x21mm
+    class CBA_765x21_6rnds {};      // 6 loose rounds of 7.65x21mm
+    class CBA_765x21_7rnds {};      // 7 loose rounds of 7.65x21mm
+    class CBA_765x21_8rnds {};      // 8 loose rounds of 7.65x21mm
+    class CBA_765x21_9rnds {};      // 9 loose rounds of 7.65x21mm
+    class CBA_765x21_10rnds {};     // 10 loose rounds of 7.65x21mm
+
     class CBA_765x21_C96 {};        // Mauser C-96 in 7.65x21mm

--- a/addons/jam/magwells_77x58.hpp
+++ b/addons/jam/magwells_77x58.hpp
@@ -1,3 +1,14 @@
+    class CBA_77x58_1rnd {};       // 1 loose round of 7.7x58mm Arisaka
+    class CBA_77x58_2rnds {};      // 2 loose rounds of 7.7x58mm Arisaka
+    class CBA_77x58_3rnds {};      // 3 loose rounds of 7.7x58mm Arisaka
+    class CBA_77x58_4rnds {};      // 4 loose rounds of 7.7x58mm Arisaka
+    class CBA_77x58_5rnds {};      // 5 loose rounds of 7.7x58mm Arisaka
+    class CBA_77x58_6rnds {};      // 6 loose rounds of 7.7x58mm Arisaka
+    class CBA_77x58_7rnds {};      // 7 loose rounds of 7.7x58mm Arisaka
+    class CBA_77x58_8rnds {};      // 8 loose rounds of 7.7x58mm Arisaka
+    class CBA_77x58_9rnds {};      // 9 loose rounds of 7.7x58mm Arisaka
+    class CBA_77x58_10rnds {};     // 10 loose rounds of 7.7x58mm Arisaka
+
     class CBA_77x58_Arisaka {};     // Japanese Type 99 Arisaka
     class CBA_77x58_Type92 {};      // Japanese Type 92 HMG
     class CBA_77x58_Type99 {};      // Japanese Type 99 LMG

--- a/addons/jam/magwells_792x107mmDS.hpp
+++ b/addons/jam/magwells_792x107mmDS.hpp
@@ -1,1 +1,12 @@
+    class CBA_792x107mm_1rnd {};       // 1 loose round of 7.92x107mm
+    class CBA_792x107mm_2rnds {};      // 2 loose rounds of 7.92x107mm
+    class CBA_792x107mm_3rnds {};      // 3 loose rounds of 7.92x107mm
+    class CBA_792x107mm_4rnds {};      // 4 loose rounds of 7.92x107mm
+    class CBA_792x107mm_5rnds {};      // 5 loose rounds of 7.92x107mm
+    class CBA_792x107mm_6rnds {};      // 6 loose rounds of 7.92x107mm
+    class CBA_792x107mm_7rnds {};      // 7 loose rounds of 7.92x107mm
+    class CBA_792x107mm_8rnds {};      // 8 loose rounds of 7.92x107mm
+    class CBA_792x107mm_9rnds {};      // 9 loose rounds of 7.92x107mm
+    class CBA_792x107mm_10rnds {};     // 10 loose rounds of 7.92x107mm
+
     class CBA_792x107mmDS_wz35 {};      // wz.35

--- a/addons/jam/magwells_792x33.hpp
+++ b/addons/jam/magwells_792x33.hpp
@@ -1,1 +1,12 @@
+    class CBA_792x33_1rnd {};       // 1 loose round of 7.92x33mm
+    class CBA_792x33_2rnds {};      // 2 loose rounds of 7.92x33mm
+    class CBA_792x33_3rnds {};      // 3 loose rounds of 7.92x33mm
+    class CBA_792x33_4rnds {};      // 4 loose rounds of 7.92x33mm
+    class CBA_792x33_5rnds {};      // 5 loose rounds of 7.92x33mm
+    class CBA_792x33_6rnds {};      // 6 loose rounds of 7.92x33mm
+    class CBA_792x33_7rnds {};      // 7 loose rounds of 7.92x33mm
+    class CBA_792x33_8rnds {};      // 8 loose rounds of 7.92x33mm
+    class CBA_792x33_9rnds {};      // 9 loose rounds of 7.92x33mm
+    class CBA_792x33_10rnds {};     // 10 loose rounds of 7.92x33mm
+
     class CBA_792x33_StG {};        // StG44

--- a/addons/jam/magwells_792x57.hpp
+++ b/addons/jam/magwells_792x57.hpp
@@ -1,3 +1,14 @@
+    class CBA_792x57_1rnd {};       // 1 loose round of 7.92x57mm
+    class CBA_792x57_2rnds {};      // 2 loose rounds of 7.92x57mm
+    class CBA_792x57_3rnds {};      // 3 loose rounds of 7.92x57mm
+    class CBA_792x57_4rnds {};      // 4 loose rounds of 7.92x57mm
+    class CBA_792x57_5rnds {};      // 5 loose rounds of 7.92x57mm
+    class CBA_792x57_6rnds {};      // 6 loose rounds of 7.92x57mm
+    class CBA_792x57_7rnds {};      // 7 loose rounds of 7.92x57mm
+    class CBA_792x57_8rnds {};      // 8 loose rounds of 7.92x57mm
+    class CBA_792x57_9rnds {};      // 9 loose rounds of 7.92x57mm
+    class CBA_792x57_10rnds {};     // 10 loose rounds of 7.92x57mm
+
     class CBA_792x57_FG42 {};       // FG42
     class CBA_792x57_G41 {};        // G41
     class CBA_792x57_G43 {};        // G43

--- a/addons/jam/magwells_8x22.hpp
+++ b/addons/jam/magwells_8x22.hpp
@@ -1,3 +1,14 @@
+    class CBA_8x22_1rnd {};       // 1 loose round of 8x22mm
+    class CBA_8x22_2rnds {};      // 2 loose rounds of 8x22mm
+    class CBA_8x22_3rnds {};      // 3 loose rounds of 8x22mm
+    class CBA_8x22_4rnds {};      // 4 loose rounds of 8x22mm
+    class CBA_8x22_5rnds {};      // 5 loose rounds of 8x22mm
+    class CBA_8x22_6rnds {};      // 6 loose rounds of 8x22mm
+    class CBA_8x22_7rnds {};      // 7 loose rounds of 8x22mm
+    class CBA_8x22_8rnds {};      // 8 loose rounds of 8x22mm
+    class CBA_8x22_9rnds {};      // 9 loose rounds of 8x22mm
+    class CBA_8x22_10rnds {};     // 10 loose rounds of 8x22mm
+
     class CBA_8x22_Type100 {};      // Japanese Type 100 SMG
     class CBA_8x22_Type14 {};       // Japanese Type 14 Nambu
     class CBA_8x22_TypeB {};        // Japanese Type B Nambu

--- a/addons/jam/magwells_8x50mmR_Mannlicher.hpp
+++ b/addons/jam/magwells_8x50mmR_Mannlicher.hpp
@@ -1,1 +1,12 @@
+    class CBA_8x50mmR_1rnd {};       // 1 loose round of 8x50mmR
+    class CBA_8x50mmR_2rnds {};      // 2 loose rounds of 8x50mmR
+    class CBA_8x50mmR_3rnds {};      // 3 loose rounds of 8x50mmR
+    class CBA_8x50mmR_4rnds {};      // 4 loose rounds of 8x50mmR
+    class CBA_8x50mmR_5rnds {};      // 5 loose rounds of 8x50mmR
+    class CBA_8x50mmR_6rnds {};      // 6 loose rounds of 8x50mmR
+    class CBA_8x50mmR_7rnds {};      // 7 loose rounds of 8x50mmR
+    class CBA_8x50mmR_8rnds {};      // 8 loose rounds of 8x50mmR
+    class CBA_8x50mmR_9rnds {};      // 9 loose rounds of 8x50mmR
+    class CBA_8x50mmR_10rnds {};     // 10 loose rounds of 8x50mmR
+
     class CBA_8x50mmR_Mannlicher_M1895 {};          // Mannlicher M1895

--- a/addons/jam/magwells_8x56mmR.hpp
+++ b/addons/jam/magwells_8x56mmR.hpp
@@ -1,1 +1,12 @@
+    class CBA_8x56mmR_1rnd {};       // 1 loose round of 8x56mmR
+    class CBA_8x56mmR_2rnds {};      // 2 loose rounds of 8x56mmR
+    class CBA_8x56mmR_3rnds {};      // 3 loose rounds of 8x56mmR
+    class CBA_8x56mmR_4rnds {};      // 4 loose rounds of 8x56mmR
+    class CBA_8x56mmR_5rnds {};      // 5 loose rounds of 8x56mmR
+    class CBA_8x56mmR_6rnds {};      // 6 loose rounds of 8x56mmR
+    class CBA_8x56mmR_7rnds {};      // 7 loose rounds of 8x56mmR
+    class CBA_8x56mmR_8rnds {};      // 8 loose rounds of 8x56mmR
+    class CBA_8x56mmR_9rnds {};      // 9 loose rounds of 8x56mmR
+    class CBA_8x56mmR_10rnds {};     // 10 loose rounds of 8x56mmR
+
     class CBA_8x56mmR_Solothurn_31M {};       // Solothurn 31.M Golyoszoro

--- a/addons/jam/magwells_93x64.hpp
+++ b/addons/jam/magwells_93x64.hpp
@@ -1,5 +1,16 @@
-class CBA_93x64_LINKS {
-    BI_mags[] = {
-        "150Rnd_93x64_Mag"
+    class CBA_93x64_1rnd {};       // 1 loose round of 9.3x64mm
+    class CBA_93x64_2rnds {};      // 2 loose rounds of 9.3x64mm
+    class CBA_93x64_3rnds {};      // 3 loose rounds of 9.3x64mm
+    class CBA_93x64_4rnds {};      // 4 loose rounds of 9.3x64mm
+    class CBA_93x64_5rnds {};      // 5 loose rounds of 9.3x64mm
+    class CBA_93x64_6rnds {};      // 6 loose rounds of 9.3x64mm
+    class CBA_93x64_7rnds {};      // 7 loose rounds of 9.3x64mm
+    class CBA_93x64_8rnds {};      // 8 loose rounds of 9.3x64mm
+    class CBA_93x64_9rnds {};      // 9 loose rounds of 9.3x64mm
+    class CBA_93x64_10rnds {};     // 10 loose rounds of 9.3x64mm
+
+    class CBA_93x64_LINKS {
+        BI_mags[] = {
+            "150Rnd_93x64_Mag"
+        };
     };
-};

--- a/addons/jam/magwells_9x18.hpp
+++ b/addons/jam/magwells_9x18.hpp
@@ -1,3 +1,14 @@
+    class CBA_9x18_1rnd {};       // 1 loose round of 9x18mm
+    class CBA_9x18_2rnds {};      // 2 loose rounds of 9x18mm
+    class CBA_9x18_3rnds {};      // 3 loose rounds of 9x18mm
+    class CBA_9x18_4rnds {};      // 4 loose rounds of 9x18mm
+    class CBA_9x18_5rnds {};      // 5 loose rounds of 9x18mm
+    class CBA_9x18_6rnds {};      // 6 loose rounds of 9x18mm
+    class CBA_9x18_7rnds {};      // 7 loose rounds of 9x18mm
+    class CBA_9x18_8rnds {};      // 8 loose rounds of 9x18mm
+    class CBA_9x18_9rnds {};      // 9 loose rounds of 9x18mm
+    class CBA_9x18_10rnds {};     // 10 loose rounds of 9x18mm
+
     class CBA_9x18_APS {};      // Stechkin automatic pistol (APS)
     class CBA_9x18_CZ82 {};     // CZ 82, CZ 83
     class CBA_9x18_Fort12 {};   // Fort-12

--- a/addons/jam/magwells_9x19.hpp
+++ b/addons/jam/magwells_9x19.hpp
@@ -1,3 +1,14 @@
+    class CBA_9x19_1rnd {};       // 1 loose round of 9x19mm Parabellum
+    class CBA_9x19_2rnds {};      // 2 loose rounds of 9x19mm Parabellum
+    class CBA_9x19_3rnds {};      // 3 loose rounds of 9x19mm Parabellum
+    class CBA_9x19_4rnds {};      // 4 loose rounds of 9x19mm Parabellum
+    class CBA_9x19_5rnds {};      // 5 loose rounds of 9x19mm Parabellum
+    class CBA_9x19_6rnds {};      // 6 loose rounds of 9x19mm Parabellum
+    class CBA_9x19_7rnds {};      // 7 loose rounds of 9x19mm Parabellum
+    class CBA_9x19_8rnds {};      // 8 loose rounds of 9x19mm Parabellum
+    class CBA_9x19_9rnds {};      // 9 loose rounds of 9x19mm Parabellum
+    class CBA_9x19_10rnds {};     // 10 loose rounds of 9x19mm Parabellum
+
     class CBA_9x19_C96 {};          // Mauser C-96 in 9x19mm
     class CBA_9x19_CZ2075 {};       // Subcompact CZ 2075 in 9x19mm
     class CBA_9x19_CZ75_Cpct {};    // Compact CZ 75, CZ 85 in 9x19mm

--- a/addons/jam/magwells_9x21.hpp
+++ b/addons/jam/magwells_9x21.hpp
@@ -1,1 +1,12 @@
+    class CBA_9x21_1rnd {};       // 1 loose round of 9x21mm
+    class CBA_9x21_2rnds {};      // 2 loose rounds of 9x21mm
+    class CBA_9x21_3rnds {};      // 3 loose rounds of 9x21mm
+    class CBA_9x21_4rnds {};      // 4 loose rounds of 9x21mm
+    class CBA_9x21_5rnds {};      // 5 loose rounds of 9x21mm
+    class CBA_9x21_6rnds {};      // 6 loose rounds of 9x21mm
+    class CBA_9x21_7rnds {};      // 7 loose rounds of 9x21mm
+    class CBA_9x21_8rnds {};      // 8 loose rounds of 9x21mm
+    class CBA_9x21_9rnds {};      // 9 loose rounds of 9x21mm
+    class CBA_9x21_10rnds {};     // 10 loose rounds of 9x21mm
+
     class CBA_9x21_SR1M {};       // 6P53/SR1M pistol

--- a/addons/jam/magwells_9x39.hpp
+++ b/addons/jam/magwells_9x39.hpp
@@ -1,1 +1,12 @@
+    class CBA_9x39_1rnd {};       // 1 loose round of 9x39mm
+    class CBA_9x39_2rnds {};      // 2 loose rounds of 9x39mm
+    class CBA_9x39_3rnds {};      // 3 loose rounds of 9x39mm
+    class CBA_9x39_4rnds {};      // 4 loose rounds of 9x39mm
+    class CBA_9x39_5rnds {};      // 5 loose rounds of 9x39mm
+    class CBA_9x39_6rnds {};      // 6 loose rounds of 9x39mm
+    class CBA_9x39_7rnds {};      // 7 loose rounds of 9x39mm
+    class CBA_9x39_8rnds {};      // 8 loose rounds of 9x39mm
+    class CBA_9x39_9rnds {};      // 9 loose rounds of 9x39mm
+    class CBA_9x39_10rnds {};     // 10 loose rounds of 9x39mm
+
     class CBA_9x39_VSS {};          // Vintorez, Val


### PR DESCRIPTION
**When merged this pull request will:**
- Add "magwells" for loose ammunition, that isn't contained in magazines or clips.
- These exist already in limited form for a couple calibres (such as `CBA_357_6rnds`), this just expands it to all current small arms in JAM.