### PR TITLE
Common - Isolate PFH errors

### DIFF
--- a/addons/common/init_perFrameHandler.sqf
+++ b/addons/common/init_perFrameHandler.sqf
@@ -33,7 +33,7 @@ GVAR(waitUntilAndExecArray) = [];
 
         if (diag_tickTime > _delta) then {
             _x set [2, _delta + _delay];
-            [_args, _handle] call _function;
+            isNil {[_args, _handle] call _function};
         };
     } forEach GVAR(perFrameHandlerArray);
 


### PR DESCRIPTION
**When merged this pull request will:**
- Keep later PFHs and frame queues running when one PFH errors.

used the isNil suggestion from the issue so one broken PFH no longer stops the rest. ScriptError and the stack trace are still reported normally.

tested this with persistent and one-off errors, nested handlers, self-removal, adding and removing handlers during iteration, return values and delayed handlers. later handlers and frame queues kept running after an error, and the largest measured overhead was about 0.16 ms with 500 PFHs.

<img width="561" height="145" alt="image" src="https://github.com/user-attachments/assets/9405535e-b879-4209-bedc-733cc75d6aec" />


Fixes [#1602](https://github.com/CBATeam/CBA_A3/issues/1602)
