### PR TITLE
Diagnostic - Fix watch controls on mission restart

### DIFF
--- a/addons/diagnostic/XEH_preInit.sqf
+++ b/addons/diagnostic/XEH_preInit.sqf
@@ -8,6 +8,11 @@ ADDON = false;
 #include "XEH_PREP.hpp"
 #include "initSettings.inc.sqf"
 
+// Remove stale controls
+private _missionDisplay = findDisplay 46;
+for "_index" from 0 to 3 do {
+    ctrlDelete (_missionDisplay displayCtrl (1000 + IDC_DEBUGCONSOLE_WATCHINPUT_1 + _index));
+};
 
 [QGVAR(debug), {_this call CBA_fnc_debug}] call CBA_fnc_addEventHandler;
 


### PR DESCRIPTION
**When merged this pull request will:**
- Remove stale watch controls after restarting a mission in the editor.

Fixes [#1819](https://github.com/CBATeam/CBA_A3/issues/1819)
