### PR TITLE
Main - Fix addon self requiring

### DIFF
--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -25,7 +25,6 @@ class CfgPatches {
             "cba_jr_prep",
             "cba_keybinding",
             "cba_loadout",
-            "cba_main",
             "cba_modules",
             "cba_music",
             "cba_network",


### PR DESCRIPTION
RPT:
```
Addon has invalid dependency, Addon 'cba_main' requires itself!
 ➥ Context: x\cba\addons\main\config.cpp/CfgPatches/cba_main.requiredAddons
->Last modified by: cba_main
```