### PR TITLE
Common - cba_fnc_getCfgDataHashmap: support for subclasses

### DIFF
--- a/addons/common/fnc_getCfgDataHashmap.sqf
+++ b/addons/common/fnc_getCfgDataHashmap.sqf
@@ -4,6 +4,7 @@ Function: CBA_fnc_getCfgDataHashmap
 
 Description:
     This function extracts all config properties of a class and returns them as a Hashmap with the properties as keys (string).
+    SubClasses will be returned as their own Hashmap.
 
     The following Values will be converted:
     Boolean as String ("true", "false") will be converted to boolean data-type.
@@ -31,60 +32,65 @@ Author:
 
 
 params [
-    ["_cfg", configNull, [configNull]],
-    ["_condition", "true", [""]],
-    ["_inherit", true, [true]],
-    ["_convert", true, [true]],
-    ["_toLower", false, [true]]
+	["_cfg", configNull, [configNull]],
+	["_condition", "true", [""]],
+	["_inherit", true, [true]],
+	["_convert", true, [true]],
+	["_toLower", false, [true]]
 ];
 
 if !(isClass _cfg || { isNull _cfg } ) exitWith { nil };
 
 private _properties = configProperties [_cfg, _condition, _inherit];
 
-private _returnHashMap = createHashMap;
-
 private _convertApply = [
-    nil,
-    {
-        switch (true) do {
-            case (_x isEqualType [] ): { _x apply _convertApply };
-            case (_x isEqualTo "true");
-            case (_x isEqualTo "(true)"): { true };
-            case (_x isEqualTo "false");
-            case (_x isEqualTo "(false)"): { false };
-            default { _x };
-        }
-    }
+	nil,
+	{
+		switch (true) do {
+			case (_x isEqualType [] ): { _x apply _convertApply };
+			case (_x isEqualTo "true");
+			case (_x isEqualTo "(true)"): { true };
+			case (_x isEqualTo "false");
+			case (_x isEqualTo "(false)"): { false };
+			default { _x };
+		}
+	}
 ] select _convert;
 
 
 private _convertCall = [
-    {
-        _this
-    },
-    {
-        switch (true) do {
-            case (_this isEqualType [] ): { _this apply _convertApply };
-            case (_this isEqualTo "true");
-            case (_this isEqualTo "(true)"): { true };
-            case (_this isEqualTo "false");
-            case (_this isEqualTo "(false)"): { false };
-            default { _this };
-        };
-    }
+	{
+		_this
+	},
+	{
+		switch (true) do {
+			case (_this isEqualType [] ): { _this apply _convertApply };
+			case (_this isEqualTo "true");
+			case (_this isEqualTo "(true)"): { true };
+			case (_this isEqualTo "false");
+			case (_this isEqualTo "(false)"): { false };
+			default { _this };
+		};
+	}
 ] select _convert;
 
 
+private _returnHashMap = createHashMap;
 {
-    private _cfg = _x;
-    private _key = if (_toLower) then { toLowerANSI configName _cfg } else { configName _cfg };
-    private _value = _cfg call BIS_fnc_getCfgData call _convertCall;
+	private _cfg = _x;
+	private _key = if (_toLower) then { toLowerANSI configName _cfg } else { configName _cfg };
 
-    _returnHashMap set [
-        _key,
-        _value
-    ];
+		private _value = if ( isClass _cfg ) then {
+		[_cfg, _condition, _inherit, _convert, _toLower] call CBA_fnc_getCfgDataHashmap;
+
+	} else {
+		_cfg call BIS_fnc_getCfgData call _convertCall
+	};
+
+	_returnHashMap set [
+		_key,
+		_value
+	];
 
 } forEach _properties;
 

--- a/addons/common/fnc_getCfgDataHashmap.sqf
+++ b/addons/common/fnc_getCfgDataHashmap.sqf
@@ -80,9 +80,8 @@ private _returnHashMap = createHashMap;
     private _cfg = _x;
     private _key = if (_toLower) then { toLowerANSI configName _cfg } else { configName _cfg };
 
-        private _value = if ( isClass _cfg ) then {
+    private _value = if ( isClass _cfg ) then {
         [_cfg, _condition, _inherit, _convert, _toLower] call CBA_fnc_getCfgDataHashmap;
-
     } else {
         _cfg call BIS_fnc_getCfgData call _convertCall
     };

--- a/addons/common/fnc_getCfgDataHashmap.sqf
+++ b/addons/common/fnc_getCfgDataHashmap.sqf
@@ -32,11 +32,11 @@ Author:
 
 
 params [
-	["_cfg", configNull, [configNull]],
-	["_condition", "true", [""]],
-	["_inherit", true, [true]],
-	["_convert", true, [true]],
-	["_toLower", false, [true]]
+    ["_cfg", configNull, [configNull]],
+    ["_condition", "true", [""]],
+    ["_inherit", true, [true]],
+    ["_convert", true, [true]],
+    ["_toLower", false, [true]]
 ];
 
 if !(isClass _cfg || { isNull _cfg } ) exitWith { nil };
@@ -44,53 +44,53 @@ if !(isClass _cfg || { isNull _cfg } ) exitWith { nil };
 private _properties = configProperties [_cfg, _condition, _inherit];
 
 private _convertApply = [
-	nil,
-	{
-		switch (true) do {
-			case (_x isEqualType [] ): { _x apply _convertApply };
-			case (_x isEqualTo "true");
-			case (_x isEqualTo "(true)"): { true };
-			case (_x isEqualTo "false");
-			case (_x isEqualTo "(false)"): { false };
-			default { _x };
-		}
-	}
+    nil,
+    {
+        switch (true) do {
+            case (_x isEqualType [] ): { _x apply _convertApply };
+            case (_x isEqualTo "true");
+            case (_x isEqualTo "(true)"): { true };
+            case (_x isEqualTo "false");
+            case (_x isEqualTo "(false)"): { false };
+            default { _x };
+        }
+    }
 ] select _convert;
 
 
 private _convertCall = [
-	{
-		_this
-	},
-	{
-		switch (true) do {
-			case (_this isEqualType [] ): { _this apply _convertApply };
-			case (_this isEqualTo "true");
-			case (_this isEqualTo "(true)"): { true };
-			case (_this isEqualTo "false");
-			case (_this isEqualTo "(false)"): { false };
-			default { _this };
-		};
-	}
+    {
+        _this
+    },
+    {
+        switch (true) do {
+            case (_this isEqualType [] ): { _this apply _convertApply };
+            case (_this isEqualTo "true");
+            case (_this isEqualTo "(true)"): { true };
+            case (_this isEqualTo "false");
+            case (_this isEqualTo "(false)"): { false };
+            default { _this };
+        };
+    }
 ] select _convert;
 
 
 private _returnHashMap = createHashMap;
 {
-	private _cfg = _x;
-	private _key = if (_toLower) then { toLowerANSI configName _cfg } else { configName _cfg };
+    private _cfg = _x;
+    private _key = if (_toLower) then { toLowerANSI configName _cfg } else { configName _cfg };
 
-		private _value = if ( isClass _cfg ) then {
-		[_cfg, _condition, _inherit, _convert, _toLower] call CBA_fnc_getCfgDataHashmap;
+        private _value = if ( isClass _cfg ) then {
+        [_cfg, _condition, _inherit, _convert, _toLower] call CBA_fnc_getCfgDataHashmap;
 
-	} else {
-		_cfg call BIS_fnc_getCfgData call _convertCall
-	};
+    } else {
+        _cfg call BIS_fnc_getCfgData call _convertCall
+    };
 
-	_returnHashMap set [
-		_key,
-		_value
-	];
+    _returnHashMap set [
+        _key,
+        _value
+    ];
 
 } forEach _properties;
 

--- a/addons/common/fnc_getCfgDataHashmap.sqf
+++ b/addons/common/fnc_getCfgDataHashmap.sqf
@@ -81,7 +81,7 @@ private _returnHashMap = createHashMap;
     private _key = if (_toLower) then { toLowerANSI configName _cfg } else { configName _cfg };
 
     private _value = if ( isClass _cfg ) then {
-        [_cfg, _condition, _inherit, _convert, _toLower] call CBA_fnc_getCfgDataHashmap;
+        [_cfg, _condition, _inherit, _convert, _toLower] call CBA_fnc_getCfgDataHashmap
     } else {
         _cfg call BIS_fnc_getCfgData call _convertCall
     };

--- a/addons/common/fnc_getCfgDataHashmap.sqf
+++ b/addons/common/fnc_getCfgDataHashmap.sqf
@@ -81,7 +81,7 @@ private _returnHashMap = createHashMap;
     private _key = if (_toLower) then { toLowerANSI configName _cfg } else { configName _cfg };
 
     private _value = if ( isClass _cfg ) then {
-        [_cfg, _condition, _inherit, _convert, _toLower] call FUNC(getCfgDataHashmap)
+        [_cfg, _condition, _inherit, _convert, _toLower] call CBA_fnc_getCfgDataHashmap
     } else {
         _cfg call BIS_fnc_getCfgData call _convertCall
     };

--- a/addons/common/fnc_getCfgDataHashmap.sqf
+++ b/addons/common/fnc_getCfgDataHashmap.sqf
@@ -81,7 +81,7 @@ private _returnHashMap = createHashMap;
     private _key = if (_toLower) then { toLowerANSI configName _cfg } else { configName _cfg };
 
     private _value = if ( isClass _cfg ) then {
-        [_cfg, _condition, _inherit, _convert, _toLower] call CBA_fnc_getCfgDataHashmap
+        [_cfg, _condition, _inherit, _convert, _toLower] call FUNC(getCfgDataHashmap)
     } else {
         _cfg call BIS_fnc_getCfgData call _convertCall
     };


### PR DESCRIPTION
Previously, a subclass would return with `any` as its value. With this fix they will return a further hashmap of its content.