### PR TITLE
UI - Add condition and parameters to Pause Menu Buttons

### DIFF
--- a/addons/ui/fnc_addPauseMenuOption.sqf
+++ b/addons/ui/fnc_addPauseMenuOption.sqf
@@ -6,8 +6,10 @@ Description:
     Adds a menu option to the ESC menu "Options" tab.
 
 Parameters:
-    _name   - name of the menu button or array of name and tooltip <STRING, ARRAY>
-    _dialog - Dialog to open when clicking the menu button <STRING>
+    _name         - name of the menu button or array of name and tooltip <STRING, ARRAY>
+    _dialogOrCode - Dialog to open or code to execute when clicking the menu button <STRING, CODE>
+    _condition    - condition to check whether the menu button should be shown (optional, default: {true}) <CODE>
+    _params       - parameters passed to the condition and dialog code (optional, default: []) <ARRAY>
 
 Returns:
     Nothing
@@ -21,13 +23,13 @@ Author:
     commy2
 ---------------------------------------------------------------------------- */
 
-params [["_name", "", ["", []]], ["_dialog", "", [""]]];
+params [["_name", "", ["", []]], ["_dialogOrCode", "", ["", {}]], ["_condition", {true}, [{}]], ["_params", []]];
 _name params [["_displayName", "", [""]], ["_tooltip", "", [""]]];
 
 if (isNil QGVAR(MenuButtons)) then {
     GVAR(MenuButtons) = [];
 };
 
-GVAR(MenuButtons) pushBack [_displayName, _tooltip, _dialog];
+GVAR(MenuButtons) pushBack [_displayName, _tooltip, _dialogOrCode, _condition, _params];
 
 nil

--- a/addons/ui/fnc_initDisplayInterrupt.sqf
+++ b/addons/ui/fnc_initDisplayInterrupt.sqf
@@ -18,8 +18,15 @@ params ["_display"];
 private _buttons = [];
 _display setVariable [QGVAR(MenuButtons), _buttons];
 
+private _menuButtons = GVAR(MenuButtons) select {
+    _x params ["", "", "", "_condition", "_params"];
+    private _return = nil;
+    !isNil {_return = _params call _condition; _return} // handle script errors
+    && {_return param [0, false, [true]]}
+};
+
 // initial button placement
-private _offset = -1.1 * (count GVAR(MenuButtons) + 4);
+private _offset = -1.1 * (count _menuButtons + 4);
 if (!isMultiplayer && {getNumber (missionConfigFile >> "replaceAbortButton") > 0}) then {
     _offset = _offset - 1.1;
 };
@@ -48,13 +55,21 @@ private _buttonType = ["RscButtonMenu", "RscButtonMenuLeft"] select isClass (con
 
 {
     _offset = _offset + 1.1;
-    _x params ["_displayName", "_tooltip", "_dialog"];
+    _x params ["_displayName", "_tooltip", "_dialogOrCode", "_condition", "_params"];
 
     private _button = _display ctrlCreate [_buttonType, -1];
 
     _button ctrlSetText toUpper _displayName;
     _button ctrlSetTooltip _tooltip;
-    _button buttonSetAction format ["findDisplay %1 createDisplay '%2'", ctrlIDD _display, _dialog];
+    _button setVariable [QGVAR(params), [_dialogOrCode, _condition, _params]];
+    _button ctrlAddEventHandler ["ButtonClick", {
+        params ["_button"];
+        _button getVariable QGVAR(params) params ["_dialogOrCode", "_condition", "_params"];
+        if !(_params call _condition param [0, false, [true]]) exitWith {}; // no problem with script errors
+        if (_dialogOrCode isEqualType {}) exitWith {_params call _dialogOrCode};
+        private _display = ctrlParent _button;
+        _display createDisplay _dialogOrCode;
+    }];
     _button ctrlEnable false;
     _button ctrlSetFade 1;
 
@@ -67,7 +82,7 @@ private _buttonType = ["RscButtonMenu", "RscButtonMenuLeft"] select isClass (con
 
     _button ctrlCommit 0;
     _buttons pushBack _button;
-} forEach GVAR(MenuButtons);
+} forEach _menuButtons;
 
 // --- replace expand button action
 private _button = _display displayCtrl 101;


### PR DESCRIPTION
**When merged this pull request will:**
- add condition and parameters to Pause Menu Buttons;
- allow `_dialog` to accept code to execute instead of creating a dialog.

The condition is checked when the Pause Menu is opened and when the button is pressed. Parameters are passed to both the condition and dialog code.