### PR TITLE
UI - Add setting to hide world suffix from missions in Create MP Mission dialog

### DIFF
--- a/addons/ui/fnc_initDisplayRemoteMissions.sqf
+++ b/addons/ui/fnc_initDisplayRemoteMissions.sqf
@@ -102,12 +102,19 @@ private _fnc_storeMapMissions = {_this spawn {isNil { // delay a frame
     params ["_ctrlMaps"];
     private _display = ctrlParent _ctrlMaps;
     private _ctrlMissions = _display displayCtrl IDC_SERVER_MISSION;
+    private _map = _ctrlMaps lbData lbCurSel _ctrlMaps;
 
     private _missions = [];
     for "_i" from 0 to (lbSize _ctrlMissions - 1) do {
         private _name = _ctrlMissions lbText _i;
         with uiNamespace do {
             _name = _name call CBA_fnc_decodeURL;
+        };
+        // delete map suffix
+        private _nameArray = _name splitString ".";
+        if (count _nameArray > 1 && {_nameArray select -1 == _map}) then {
+            _nameArray resize (count _nameArray - 1);
+            _name = _nameArray joinString ".";
         };
 
         private _value = _ctrlMissions lbValue _i;

--- a/addons/ui/fnc_initDisplayRemoteMissions.sqf
+++ b/addons/ui/fnc_initDisplayRemoteMissions.sqf
@@ -155,7 +155,7 @@ private _fnc_storeMapMissions = {_this spawn {isNil { // delay a frame
         // delete map suffix
         private _nameArray = _name splitString ".";
         if (count _nameArray > 1 && {_nameArray select -1 == _map}) then {
-            _nameArray resize (count _nameArray - 1);
+            _nameArray deleteAt [-1];
             _name = _nameArray joinString ".";
         };
 

--- a/addons/ui/fnc_initDisplayRemoteMissions.sqf
+++ b/addons/ui/fnc_initDisplayRemoteMissions.sqf
@@ -152,11 +152,12 @@ private _fnc_storeMapMissions = {_this spawn {isNil { // delay a frame
         with uiNamespace do {
             _name = _name call CBA_fnc_decodeURL;
         };
-        // delete map suffix
-        private _nameArray = _name splitString ".";
-        if (count _nameArray > 1 && {_nameArray select -1 == _map}) then {
-            _nameArray deleteAt [-1];
-            _name = _nameArray joinString ".";
+        if (profileNamespace getVariable [QGVAR(hideMissionWorldSuffix), false]) then {
+            private _nameArray = _name splitString ".";
+            if (count _nameArray > 1 && {_nameArray select -1 == _map}) then {
+                _nameArray deleteAt [-1];
+                _name = _nameArray joinString ".";
+            };
         };
 
         private _value = _ctrlMissions lbValue _i;

--- a/addons/ui/initSettings.inc.sqf
+++ b/addons/ui/initSettings.inc.sqf
@@ -1,7 +1,9 @@
+private _category = [LELSTRING(main,DisplayName), LLSTRING(Category)];
+
 [
     QGVAR(StorePasswords), "LIST",
     [LLSTRING(StoreServerPasswords), LLSTRING(StoreServerPasswordsTooltip)],
-    [LELSTRING(main,DisplayName), LLSTRING(Category)],
+    _category,
     [[1, 0, -1], [
         [LLSTRING(SavePasswords), LLSTRING(SavePasswordsTooltip)],
         [LLSTRING(DoNotSavePasswords), LLSTRING(DoNotSavePasswordsTooltip)],
@@ -22,7 +24,7 @@
     QGVAR(notifyLifetime),
     "SLIDER",
     [LLSTRING(NotifyLifetime), LLSTRING(NotifyLifetimeTooltip)],
-    [LELSTRING(main,DisplayName), LLSTRING(Category)],
+    _category,
     [1, 10, 4, 1], // default value
     2 // global
 ] call CBA_fnc_addSetting;
@@ -31,7 +33,24 @@
     QGVAR(autoExpandOptions),
     "CHECKBOX",
     LLSTRING(AutoExpandOptions),
-    [LELSTRING(main,DisplayName), LLSTRING(Category)],
+    _category,
     true,
     2
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(hideMissionWorldSuffix),
+    "CHECKBOX",
+    [LLSTRING(HideMissionWorldSuffix), LLSTRING(HideMissionWorldSuffixTooltip)],
+    _category,
+    false,
+    2,
+    {
+        if (_this) then {
+            profileNamespace setVariable [QGVAR(hideMissionWorldSuffix), _this];
+        } else {
+            profileNamespace setVariable [QGVAR(hideMissionWorldSuffix), nil];
+        };
+        saveProfileNamespace;
+    }
 ] call CBA_fnc_addSetting;

--- a/addons/ui/stringtable.xml
+++ b/addons/ui/stringtable.xml
@@ -156,6 +156,14 @@
             <Chinesesimp>当连接到服务器时将不保存密码。已保存的密码将不自动填写。</Chinesesimp>
             <Turkish>Çok oyunculu bir sunucuya girerken şifreler kaydedilmez. Zaten kayıtlı olan şifreler otomatik olarak doldurulmaz.</Turkish>
         </Key>
+        <Key ID="STR_CBA_UI_HideMissionWorldSuffix">
+            <English>Hide mission world name suffix</English>
+            <Russian>Убрать название мира у миссий</Russian>
+        </Key>
+        <Key ID="STR_CBA_UI_HideMissionWorldSuffixTooltip">
+            <English>Hide world name suffix in multiplayer mission list.</English>
+            <Russian>Убрать суффикс с названием мира в списке миссий в многопользовательской игре.</Russian>
+        </Key>
         <Key ID="STR_CBA_UI_LobbyManager">
             <English>Lobby Manager</English>
             <Czech>Manažer lobby</Czech>


### PR DESCRIPTION
**When merged this pull request will:**
- title.

### World + Missions:
<img width="1238" height="185" alt="overall" src="https://github.com/user-attachments/assets/b7ea493a-350c-4056-9ae1-685958a683a2" />

### MP Host before/after
<img width="460" height="200" alt="MP Host off" src="https://github.com/user-attachments/assets/eca44261-b2f3-4cc2-85db-4ab532f20140" />
<img width="460" height="200" alt="MP Host on" src="https://github.com/user-attachments/assets/948449c5-b775-401a-8a7c-320a7962e0d7" />

### Dedicated before/after
<img width="460" height="200" alt="dedi def off" src="https://github.com/user-attachments/assets/0caf8a55-1f48-415e-87f0-5749a1858cb7" />
<img width="460" height="200" alt="dedi def on" src="https://github.com/user-attachments/assets/29a7b00c-c565-470e-a3ea-a324d248450d" />


### Dedicated with `SkipDescriptionParsing` before/after
<img width="460" height="200" alt="dedi skip off" src="https://github.com/user-attachments/assets/a2737ba3-d496-4bb1-8aa0-b19c64147678" />
<img width="460" height="200" alt="dedi skip on" src="https://github.com/user-attachments/assets/6158fefd-e852-4044-a454-d783f843a18d" />
