### PR TITLE
Settings - Fix showing Mission checkboxes when on Mission tab

### DIFF
--- a/addons/settings/fnc_gui_filterSettings.sqf
+++ b/addons/settings/fnc_gui_filterSettings.sqf
@@ -55,7 +55,9 @@ private _shownRows = [];
 
     // a header is kept for as long as the search left it anything, folded or not
     _x setVariable [QGVAR(matched), _matched];
-    _x ctrlShow _show;
+    if ((ctrlShown _x) isNotEqualTo _show) then {
+        _x ctrlShow _show;
+    };
 
     if (_show) then {
         _shownRows pushBack _x;


### PR DESCRIPTION
Open settings in 3den
Mission Tab
Looks normal
Change category
Now shows greyed out "Mission" checkboxes

<img width="1185" height="261" alt="20260811233812_1" src="https://github.com/user-attachments/assets/b87883c2-e61a-483b-b63d-54a1a262b508" />

seems to be from ctrlShow on the row's group applying to the checkbox
> Using ctrlShow on a controls group will show or hide all controls within the controls group (including controls that are placed in nested controls groups).

I couldn't find any times when line 58 hit true, so it may be possible to just remove the line?