### PR TITLE
Events - Drop dead nil check and wrapper array from dispatch

### DIFF
--- a/addons/events/script_component.hpp
+++ b/addons/events/script_component.hpp
@@ -37,11 +37,14 @@
 
 #define SEND_TUEVENT_TO_SERVER(params,name,vehicle,turret) TUEVENT_PVAR = [name, params, vehicle, turret]; publicVariableServer TUEVENT_PVAR_STR
 
+// Handlers are never nil: addEventHandler rejects nil and removeEventHandler compacts with
+// deleteAt, so the isNil check could never be true. It is not free either, isNil on a string
+// looks the variable up by name, which measured ~310ns per handler.
+// getVariable supplies the default directly. The [...] param [0, []] this replaces was added to
+// stop undefined events erroring (79857b37), which the default covers, and it cost ~158ns more.
 #define CALL_EVENT(args,event) {\
-    if !(isNil "_x") then {\
-        args call _x;\
-    };\
-} forEach +([GVAR(eventNamespace) getVariable event] param [0, []]) // copy array so events can be removed while iterating safely
+    args call _x;\
+} forEach +(GVAR(eventNamespace) getVariable [event, []]) // copy array so events can be removed while iterating safely
 
 #define GETOBJ(obj) (if (obj isEqualType grpNull) then {leader obj} else {obj})
 

--- a/addons/settings/fnc_initDisplay3DEN.sqf
+++ b/addons/settings/fnc_initDisplay3DEN.sqf
@@ -47,7 +47,12 @@ private _fnc_resetMissionSettings = {
         };
     } forEach GVAR(allSettings);
 
-    QGVAR(refreshAllSettings) call CBA_fnc_localEvent;
+    // shared by the OnMissionPreview and OnMissionPreviewEnd handlers, both of which cross a
+    // missionNamespace reset, so this can run before the events addon preInit has made the
+    // registry. Nothing can be listening yet either, so the raise is a no-op.
+    if (!isNil QEGVAR(events,eventNamespace)) then {
+        QGVAR(refreshAllSettings) call CBA_fnc_localEvent;
+    };
 };
 
 add3DENEventHandler ["OnMissionPreview", _fnc_resetMissionSettings];

--- a/addons/xeh/fnc_endLoadingScreen.inc.sqf
+++ b/addons/xeh/fnc_endLoadingScreen.inc.sqf
@@ -5,7 +5,11 @@ private _return = call {
 };
 
 isNil {
-    [QGVAR(LoadingScreenEnded), _this] call CBA_fnc_localEvent;
+    // BIS preload calls this before the events addon preInit has made the registry,
+    // and no handler can be registered before that either, so the raise is a no-op
+    if (!isNil QEGVAR(events,eventNamespace)) then {
+        [QGVAR(LoadingScreenEnded), _this] call CBA_fnc_localEvent;
+    };
 };
 
 RETNIL(_return) //scheduler safe

--- a/addons/xeh/fnc_startLoadingScreen.inc.sqf
+++ b/addons/xeh/fnc_startLoadingScreen.inc.sqf
@@ -5,7 +5,11 @@ private _return = call {
 };
 
 isNil {
-    [QGVAR(LoadingScreenStarted), _this] call CBA_fnc_localEvent;
+    // BIS preload calls this before the events addon preInit has made the registry,
+    // and no handler can be registered before that either, so the raise is a no-op
+    if (!isNil QEGVAR(events,eventNamespace)) then {
+        [QGVAR(LoadingScreenStarted), _this] call CBA_fnc_localEvent;
+    };
 };
 
 RETNIL(_return) //scheduler safe


### PR DESCRIPTION
**When merged this pull request will:**
- Remove the `isNil "_x"` check from `CALL_EVENT`, it can never be true
- Replace the `[...] param [0, []]` wrapper with a `getVariable` default value
- Skip the event raise in `startLoadingScreen`, `endLoadingScreen` and the 3DEN preview settings reset when it happens before `cba_events` preInit

The `isNil "_x"` lookup was slow and couldn't be true. `param [0, []]` is slower than a `getVariable` default.

`param [0, []]` did guard against a script error if anything ran before `cba_events`'s preInit created the namespace. Can see that in the `OnMissionPreview` and `OnMissionPreviewEnd` 3DEN Event Handlers. But the event raise would've been a no-op anyway, it was just preventing the script error from showing up.

### Performance

`diag_codePerformance`, 100k cycles:

| handlers | before | after | saved |
| --- | --- | --- | --- |
| 0 | 669ns | 566ns | 103ns |
| 1 | 1559ns | 1094ns | 464ns |
| 3 | 3076ns | 2041ns | 1035ns |

The wrapper saving is per raise (~100-150ns), the `isNil` saving is per handler (~285ns), so it scales with listener count. As a share of a full `CBA_fnc_localEvent` call:

| handlers | saved |
| --- | --- |
| 0 | ~6% |
| 1 | ~15% |
| 3 | ~22% |
| many | approaches ~38% |

For scale, ACE3 has 782 raise sites and 491 handler registrations. `ace_firedPlayer` has 9 listeners and fires on every player shot.

### Testing

Editor and mission preview, RPT clean. Checked that undefined events still don't error, handlers still fire in registration order, a handler removing itself mid-dispatch doesn't break iteration, handlers added mid-dispatch don't fire until the next raise, `localEvent` still returns the last handler's value, and both loading screen events still fire at runtime.
