### PR TITLE
pid - Add PID controller and associated utility functions

### DIFF
--- a/addons/pid/$PBOPREFIX$
+++ b/addons/pid/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\cba\addons\pid

--- a/addons/pid/CfgEventHandlers.hpp
+++ b/addons/pid/CfgEventHandlers.hpp
@@ -1,0 +1,11 @@
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_preStart));
+    };
+};
+
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_preInit));
+    };
+};

--- a/addons/pid/XEH_PREP.hpp
+++ b/addons/pid/XEH_PREP.hpp
@@ -1,0 +1,7 @@
+PREP(create);
+PREP(error_degree);
+PREP(error_linear);
+PREP(reset);
+PREP(setGains);
+PREP(setpoint);
+PREP(update);

--- a/addons/pid/XEH_preInit.sqf
+++ b/addons/pid/XEH_preInit.sqf
@@ -1,0 +1,7 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+#include "XEH_PREP.hpp"
+
+ADDON = true;

--- a/addons/pid/XEH_preStart.sqf
+++ b/addons/pid/XEH_preStart.sqf
@@ -1,0 +1,3 @@
+#include "script_component.hpp"
+
+#include "XEH_PREP.hpp"

--- a/addons/pid/config.cpp
+++ b/addons/pid/config.cpp
@@ -1,0 +1,17 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = CSTRING(component);
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"cba_common"};
+        author = "$STR_CBA_Author";
+        authors[] = {"tcvm"};
+        url = "$STR_CBA_URL";
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgEventHandlers.hpp"

--- a/addons/pid/fnc_create.sqf
+++ b/addons/pid/fnc_create.sqf
@@ -28,7 +28,7 @@ Returns:
 
 Examples:
     (begin example)
-        private _pid = [1, 0.05, 0.2, 5, CBA_pid_fnc_error_linear, 0, 10, 15] call CBA_pid_fnc_create;
+        private _pid = [1, 0.05, 0.2, 5, 0, 10, 15, CBA_pid_fnc_error_linear] call CBA_pid_fnc_create;
     (end)
 
 Author:

--- a/addons/pid/fnc_create.sqf
+++ b/addons/pid/fnc_create.sqf
@@ -7,13 +7,21 @@ Description:
 
 Parameters:
     _pGain          - gain for the immediate error <NUMBER>
+                      (Default: 0)
     _iGain          - gain for the persistent error over time <NUMBER>
+                      (Default: 0)
     _dGain          - gain for the error rate over time <NUMBER>
+                      (Default: 0)
     _setpoint       - initial setpoint for the controller <NUMBER>
+                      (Default: 0)
     _errorFunction  - the function which calculates the error which the controller operators <CODE>
+                      (Default: <CBA_pid_fnc_error_linear>)
     _min            - the minimum value the controller can return <NUMBER>
+                      (Default: -1e99)
     _max            - the maximum value the controller can return <NUMBER>
+                      (Default: 1e99)
     _historyLength  - how many past errors are stored and used to calculate the derivative/integral <NUMBER>
+                      (Default: 10)
 
 Returns:
     _pid            - a PID controller <LOCATION>
@@ -32,10 +40,10 @@ params [
     ["_iGain", 0, [0]],
     ["_dGain", 0, [0]],
     ["_setpoint", 0, [0]],
-    ["_errorFunction", FUNC(error_linear), [{0}]],
+    ["_errorFunction", FUNC(error_linear), [{}]],
     ["_min", -1e99, [0]],
     ["_max",  1e99, [0]],
-    ["_historyLength", 3, [0]],
+    ["_historyLength", 10, [0]],
 ];
 
 private _pid = call CBA_fnc_createNamespace;

--- a/addons/pid/fnc_create.sqf
+++ b/addons/pid/fnc_create.sqf
@@ -41,9 +41,9 @@ params [
     ["_dGain", 0, [0]],
     ["_setpoint", 0, [0]],
     ["_errorFunction", FUNC(error_linear), [{}]],
-    ["_min", -1e38, [0]],
-    ["_max",  1e38, [0]],
-    ["_historyLength", 10, [0]]
+    ["_min", -LARGE_NUMBER, [0]],
+    ["_max",  LARGE_NUMBER, [0]],
+    ["_historyLength", DEFAULT_HISTORY_LENGTH, [0]]
 ];
 
 private _pid = call CBA_fnc_createNamespace;

--- a/addons/pid/fnc_create.sqf
+++ b/addons/pid/fnc_create.sqf
@@ -42,8 +42,8 @@ params [
     ["_setpoint", 0, [0]],
     ["_min", -LARGE_NUMBER, [0]],
     ["_max",  LARGE_NUMBER, [0]],
-    ["_errorFunction", FUNC(error_linear), [{}]],
-    ["_historyLength", DEFAULT_HISTORY_LENGTH, [0]]
+    ["_historyLength", DEFAULT_HISTORY_LENGTH, [0]],
+    ["_errorFunction", FUNC(error_linear), [{}]]
 ];
 
 private _pid = call CBA_fnc_createNamespace;

--- a/addons/pid/fnc_create.sqf
+++ b/addons/pid/fnc_create.sqf
@@ -34,7 +34,7 @@ params [
     ["_setpoint", 0, [0]],
     ["_errorFunction", FUNC(error_linear), [{0}]],
     ["_min", -1e99, [0]],
-    ["_max", -1e99, [0]],
+    ["_max",  1e99, [0]],
     ["_historyLength", 3, [0]],
 ];
 

--- a/addons/pid/fnc_create.sqf
+++ b/addons/pid/fnc_create.sqf
@@ -1,0 +1,49 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: CBA_pid_fnc_create
+
+Description:
+    Creates a PID controller.
+
+Parameters:
+    _pGain          - gain for the immediate error <NUMBER>
+    _iGain          - gain for the persistent error over time <NUMBER>
+    _dGain          - gain for the error rate over time <NUMBER>
+    _setpoint       - initial setpoint for the controller <NUMBER>
+    _errorFunction  - the function which calculates the error which the controller operators <CODE>
+    _min            - the minimum value the controller can return <NUMBER>
+    _max            - the maximum value the controller can return <NUMBER>
+    _historyLength  - how many past errors are stored and used to calculate the derivative/integral <NUMBER>
+
+Returns:
+    _pid            - a PID controller <LOCATION>
+
+Examples:
+    (begin example)
+        private _pid = [1, 0.05, 0.2, 5, CBA_pid_fnc_error_linear, 0, 10, 15] call CBA_pid_fnc_create;
+    (end)
+
+Author:
+    tcvm
+---------------------------------------------------------------------------- */
+SCRIPT(create);
+params [
+    ["_pGain", 0, [0]],
+    ["_iGain", 0, [0]],
+    ["_dGain", 0, [0]],
+    ["_setpoint", 0, [0]],
+    ["_errorFunction", FUNC(error_linear), [{0}]],
+    ["_min", -1e99, [0]],
+    ["_max", -1e99, [0]],
+    ["_historyLength", 3, [0]],
+];
+
+private _pid = call CBA_fnc_createNamespace;
+_pid setVariable [QGVAR(gains), [_pGain, _iGain, _dGain]];
+_pid setVariable [QGVAR(bounds), [_min, _max]];
+_pid setVariable [QGVAR(history), []];
+_pid setVariable [QGVAR(historyLength), _historyLength];
+_pid setVariable [QGVAR(setpoint), _setpoint];
+_pid setVariable [QGVAR(errorFunction), _errorFunction];
+
+_pid

--- a/addons/pid/fnc_create.sqf
+++ b/addons/pid/fnc_create.sqf
@@ -43,7 +43,7 @@ params [
     ["_errorFunction", FUNC(error_linear), [{}]],
     ["_min", -1e99, [0]],
     ["_max",  1e99, [0]],
-    ["_historyLength", 10, [0]],
+    ["_historyLength", 10, [0]]
 ];
 
 private _pid = call CBA_fnc_createNamespace;

--- a/addons/pid/fnc_create.sqf
+++ b/addons/pid/fnc_create.sqf
@@ -14,12 +14,12 @@ Parameters:
                       (Default: 0)
     _setpoint       - initial setpoint for the controller <NUMBER>
                       (Default: 0)
+    _min            - the minimum value the controller can return <NUMBER>
+                      (Default: -1e30)
+    _max            - the maximum value the controller can return <NUMBER>
+                      (Default: 1e30)
     _errorFunction  - the function which calculates the error which the controller operators <CODE>
                       (Default: <CBA_pid_fnc_error_linear>)
-    _min            - the minimum value the controller can return <NUMBER>
-                      (Default: -1e99)
-    _max            - the maximum value the controller can return <NUMBER>
-                      (Default: 1e99)
     _historyLength  - how many past errors are stored and used to calculate the derivative/integral <NUMBER>
                       (Default: 10)
 
@@ -40,9 +40,9 @@ params [
     ["_iGain", 0, [0]],
     ["_dGain", 0, [0]],
     ["_setpoint", 0, [0]],
-    ["_errorFunction", FUNC(error_linear), [{}]],
     ["_min", -LARGE_NUMBER, [0]],
     ["_max",  LARGE_NUMBER, [0]],
+    ["_errorFunction", FUNC(error_linear), [{}]],
     ["_historyLength", DEFAULT_HISTORY_LENGTH, [0]]
 ];
 

--- a/addons/pid/fnc_create.sqf
+++ b/addons/pid/fnc_create.sqf
@@ -41,8 +41,8 @@ params [
     ["_dGain", 0, [0]],
     ["_setpoint", 0, [0]],
     ["_errorFunction", FUNC(error_linear), [{}]],
-    ["_min", -1e99, [0]],
-    ["_max",  1e99, [0]],
+    ["_min", -1e38, [0]],
+    ["_max",  1e38, [0]],
     ["_historyLength", 10, [0]]
 ];
 

--- a/addons/pid/fnc_create.sqf
+++ b/addons/pid/fnc_create.sqf
@@ -18,10 +18,10 @@ Parameters:
                       (Default: -1e30)
     _max            - the maximum value the controller can return <NUMBER>
                       (Default: 1e30)
-    _errorFunction  - the function which calculates the error which the controller operators <CODE>
-                      (Default: <CBA_pid_fnc_error_linear>)
     _historyLength  - how many past errors are stored and used to calculate the derivative/integral <NUMBER>
                       (Default: 10)
+    _errorFunction  - the function which calculates the error which the controller operators <CODE>
+                      (Default: <CBA_pid_fnc_error_linear>)
 
 Returns:
     _pid            - a PID controller <LOCATION>

--- a/addons/pid/fnc_error_degree.sqf
+++ b/addons/pid/fnc_error_degree.sqf
@@ -1,0 +1,39 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: CBA_pid_fnc_error_degree
+
+Description:
+    Error function that is adjusted for degree values.
+    This function will account for wraparound with values in the domain of [-180, 180] or [0, 360]
+
+Parameters:
+    _observed           - the observed value <NUMBER>
+    _setpoint           - the setpoint <NUMBER>
+
+Returns:
+    Wrapped error of `setpoint - observed` <NUMBER>
+
+Examples:
+    (begin example)
+        private _error = [350, 5] call CBA_pid_fnc_error_degree;
+        // _error == 15
+    (end)
+
+Author:
+    tcvm
+---------------------------------------------------------------------------- */
+SCRIPT(error_degree);
+params [
+    ["_observed", 0, [0]],
+    ["_setpoint", 0, [0]],
+];
+
+private _absoluteError =_setpoint - _observed;
+private _error = _absoluteError;
+if (_absoluteError < -180) then {
+    _error = 360 + _absoluteError;
+};
+if (_absoluteError > 180) then {
+    _error = _absoluteError - 360;
+};
+_error

--- a/addons/pid/fnc_error_degree.sqf
+++ b/addons/pid/fnc_error_degree.sqf
@@ -25,7 +25,7 @@ Author:
 SCRIPT(error_degree);
 params [
     ["_observed", 0, [0]],
-    ["_setpoint", 0, [0]],
+    ["_setpoint", 0, [0]]
 ];
 
 private _absoluteError =_setpoint - _observed;

--- a/addons/pid/fnc_error_degree.sqf
+++ b/addons/pid/fnc_error_degree.sqf
@@ -28,7 +28,7 @@ params [
     ["_setpoint", 0, [0]]
 ];
 
-private _absoluteError =_setpoint - _observed;
+private _absoluteError = _setpoint - _observed;
 private _error = _absoluteError;
 if (_absoluteError < -180) then {
     _error = 360 + _absoluteError;

--- a/addons/pid/fnc_error_linear.sqf
+++ b/addons/pid/fnc_error_linear.sqf
@@ -24,7 +24,7 @@ Author:
 SCRIPT(error_linear);
 params [
     ["_observed", 0, [0]],
-    ["_setpoint", 0, [0]],
+    ["_setpoint", 0, [0]]
 ];
 
 _setpoint - _observed

--- a/addons/pid/fnc_error_linear.sqf
+++ b/addons/pid/fnc_error_linear.sqf
@@ -15,6 +15,7 @@ Returns:
 Examples:
     (begin example)
         private _error = [2, 5] call CBA_pid_fnc_error_linear;
+        // _error == 3
     (end)
 
 Author:

--- a/addons/pid/fnc_error_linear.sqf
+++ b/addons/pid/fnc_error_linear.sqf
@@ -1,0 +1,29 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: CBA_pid_fnc_error_linear
+
+Description:
+    Linear error function.
+
+Parameters:
+    _observed           - the observed value <NUMBER>
+    _setpoint           - the setpoint <NUMBER>
+
+Returns:
+    Error of `setpoint - observed` <NUMBER>
+
+Examples:
+    (begin example)
+        private _error = [2, 5] call CBA_pid_fnc_error_linear;
+    (end)
+
+Author:
+    tcvm
+---------------------------------------------------------------------------- */
+SCRIPT(error_linear);
+params [
+    ["_observed", 0, [0]],
+    ["_setpoint", 0, [0]],
+];
+
+_setpoint - _observed

--- a/addons/pid/fnc_reset.sqf
+++ b/addons/pid/fnc_reset.sqf
@@ -1,0 +1,29 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: CBA_pid_fnc_reset
+
+Description:
+    Reset a PID controller's history.
+
+Parameters:
+    _pid           - the controller <LOCATION>
+
+Returns:
+    Nothing
+
+Examples:
+    (begin example)
+        _pid call CBA_pid_fnc_reset;
+    (end)
+
+Author:
+    tcvm
+---------------------------------------------------------------------------- */
+SCRIPT(reset);
+params [
+    ["_pid", locationNull, [locationNull]],
+];
+
+if (isNull _pid) exitWith {};
+
+_pid setVariable [QGVAR(history), []];

--- a/addons/pid/fnc_reset.sqf
+++ b/addons/pid/fnc_reset.sqf
@@ -21,7 +21,7 @@ Author:
 ---------------------------------------------------------------------------- */
 SCRIPT(reset);
 params [
-    ["_pid", locationNull, [locationNull]],
+    ["_pid", locationNull, [locationNull]]
 ];
 
 if (isNull _pid) exitWith {};

--- a/addons/pid/fnc_setGains.sqf
+++ b/addons/pid/fnc_setGains.sqf
@@ -1,0 +1,50 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: CBA_pid_fnc_setGains
+
+Description:
+    Set new gains for a PID controller.
+
+Parameters:
+    _pid        - a pid controller <LOCATION>
+    _pGain      - the new proportional gain <NUMBER>
+                  OR
+                  `nil`, to keep the current gain <NONE>
+    _iGain      - the new integral gain <NUMBER>
+                  OR
+                  `nil`, to keep the current gain <NONE>
+    _dGain      - the new derivative gain <NUMBER>
+                  OR
+                  `nil`, to keep the current gain <NONE>
+Returns:
+    Nothing
+
+Examples:
+    (begin example)
+        [_pid, 5, nil, 0.2] call CBA_pid_fnc_setGains;
+    (end)
+
+Author:
+    tcvm
+---------------------------------------------------------------------------- */
+SCRIPT(setGains);
+params [
+    ["_pid", locationNull, [locationNull]],
+    ["_pGain", nil, [0, nil]],
+    ["_iGain", nil, [0, nil]],
+    ["_dGain", nil, [0, nil]]
+];
+
+if (isNull _pid) exitWith {};
+
+(_pid getVariable [QGVAR(gains), [0, 0, 0]]) params ["_currentPGain", "_currentIGain", "_currentDGain"];
+if !(isNil "_pGain") then {
+    _currentPGain = _pGain;
+};
+if !(isNil "_iGain") then {
+    _currentIGain = _iGain;
+};
+if !(isNil "_dGain") then {
+    _currentDGain = _dGain;
+};
+_pid setVariable [QGVAR(gains), [_currentPGain, _currentIGain, _currentDGain]];

--- a/addons/pid/fnc_setGains.sqf
+++ b/addons/pid/fnc_setGains.sqf
@@ -7,18 +7,15 @@ Description:
 
 Parameters:
     _pid        - a pid controller <LOCATION>
-    _pGain      - the new proportional gain <NUMBER>
+    _pGain      - the new proportional gain <NUMBER><NIL> (Default: `nil`)
                   OR
-                  `nil`, to keep the current gain <NIL>
-                  (Default: `nil`)
-    _iGain      - the new integral gain <NUMBER>
+                  `nil`, to keep the current gain
+    _iGain      - the new integral gain <NUMBER><NIL> (Default: `nil`)
                   OR
-                  `nil`, to keep the current gain <NIL>
-                  (Default: `nil`)
-    _dGain      - the new derivative gain <NUMBER>
+                  `nil`, to keep the current gain 
+    _dGain      - the new derivative gain <NUMBER><NIL> (Default: `nil`)
                   OR
-                  `nil`, to keep the current gain <NIL>
-                  (Default: `nil`)
+                  `nil`, to keep the current gain
 Returns:
     Nothing
 

--- a/addons/pid/fnc_setGains.sqf
+++ b/addons/pid/fnc_setGains.sqf
@@ -9,13 +9,13 @@ Parameters:
     _pid        - a pid controller <LOCATION>
     _pGain      - the new proportional gain <NUMBER>
                   OR
-                  `nil`, to keep the current gain <NONE>
+                  `nil`, to keep the current gain <NIL>
     _iGain      - the new integral gain <NUMBER>
                   OR
-                  `nil`, to keep the current gain <NONE>
+                  `nil`, to keep the current gain <NIL>
     _dGain      - the new derivative gain <NUMBER>
                   OR
-                  `nil`, to keep the current gain <NONE>
+                  `nil`, to keep the current gain <NIL>
 Returns:
     Nothing
 

--- a/addons/pid/fnc_setGains.sqf
+++ b/addons/pid/fnc_setGains.sqf
@@ -10,12 +10,15 @@ Parameters:
     _pGain      - the new proportional gain <NUMBER>
                   OR
                   `nil`, to keep the current gain <NIL>
+                  (Default: `nil`)
     _iGain      - the new integral gain <NUMBER>
                   OR
                   `nil`, to keep the current gain <NIL>
+                  (Default: `nil`)
     _dGain      - the new derivative gain <NUMBER>
                   OR
                   `nil`, to keep the current gain <NIL>
+                  (Default: `nil`)
 Returns:
     Nothing
 

--- a/addons/pid/fnc_setpoint.sqf
+++ b/addons/pid/fnc_setpoint.sqf
@@ -1,0 +1,32 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: CBA_pid_fnc_setpoint
+
+Description:
+    Set a new setpoint for a PID controller.
+
+Parameters:
+    _pid        - a pid controller <LOCATION>
+    _setpoint   - the new target setpoint for the controller <NUMBER>
+
+Returns:
+    Nothing
+
+Examples:
+    (begin example)
+        [_pid, 42] call CBA_pid_fnc_setpoint;
+    (end)
+
+Author:
+    tcvm
+---------------------------------------------------------------------------- */
+SCRIPT(setpoint);
+params [
+    ["_pid", locationNull, [locationNull]],
+    ["_setpoint", 0, [0]],
+];
+
+if (isNull _pid) exitWith {};
+
+_pid setVariable [QGVAR(setpoint), _setpoint];
+_pid setVariable [QGVAR(history), []];

--- a/addons/pid/fnc_setpoint.sqf
+++ b/addons/pid/fnc_setpoint.sqf
@@ -8,6 +8,7 @@ Description:
 Parameters:
     _pid        - a pid controller <LOCATION>
     _setpoint   - the new target setpoint for the controller <NUMBER>
+    _reset      - if we want to reset the PID for the new setpoint <BOOL> (Default: true)
 
 Returns:
     Nothing
@@ -23,10 +24,13 @@ Author:
 SCRIPT(setpoint);
 params [
     ["_pid", locationNull, [locationNull]],
-    ["_setpoint", 0, [0]]
+    ["_setpoint", 0, [0]],
+    ["_reset", true, [true]],
 ];
 
 if (isNull _pid) exitWith {};
 
 _pid setVariable [QGVAR(setpoint), _setpoint];
-_pid setVariable [QGVAR(history), []];
+if (_reset) then {
+    _pid setVariable [QGVAR(history), []];
+};

--- a/addons/pid/fnc_setpoint.sqf
+++ b/addons/pid/fnc_setpoint.sqf
@@ -23,7 +23,7 @@ Author:
 SCRIPT(setpoint);
 params [
     ["_pid", locationNull, [locationNull]],
-    ["_setpoint", 0, [0]],
+    ["_setpoint", 0, [0]]
 ];
 
 if (isNull _pid) exitWith {};

--- a/addons/pid/fnc_setpoint.sqf
+++ b/addons/pid/fnc_setpoint.sqf
@@ -25,7 +25,7 @@ SCRIPT(setpoint);
 params [
     ["_pid", locationNull, [locationNull]],
     ["_setpoint", 0, [0]],
-    ["_reset", true, [true]],
+    ["_reset", true, [true]]
 ];
 
 if (isNull _pid) exitWith {};

--- a/addons/pid/fnc_update.sqf
+++ b/addons/pid/fnc_update.sqf
@@ -79,16 +79,20 @@ switch (true) do {
 };
 
 private _integral = 0;
+private _error_prev = 0;
 private _tn_prev = 0;
 {
-    if (_forEachIndex == 0) then {
-        _tn_prev = (_x select 0);
-        continue
-    };
     _x params ["_tn", "_error"];
-    private _stride = _tn - _tn_prev;
-    _integral = _integral + (_error * _stride);
+    if (_forEachIndex > 0) then {
+        // Trapezoidal rule for numerical integration
+        // (1 / 2) * (b - a) * (f(a) + f(b))
+        // O(h^2) error
+        private _stride = _tn - _tn_prev;
+        private _sum = _error + _error_prev;
+        _integral = _integral + 0.5 * _stride * _sum;
+    };
     _tn_prev = _tn;
+    _error_prev = _error;
 } forEach _history;
 
 (_pid getVariable [QGVAR(gains), [0, 0, 0]]) params ["_pGain", "_iGain", "_dGain"];

--- a/addons/pid/fnc_update.sqf
+++ b/addons/pid/fnc_update.sqf
@@ -38,8 +38,9 @@ private _maxHistoryLength = _pid getVariable [QGVAR(historyLength), DEFAULT_HIST
 if (_history isNotEqualTo []) then {
     // We need a continuous function, so if two measurements are for the same measured time we ignore the new measurements
     // This also gets rid of any potential divide-by-zero errors due to the stride being 0
+    // The inverse must also be monotonic, so we assume time is always increasing
     (_history select -1) params ["_x"];
-    if (_x != _time) then {
+    if (_time - _x > 0) then {
         _history pushBack [_time, _value];
     };
 } else {

--- a/addons/pid/fnc_update.sqf
+++ b/addons/pid/fnc_update.sqf
@@ -61,7 +61,7 @@ switch (true) do {
         private _stride = (_x1 select 0) - (_x0 select 0);
         if (_stride == 0) then { break };
 
-        _derivative = ((_x0 select 1) - (_x1 select 1)) / _stride;
+        _derivative = ((_x1 select 1) - (_x0 select 1)) / _stride;
     };
     case (count _history >= 3): {
         private _xn0 = _history select -1;

--- a/addons/pid/fnc_update.sqf
+++ b/addons/pid/fnc_update.sqf
@@ -30,7 +30,6 @@ params [
 ];
 
 if (isNull _pid) exitWith { 0 };
-
 private _error = [_value, _pid getVariable [QGVAR(setpoint), 0]] call (_pid getVariable [QGVAR(errorFunction), FUNC(error_linear)]);
 private _history = _pid getVariable [QGVAR(history), []];
 private _maxHistoryLength = _pid getVariable [QGVAR(historyLength), DEFAULT_HISTORY_LENGTH];
@@ -41,10 +40,10 @@ if (_history isNotEqualTo []) then {
     // The inverse must also be monotonic, so we assume time is always increasing
     (_history select -1) params ["_x"];
     if (_time - _x > 0) then {
-        _history pushBack [_time, _value];
+        _history pushBack [_time, _error];
     };
 } else {
-    _history pushBack [_time, _value];
+    _history pushBack [_time, _error];
 };
 
 if (count _history > _maxHistoryLength) then {

--- a/addons/pid/fnc_update.sqf
+++ b/addons/pid/fnc_update.sqf
@@ -56,11 +56,11 @@ switch (true) do {
         private _xn0 = _history select -1;
         private _xn1 = _history select -2;
         private _xn2 = _history select -3;
-        private _h = (_xn0 select 0) - (_xn1 select 0);
-        if (_h == 0) then { break };
+        private _stride = (_xn0 select 0) - (_xn1 select 0);
+        if (_stride == 0) then { break };
 
         private _sum = -3 * (_xn2 select 1) + 4 * (_xn1 select 1) - (_xn0 select 1);
-        _derivative = _sum / (2 * _h);
+        _derivative = _sum / (2 * _stride);
     };
     default {};
 };

--- a/addons/pid/fnc_update.sqf
+++ b/addons/pid/fnc_update.sqf
@@ -66,11 +66,13 @@ switch (true) do {
         private _xn0 = _history select -1;
         private _xn1 = _history select -2;
         private _xn2 = _history select -3;
-        private _stride = (_xn0 select 0) - (_xn1 select 0);
+        private _stride0 = (_xn0 select 0) - (_xn1 select 0);
+        private _stride1 = (_xn1 select 0) - (_xn2 select 0);
+        private _stride = _stride0 + _stride1;
         if (_stride == 0) then { break };
 
         private _sum = -3 * (_xn2 select 1) + 4 * (_xn1 select 1) - (_xn0 select 1);
-        _derivative = _sum / (2 * _stride);
+        _derivative = _sum / _stride;
     };
     default {};
 };

--- a/addons/pid/fnc_update.sqf
+++ b/addons/pid/fnc_update.sqf
@@ -81,7 +81,10 @@ switch (true) do {
 private _integral = 0;
 private _tn_prev = 0;
 {
-    if (_forEachIndex == 0) then { continue };
+    if (_forEachIndex == 0) then {
+        _tn_prev = (_x select 0);
+        continue
+    };
     _x params ["_tn", "_error"];
     private _stride = _tn - _tn_prev;
     _integral = _integral + (_error * _stride);

--- a/addons/pid/fnc_update.sqf
+++ b/addons/pid/fnc_update.sqf
@@ -31,9 +31,9 @@ params [
 
 if (isNull _pid) exitWith {};
 
-private _error = [_value, _pid getVariable [QGVAR(setpoint), 0]] call (_pid getVariable [QGVAR(errorFunction), {0}]);
+private _error = [_value, _pid getVariable [QGVAR(setpoint), 0]] call (_pid getVariable [QGVAR(errorFunction), FUNC(error_linear)]);
 private _history = _pid getVariable [QGVAR(history), []];
-private _maxHistoryLength = _pid getVariable [QGVAR(historyLength), 2];
+private _maxHistoryLength = _pid getVariable [QGVAR(historyLength), DEFAULT_HISTORY_LENGTH];
 
 _history pushBack [_time, _value];
 if (count _history > _maxHistoryLength) then {
@@ -79,6 +79,6 @@ private _tn_prev = 0;
 
 private _delta = _error * _pGain + _integral * _iGain + _derivative * _dGain;
 
-(_pid getVariable [QGVAR(bounds), [-1e38, 1e38]]) params ["_min", "_max"];
+(_pid getVariable [QGVAR(bounds), [-LARGE_NUMBER, LARGE_NUMBER]]) params ["_min", "_max"];
 
 _max min (_delta max _min)

--- a/addons/pid/fnc_update.sqf
+++ b/addons/pid/fnc_update.sqf
@@ -73,7 +73,7 @@ private _tn_prev = 0;
     private _stride = _tn - _tn_prev;
     _integral = _integral + (_error * _stride);
     _tn_prev = _tn;
-} forEach _errorHistory;
+} forEach _history;
 
 (_pid getVariable [QGVAR(gains), [0, 0, 0]]) params ["_pGain", "_iGain", "_dGain"];
 

--- a/addons/pid/fnc_update.sqf
+++ b/addons/pid/fnc_update.sqf
@@ -58,7 +58,7 @@ switch (true) do {
         private _x1 = _history select 1;
 
         private _stride = (_x1 select 0) - (_x0 select 0);
-        if (_stride == 0) then { break };
+        if (_stride == 0) exitWith {};
 
         _derivative = ((_x1 select 1) - (_x0 select 1)) / _stride;
     };
@@ -69,7 +69,7 @@ switch (true) do {
         private _stride0 = (_xn0 select 0) - (_xn1 select 0);
         private _stride1 = (_xn1 select 0) - (_xn2 select 0);
         private _stride = _stride0 + _stride1;
-        if (_stride == 0) then { break };
+        if (_stride == 0) exitWith {};
 
         private _sum = -3 * (_xn2 select 1) + 4 * (_xn1 select 1) - (_xn0 select 1);
         _derivative = _sum / _stride;

--- a/addons/pid/fnc_update.sqf
+++ b/addons/pid/fnc_update.sqf
@@ -79,6 +79,6 @@ private _tn_prev = 0;
 
 private _delta = _error * _pGain + _integral * _iGain + _derivative * _dGain;
 
-(_pid getVariable [QGVAR(bounds), [-1e99, 1e99]]) params ["_min", "_max"];
+(_pid getVariable [QGVAR(bounds), [-1e38, 1e38]]) params ["_min", "_max"];
 
 _max min (_delta max _min)

--- a/addons/pid/fnc_update.sqf
+++ b/addons/pid/fnc_update.sqf
@@ -1,0 +1,84 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: CBA_pid_fnc_update
+
+Description:
+    Updates a PID controller and returns the controller output.
+
+Parameters:
+    _pid    - a pid controller <LOCATION>
+    _value  - the measured value for this update <NUMBER>
+    _time   - the time for which the value was measured <NUMBER>
+              (Default: CBA_missionTime)
+
+Returns:
+    The output of the controller <NUMBER>
+
+Examples:
+    (begin example)
+        private _delta = [_pid, 6, CBA_missionTime] call CBA_pid_fnc_update;
+    (end)
+
+Author:
+    tcvm
+---------------------------------------------------------------------------- */
+SCRIPT(update);
+params [
+    ["_pid", locationNull, [locationNull]],
+    ["_value", 0, [0]],
+    ["_time", CBA_missionTime, [0]]
+];
+
+if (isNull _pid) exitWith {};
+
+private _error = [_value, _pid getVariable [QGVAR(setpoint), 0]] call (_pid getVariable [QGVAR(errorFunction), {0}]);
+private _history = _pid getVariable [QGVAR(history), []];
+private _maxHistoryLength = _pid getVariable [QGVAR(historyLength), 2];
+
+_history pushBack [_time, _value];
+if (count _history > _maxHistoryLength) then {
+    _history deleteAt 0;
+};
+_pid setVariable [QGVAR(history), _history];
+
+private _derivative = 0;
+switch (true) do {
+    case (count _history == 2): {
+        private _x0 = _history select 0;
+        private _x1 = _history select 1;
+
+        private _stride = (_x1 select 0) - (_x0 select 0);
+        if (_stride == 0) then { break };
+
+        _derivative = ((_x0 select 1) - (_x1 select 1)) / _stride;
+    };
+    case (count _history >= 3): {
+        private _xn0 = _history select -1;
+        private _xn1 = _history select -2;
+        private _xn2 = _history select -3;
+        private _h = (_xn0 select 0) - (_xn1 select 0);
+        if (_h == 0) then { break };
+
+        private _sum = -3 * (_xn2 select 1) + 4 * (_xn1 select 1) - (_xn0 select 1);
+        _derivative = _sum / (2 * _h);
+    };
+    default {};
+};
+
+private _integral = 0;
+private _tn_prev = 0;
+{
+    if (_forEachIndex == 0) then { continue };
+    _x params ["_tn", "_error"];
+    private _stride = _tn - _tn_prev;
+    _integral = _integral + (_error * _stride);
+    _tn_prev = _tn;
+} forEach _errorHistory;
+
+(_pid getVariable [QGVAR(gains), [0, 0, 0]]) params ["_pGain", "_iGain", "_dGain"];
+
+private _delta = _error * _pGain + _integral * _iGain + _derivative * _dGain;
+
+(_pid getVariable [QGVAR(bounds), [-1e99, 1e99]]) params ["_min", "_max"];
+
+_max min (_delta max _min)

--- a/addons/pid/fnc_update.sqf
+++ b/addons/pid/fnc_update.sqf
@@ -35,7 +35,17 @@ private _error = [_value, _pid getVariable [QGVAR(setpoint), 0]] call (_pid getV
 private _history = _pid getVariable [QGVAR(history), []];
 private _maxHistoryLength = _pid getVariable [QGVAR(historyLength), DEFAULT_HISTORY_LENGTH];
 
-_history pushBack [_time, _value];
+if (_history isNotEqualTo []) then {
+    // We need a continuous function, so if two measurements are for the same measured time we ignore the new measurements
+    // This also gets rid of any potential divide-by-zero errors due to the stride being 0
+    (_history select -1) params ["_x"];
+    if (_x != _time) then {
+        _history pushBack [_time, _value];
+    };
+} else {
+    _history pushBack [_time, _value];
+};
+
 if (count _history > _maxHistoryLength) then {
     _history deleteAt 0;
 };

--- a/addons/pid/fnc_update.sqf
+++ b/addons/pid/fnc_update.sqf
@@ -29,7 +29,7 @@ params [
     ["_time", CBA_missionTime, [0]]
 ];
 
-if (isNull _pid) exitWith {};
+if (isNull _pid) exitWith { 0 };
 
 private _error = [_value, _pid getVariable [QGVAR(setpoint), 0]] call (_pid getVariable [QGVAR(errorFunction), FUNC(error_linear)]);
 private _history = _pid getVariable [QGVAR(history), []];

--- a/addons/pid/license.txt
+++ b/addons/pid/license.txt
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/addons/pid/script_component.hpp
+++ b/addons/pid/script_component.hpp
@@ -2,14 +2,14 @@
 #include "\x\cba\addons\main\script_mod.hpp"
 
 // #define DISABLE_COMPILE_CACHE
-// #define STATEMACHINE_PERFORMANCE_COUNTERS
+// #define PID_PERFORMANCE_COUNTERS
 
 #ifdef DEBUG_ENABLED_PID
     #define DEBUG_MODE_FULL
 #endif
 
 #ifdef DEBUG_SETTINGS_PID
-    #define DEBUG_SETTINGS DEBUG_SETTINGS_STATEMACHINE
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_PID
 #endif
 
 #include "\x\cba\addons\main\script_macros.hpp"

--- a/addons/pid/script_component.hpp
+++ b/addons/pid/script_component.hpp
@@ -13,3 +13,6 @@
 #endif
 
 #include "\x\cba\addons\main\script_macros.hpp"
+
+#define DEFAULT_HISTORY_LENGTH 10
+#define LARGE_NUMBER (1e38)

--- a/addons/pid/script_component.hpp
+++ b/addons/pid/script_component.hpp
@@ -1,0 +1,15 @@
+#define COMPONENT pid
+#include "\x\cba\addons\main\script_mod.hpp"
+
+// #define DISABLE_COMPILE_CACHE
+// #define STATEMACHINE_PERFORMANCE_COUNTERS
+
+#ifdef DEBUG_ENABLED_PID
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_PID
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_STATEMACHINE
+#endif
+
+#include "\x\cba\addons\main\script_macros.hpp"

--- a/addons/pid/stringtable.xml
+++ b/addons/pid/stringtable.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="CBA_A3">
-    <Package name="Statemachine">
-        <Key ID="STR_cba_statemachine_Component">
+    <Package name="PID">
+        <Key ID="STR_cba_pid_Component">
             <English>Community Base Addons - PID</English>
         </Key>
     </Package>

--- a/addons/pid/stringtable.xml
+++ b/addons/pid/stringtable.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project name="CBA_A3">
+    <Package name="Statemachine">
+        <Key ID="STR_cba_statemachine_Component">
+            <English>Community Base Addons - PID</English>
+        </Key>
+    </Package>
+</Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Add PID controller interface
- Taylor series for approximating derivative up to degree 2
- Integral windup prevention via integrating over short history
- Function to update PID gains of existing controller
- Function to reset PID history
- Function to update PID setpoint
- Error function for linear cases
- Error function for dealing with degree wrap-around
- Respect the [Submitting Content Guidelines](https://github.com/CBATeam/CBA_A3/wiki/Submitting%20content)

I was working on another PID controller for a project outside of ACE that needed 6 controllers, and after I wrote one of the PID updates wrong I realised that this would be a good fit for CBA. This PID controller can replace existing implementations in ACE missileguidance, but also would work well with an AI mod I am assisting with. I think that a PID controller is useful to a variety of mods: it can implement target tracking, smooth animations, speed control; pretty much anything that requires tracking a setpoint

I copied structure from `CBA_statemachine`. If there is any structural errors, that's ignorance on my part