### PR TITLE
Common - Check PFH delay before destructuring

### DIFF
--- a/addons/common/init_perFrameHandler.sqf
+++ b/addons/common/init_perFrameHandler.sqf
@@ -29,9 +29,9 @@ GVAR(waitUntilAndExecArray) = [];
 
     // Execute per frame handlers
     {
-        _x params ["_function", "_delay", "_delta", "", "_args", "_handle"];
+        if (diag_tickTime > (_x select 2)) then {
+            _x params ["_function", "_delay", "_delta", "", "_args", "_handle"];
 
-        if (diag_tickTime > _delta) then {
             _x set [2, _delta + _delay];
             [_args, _handle] call _function;
         };


### PR DESCRIPTION
**When merged this pull request will:**
- Check tick time before params.
- Respect the [Submitting Content Guidelines](https://github.com/CBATeam/CBA_A3/wiki/Submitting%20content)

`(_x select 2)` is faster than full `params` and it's readable enough IMO since the lines are close together.