### PR TITLE
Events - Use a native hashmap for event handler ids

### DIFF
--- a/addons/events/fnc_addEventHandler.sqf
+++ b/addons/events/fnc_addEventHandler.sqf
@@ -28,25 +28,24 @@ SCRIPT(addEventHandler);
     if (_eventName isEqualTo "" || isNil "_eventFunc") exitWith {-1};
 
     private _events = GVAR(eventNamespace) getVariable _eventName;
-    private _eventHash = GVAR(eventHashes) getVariable _eventName;
+    private _eventIds = GVAR(eventHashes) getVariable _eventName;
 
     // generate event name on logic
     if (isNil "_events") then {
         _events = [];
         GVAR(eventNamespace) setVariable [_eventName, _events];
 
-        _eventHash = [[], -1] call CBA_fnc_hashCreate;
-        GVAR(eventHashes) setVariable [_eventName, _eventHash];
+        _eventIds = createHashMap;
+        GVAR(eventHashes) setVariable [_eventName, _eventIds];
     };
 
     private _internalId = _events pushBack _eventFunc;
 
     // get new id
-    private _eventId = [_eventHash, "#lastId"] call CBA_fnc_hashGet;
-    INC(_eventId);
+    private _eventId = (_eventIds getOrDefault [LAST_ID_KEY, -1]) + 1;
 
-    [_eventHash, "#lastId", _eventId] call CBA_fnc_hashSet;
-    [_eventHash, _eventId, _internalId] call CBA_fnc_hashSet;
+    _eventIds set [LAST_ID_KEY, _eventId];
+    _eventIds set [_eventId, _internalId];
 
     _eventId
 }, _this] call CBA_fnc_directCall;

--- a/addons/events/fnc_removeEventHandler.sqf
+++ b/addons/events/fnc_removeEventHandler.sqf
@@ -28,22 +28,22 @@ params [["_eventName", "", [""]], ["_eventId", -1, [0]]];
     if (_eventId < 0) exitWith {};
 
     private _events = GVAR(eventNamespace) getVariable _eventName;
-    private _eventHash = GVAR(eventHashes) getVariable _eventName;
+    private _eventIds = GVAR(eventHashes) getVariable _eventName;
 
     if (isNil "_events") exitWith {};
 
-    private _internalId = [_eventHash, _eventId] call CBA_fnc_hashGet;
+    private _internalId = _eventIds getOrDefault [_eventId, -1];
 
     if (_internalId != -1) then {
         _events deleteAt _internalId;
-        [_eventHash, _eventId] call CBA_fnc_hashRem;
+        _eventIds deleteAt _eventId;
 
-        // decrement all higher internal ids, to adjust to new array position, _key == _eventId, _value == _internalId
-        [_eventHash, {
-            if (_value > _internalId && {_key isNotEqualTo "#lastId"}) then {
-                [_eventHash, _key, _value - 1] call CBA_fnc_hashSet;
+        // decrement all higher internal ids, to adjust to new array position, _x == _eventId, _y == _internalId
+        {
+            if ((_y > _internalId) && (_x isNotEqualTo LAST_ID_KEY)) then {
+                _eventIds set [_x, _y - 1];
             };
-        }] call CBA_fnc_hashEachPair;
+        } forEach _eventIds;
     };
 } call CBA_fnc_directCall;
 

--- a/addons/events/script_component.hpp
+++ b/addons/events/script_component.hpp
@@ -37,6 +37,8 @@
 
 #define SEND_TUEVENT_TO_SERVER(params,name,vehicle,turret) TUEVENT_PVAR = [name, params, vehicle, turret]; publicVariableServer TUEVENT_PVAR_STR
 
+#define LAST_ID_KEY "#lastId"
+
 #define CALL_EVENT(args,event) {\
     if !(isNil "_x") then {\
         args call _x;\


### PR DESCRIPTION
**When merged this pull request will:**
- Make CBA_fnc_addEventHandler and CBA_fnc_removeEventHandler faster
- Respect the [Submitting Content Guidelines](https://github.com/CBATeam/CBA_A3/wiki/Submitting%20content)

The per event id to index map used the array based CBA hash, so every lookup was a linear find and removal reindexed through hashSet, making it O(n^2). A native hashmap makes add O(1) and removal a single O(n) pass.