### PR TITLE
JAM - Add missing 150rnd drum mags to STANAG 2DXL magwell

### DIFF
--- a/addons/jam/magwells_556x45.hpp
+++ b/addons/jam/magwells_556x45.hpp
@@ -69,7 +69,11 @@
     class CBA_556x45_STANAG_2D_XL {     // STANAG mags, extra large twin-drums (150rnd Armatac SAW-MAG)
         BI_mags[] = {
             "150Rnd_556x45_Drum_Mag_F",
-            "150Rnd_556x45_Drum_Mag_Tracer_F"
+            "150Rnd_556x45_Drum_Mag_Tracer_F",
+            "150Rnd_556x45_Drum_Green_Mag_F",
+            "150Rnd_556x45_Drum_Sand_Mag_F",
+            "150Rnd_556x45_Drum_Green_Mag_TracerF",
+            "150Rnd_556x45_Drum_Sand_Mag_Tracer_F"
         };
     };
 

--- a/addons/jam/magwells_556x45.hpp
+++ b/addons/jam/magwells_556x45.hpp
@@ -72,7 +72,7 @@
             "150Rnd_556x45_Drum_Mag_Tracer_F",
             "150Rnd_556x45_Drum_Green_Mag_F",
             "150Rnd_556x45_Drum_Sand_Mag_F",
-            "150Rnd_556x45_Drum_Green_Mag_TracerF",
+            "150Rnd_556x45_Drum_Green_Mag_Tracer_F",
             "150Rnd_556x45_Drum_Sand_Mag_Tracer_F"
         };
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Add the Sand and Green colour variants of the 150rnd 5.56 STANAG drum mag to the STANAG 2D XL magwell
- Respect the [Submitting Content Guidelines](https://github.com/CBATeam/CBA_A3/wiki/Submitting%20content)
