### PR TITLE
UI - Add Missions button to MP Role Assignment dialog for admins

### DIFF
--- a/addons/ui/CfgEventHandlers.hpp
+++ b/addons/ui/CfgEventHandlers.hpp
@@ -19,6 +19,7 @@ class Extended_DisplayLoad_EventHandlers {
     };
     class RscDisplayMultiplayerSetup {
         ADDON = QUOTE(call (uiNamespace getVariable 'FUNC(initDisplayMultiplayerSetup)'));
+        GVAR(addMissionsButton) = QUOTE(call (uiNamespace getVariable 'FUNC(addMissionsButton)'));
     };
     class RscDisplayOptionsLayout {
         ADDON = QUOTE(call (uiNamespace getVariable 'FUNC(initDisplayOptionsLayout)'));

--- a/addons/ui/XEH_preStart.sqf
+++ b/addons/ui/XEH_preStart.sqf
@@ -18,4 +18,5 @@ PREP(preloadCurator);
 
 PREP(openItemContextMenu);
 
+PREP(addMissionsButton);
 PREP(getInventoryItemData);

--- a/addons/ui/fnc_addMissionsButton.sqf
+++ b/addons/ui/fnc_addMissionsButton.sqf
@@ -40,7 +40,7 @@ _ctrlMissionsButton ctrlSetText localize "STR_DISP_MP_DS_MISSIONS";
 
 _ctrlMissionsButton ctrlAddEventHandler ["ButtonClick", {serverCommand "#missions"}];
 
-private _fnc_missionButtonControl = {
+private _fnc_missionsButtonControl = {
     params ["_display"];
     private _ctrlMissionsButton = _display displayCtrl IDC_RESTART;
     if (ctrlShown _ctrlMissionsButton) then {
@@ -49,5 +49,5 @@ private _fnc_missionButtonControl = {
         if (serverCommandAvailable "#missions") then {_ctrlMissionsButton ctrlShow true};
     };
 };
-_display displayAddEventHandler ["MouseMoving", _fnc_missionButtonControl];
-_display displayAddEventHandler ["MouseHolding", _fnc_missionButtonControl];
+_display displayAddEventHandler ["MouseMoving", _fnc_missionsButtonControl];
+_display displayAddEventHandler ["MouseHolding", _fnc_missionsButtonControl];

--- a/addons/ui/fnc_addMissionsButton.sqf
+++ b/addons/ui/fnc_addMissionsButton.sqf
@@ -1,0 +1,53 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Internal Function: cba_ui_fnc_addMissionsButton
+
+Description:
+    Adds Missions button on Multiplayer Role Assignment screen.
+
+Parameters:
+    _display - RscDisplayMultiplayerSetup display <DISPLAY>
+
+Returns:
+    Nothing/Undefined.
+
+Examples:
+    (begin example)
+        call cba_ui_fnc_addMissionsButton
+    (end)
+
+Author:
+    Dystopian
+---------------------------------------------------------------------------- */
+
+params ["_display"];
+
+private _ctrlCancel = _display displayCtrl IDC_CANCEL;
+if (isNull _ctrlCancel) exitWith {};
+
+ctrlPosition _ctrlCancel params ["_cancelLeft", "_cancelTop", "_cancelWidth", "_cancelHeight"];
+
+private _ctrlMissionsButton = _display ctrlCreate ["RscButtonMenu", IDC_RESTART];
+_ctrlMissionsButton ctrlShow false;
+_ctrlMissionsButton ctrlSetPosition [
+    _cancelLeft + _cancelWidth + 0.1 * GUI_GRID_W,
+    _cancelTop,
+    _cancelWidth,
+    _cancelHeight
+];
+_ctrlMissionsButton ctrlCommit 0;
+_ctrlMissionsButton ctrlSetText localize "STR_DISP_MP_DS_MISSIONS";
+
+_ctrlMissionsButton ctrlAddEventHandler ["ButtonClick", {serverCommand "#missions"}];
+
+private _fnc_missionButtonControl = {
+    params ["_display"];
+    private _ctrlMissionsButton = _display displayCtrl IDC_RESTART;
+    if (ctrlShown _ctrlMissionsButton) then {
+        if (!serverCommandAvailable "#missions") then {_ctrlMissionsButton ctrlShow false};
+    } else {
+        if (serverCommandAvailable "#missions") then {_ctrlMissionsButton ctrlShow true};
+    };
+};
+_display displayAddEventHandler ["MouseMoving", _fnc_missionButtonControl];
+_display displayAddEventHandler ["MouseHolding", _fnc_missionButtonControl];


### PR DESCRIPTION
**When merged this pull request will:**
- title.

<img width="303" height="39" alt="image" src="https://github.com/user-attachments/assets/3ffa8ecd-9920-4066-88ab-cd160e26b1a2" />

The button appears only for admins on dedicated server.

Default `Disconnect` button on dedicated just disconnects admin from server. Admin needs to run `#missions` server command to return to the previous dialog. The new button helps to do it faster.