### PR TITLE
Translations - Spanish

### DIFF
--- a/addons/accessory/stringtable.xml
+++ b/addons/accessory/stringtable.xml
@@ -5,7 +5,7 @@
             <English>Community Base Addons - Accessory Functions</English>
             <Czech>Community Base Addons - Funkce doplňků</Czech>
             <French>Community Base Addons - Fonctions des accessoires</French>
-            <Spanish>Community Base Addons - Funciones accesorias</Spanish>
+            <Spanish>Community Base Addons - Funciones de accesorios</Spanish>
             <Italian>Community Base Addons - Funzioni per Accessori</Italian>
             <Polish>Community Base Addons - Funkcje Akcesoriów</Polish>
             <Russian>Community Base Addons - Функционал аксессуаров</Russian>
@@ -35,7 +35,7 @@
             <English>Cycles to the next mode available for your optics slot attachment</English>
             <Czech>Přepíná na další možný režim doplňku slotu pro zaměřovač</Czech>
             <French>Basculer sur le mode suivant de l'optique.</French>
-            <Spanish>Pasa al siguiente modo disponible para su accesorio de ranura óptica</Spanish>
+            <Spanish>Pasa al siguiente modo disponible del accesorio de la ranura óptica.</Spanish>
             <Italian>Passa alla modalità successiva della tua ottica</Italian>
             <Polish>Przełącza na następny dostępny tryb optyki</Polish>
             <Russian>Переключает на следующий режим доступный для оптики на оружии</Russian>
@@ -50,7 +50,7 @@
             <English>Prev optics state</English>
             <Czech>Předchozí režim zaměřovače</Czech>
             <French>Mode précédent de l'optique</French>
-            <Spanish>Estado de la óptica anterior</Spanish>
+            <Spanish>Estado anterior de la óptica</Spanish>
             <Italian>Stato precedente dell'ottica</Italian>
             <Polish>Poprzedni tryb optyki</Polish>
             <Russian>Предыдущее состояние оптики</Russian>
@@ -65,7 +65,7 @@
             <English>Cycles to the previous mode available for your optics slot attachment</English>
             <Czech>Přepíná na předchozí možný režim doplňku slotu pro zaměřovač</Czech>
             <French>Basculer sur le mode précédent de l'optique.</French>
-            <Spanish>Cambia al modo anterior disponible para su accesorio de ranura óptica.</Spanish>
+            <Spanish>Pasa al modo anterior disponible del accesorio de la ranura óptica.</Spanish>
             <Italian>Passa alla modalità precedente della tua ottica</Italian>
             <Polish>Przełącza na poprzedni dostępny tryb optyki</Polish>
             <Russian>Переключает на предыдущий режим доступный для оптики на оружии</Russian>
@@ -80,7 +80,7 @@
             <English>Next rail item state</English>
             <Czech>Další režim doplňku na liště</Czech>
             <French>Mode suivant de l'accessoire sur rail</French>
-            <Spanish>Estado de la siguiente posición del riel</Spanish>
+            <Spanish>Siguiente estado del accesorio del riel</Spanish>
             <Italian>Stato successivo dell'oggetto sulla slitta</Italian>
             <Polish>Następny tryb akcesoria na szynie</Polish>
             <Russian>Следующее состояние приспособления на оружии</Russian>
@@ -95,7 +95,7 @@
             <English>Cycles to the next mode available for your rail slot attachment</English>
             <Czech>Přepíná na další možný režim doplňku na liště</Czech>
             <French>Basculer sur le mode suivant de l'accessoire du rail.</French>
-            <Spanish>Pasa al siguiente modo disponible para el accesorio de la ranura del riel.</Spanish>
+            <Spanish>Pasa al siguiente modo disponible del accesorio de la ranura del riel.</Spanish>
             <Italian>Passa alla modalità successiva del tuo accessorio sulla slitta</Italian>
             <Polish>Przełącza na następny tryb akcesoria na szynie</Polish>
             <Russian>Переключает на следующий режим, доступный для приспособления на планке</Russian>
@@ -110,7 +110,7 @@
             <English>Prev rail item state</English>
             <Czech>Předchozí režim doplňku na liště</Czech>
             <French>Mode précédent de l'accessoire sur rail</French>
-            <Spanish>Estado anterior del riel</Spanish>
+            <Spanish>Estado anterior del accesorio del riel</Spanish>
             <Italian>Stato precedente dell'oggetto sulla slitta</Italian>
             <Polish>Poprzedni tryb akcesoria na szynie</Polish>
             <Russian>Предыдущее состояние приспособления на планке</Russian>
@@ -125,7 +125,7 @@
             <English>Cycles to the previous mode available for your rail slot attachment</English>
             <Czech>Přepíná na předchozí možný režim doplňku na liště</Czech>
             <French>Basculer sur le mode précédent de l'accessoire du rail.</French>
-            <Spanish>Pasa al modo anterior disponible para su accesorio de ranura de riel</Spanish>
+            <Spanish>Pasa al modo anterior disponible del accesorio de la ranura del riel.</Spanish>
             <Italian>Passa alla modalità precedente del tuo accessorio sulla slitta</Italian>
             <Polish>Przełącza na poprzedni tryb akcesoria na szynie</Polish>
             <Russian>Переключает на предыдущий режим, доступный для приспособления на планке</Russian>

--- a/addons/ai/stringtable.xml
+++ b/addons/ai/stringtable.xml
@@ -5,7 +5,7 @@
             <English>AI Building Position</English>
             <Czech>Poloha stavby AI</Czech>
             <French>Position IA bâtiment</French>
-            <Spanish>Posición del edificio de IA</Spanish>
+            <Spanish>Posición de IA en edificio</Spanish>
             <Italian>Posizione edificio AI</Italian>
             <Polish>Pozycja AI w budynku</Polish>
             <Russian>Позиция ИИ в здании</Russian>
@@ -49,7 +49,7 @@
             <English>Invisible Target Soldier</English>
             <Czech>Neviditelný cíl (Voják)</Czech>
             <French>Cible invisible - Soldat</French>
-            <Spanish>Soldado Objetivo Invisible</Spanish>
+            <Spanish>Soldado objetivo invisible</Spanish>
             <Italian>Obiettivo invisibile - Soldato</Italian>
             <Polish>Żołnierz - niewidoczny cel</Polish>
             <Portuguese>Soldado alvo invisível</Portuguese>

--- a/addons/arrays/stringtable.xml
+++ b/addons/arrays/stringtable.xml
@@ -5,6 +5,7 @@
             <English>Community Base Addons - Arrays</English>
             <Czech>Community Base Addons - Pole</Czech>
             <French>Community Base Addons - Tableaux</French>
+            <Spanish>Community Base Addons - Arrays</Spanish>
             <Italian>Community Base Addons - Array</Italian>
             <Polish>Community Base Addons - Tablice</Polish>
             <Russian>Community Base Addons - Массивы</Russian>

--- a/addons/bitwise/stringtable.xml
+++ b/addons/bitwise/stringtable.xml
@@ -4,6 +4,7 @@
         <Key ID="STR_CBA_bitwise_Component">
             <English>Community Base Addons - Bitwise</English>
             <French>Community Base Addons - Bit par bit</French>
+            <Spanish>Community Base Addons - Operaciones de bits</Spanish>
             <Russian>Community Base Addons - Битовые операции</Russian>
             <German>Community Base Addons - Bitweise</German>
             <Korean>커뮤니티 베이스 애드온 - 비트 연산</Korean>

--- a/addons/characters/stringtable.xml
+++ b/addons/characters/stringtable.xml
@@ -5,6 +5,7 @@
             <English>Community Base Addons - Characters</English>
             <Czech>Community Base Addons - Postavy</Czech>
             <French>Community Base Addons - Personnages</French>
+            <Spanish>Community Base Addons - Personajes</Spanish>
             <Italian>Community Base Addons - Personaggi</Italian>
             <Polish>Community Base Addons - Postacie</Polish>
             <Russian>Community Base Addons - Персонажи</Russian>
@@ -18,6 +19,7 @@
             <English>Men (Malaria-Infected)</English>
             <Czech>Muži (Nakažení malárií)</Czech>
             <French>Hommes (Infectés par la malaria)</French>
+            <Spanish>Hombres (infectados de malaria)</Spanish>
             <Italian>Uomo (Infetto da malaria)</Italian>
             <Polish>Ludzie (Zainfekowani malarią)</Polish>
             <Russian>Люди (зараженные малярией)</Russian>

--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -5,6 +5,7 @@
             <English>Community Base Addons - Common Component</English>
             <Czech>Community Base Addons - Společná součást</Czech>
             <French>Community Base Addons - Composants communs</French>
+            <Spanish>Community Base Addons - Componente común</Spanish>
             <Italian>Community Base Addons - Componenti Comuni</Italian>
             <Polish>Community Base Addons - Ogólne Komponenty</Polish>
             <Russian>Community Base Addons - Общие компоненты</Russian>
@@ -19,6 +20,7 @@
             <English>CBA Weapons</English>
             <Czech>Zbraně CBA</Czech>
             <French>CBA Armes</French>
+            <Spanish>Armas de CBA</Spanish>
             <Italian>Armi CBA</Italian>
             <Polish>CBA Bronie</Polish>
             <Russian>CBA Оружие</Russian>
@@ -33,6 +35,7 @@
             <English>You must first start a mission.</English>
             <Czech>První musíte zapnout misi.</Czech>
             <French>Vous devez d'abord commencer une mission.</French>
+            <Spanish>Primero hay que iniciar una misión.</Spanish>
             <Italian>Prima devi far partire una missione.</Italian>
             <Polish>Należy najpierw uruchomić misję.</Polish>
             <Russian>Вначале необходимо запустить миссию.</Russian>

--- a/addons/diagnostic/stringtable.xml
+++ b/addons/diagnostic/stringtable.xml
@@ -20,7 +20,7 @@
             <English>4 Spaces</English>
             <Czech>4 mezery</Czech>
             <French>4 espaces</French>
-            <Spanish>4 Espacios</Spanish>
+            <Spanish>4 espacios</Spanish>
             <Italian>4 Spazi</Italian>
             <Polish>4 Spacje</Polish>
             <Russian>4 пробела</Russian>
@@ -34,7 +34,7 @@
             <English>Debug Console Indentation</English>
             <Czech>Odsazení ladící konzole</Czech>
             <French>Indentation dans la console de débogage</French>
-            <Spanish>Espaciado de la Consola de Depuración</Spanish>
+            <Spanish>Sangría de la consola de depuración</Spanish>
             <Italian>Indentazione console di debug</Italian>
             <Polish>Indentacja w konsoli debugowania</Polish>
             <Russian>Отступ консоли отладки</Russian>
@@ -48,7 +48,7 @@
             <English>Type of indentation that can be added to expression in the debug console by pressing Tab key or removed by pressing Shift + Tab.</English>
             <Czech>Typ odsazení, které lze přidat do výrazu v ladicí konzoli stisknutím klávesy Tab nebo odstranit stisknutím Shift + Tab.</Czech>
             <French>Type d'indentation qui peut être employée dans la console de débogage.\nTab ajoute une indentation, et Shift + Tab en supprime une.</French>
-            <Spanish>Tipo de sangría que se puede agregar a la expresión en la consola de depuración presionando la tecla Tab o eliminar presionando Shift + Tab</Spanish>
+            <Spanish>Tipo de sangría que se puede añadir a las expresiones de la consola de depuración pulsando la tecla Tab, o eliminar pulsando Mayús + Tab.</Spanish>
             <Italian>Il tipo di intentazione che può essere aggiunta all'espressione nella console di debug premendo il tasto Tab o rimossa premendo Shift + Tab</Italian>
             <Polish>Rodzaj indentacji która może być dodana do wyrażenia w konsoli debugowania za pomocą klawisza Tab lub usunięta za pomocą Shift + Tab.</Polish>
             <Russian>Тип отступа, который может быть добавлен к коду в консоли отладки нажатием клавиши Tab или убран нажатием клавиш Shift + Tab.</Russian>
@@ -62,7 +62,7 @@
             <English>Enable Target Debugging</English>
             <Czech>Zapnout cílové ladění</Czech>
             <French>Activer le débogage de la cible</French>
-            <Spanish>Activar Depuración de Objetivo</Spanish>
+            <Spanish>Activar la depuración de objetivos</Spanish>
             <Italian>Attiva il debug remoto</Italian>
             <Polish>Włącz debugowanie na celu</Polish>
             <Russian>Включить отладку цели</Russian>
@@ -92,7 +92,7 @@
             <English>Extended Debug Console</English>
             <Czech>Rozšířená ladící konzole</Czech>
             <French>Console de débogage étendue</French>
-            <Spanish>Consola Extendida de Depuración</Spanish>
+            <Spanish>Consola de depuración extendida</Spanish>
             <Italian>Console debug estesa</Italian>
             <Polish>Rozszerzona Konsola Debugowania</Polish>
             <Russian>Расширенная консоль отладки</Russian>
@@ -107,7 +107,7 @@
             <English>Next Statement</English>
             <Czech>Následující zpráva</Czech>
             <French>Déclaration suivante</French>
-            <Spanish>Expresión Siguiente</Spanish>
+            <Spanish>Expresión siguiente</Spanish>
             <Italian>Espressione Succ.</Italian>
             <Polish>Następne polecenie</Polish>
             <Russian>След. команда</Russian>
@@ -122,7 +122,7 @@
             <English>Previous Statement</English>
             <Czech>Předchozí zpráva</Czech>
             <French>Déclaration précédente</French>
-            <Spanish>Expresión Anterior</Spanish>
+            <Spanish>Expresión anterior</Spanish>
             <Italian>Espressione Prec.</Italian>
             <Polish>Poprzednie polecenie</Polish>
             <Russian>Пред. команда</Russian>
@@ -137,7 +137,7 @@
             <English>Target Exec</English>
             <Czech>Cílový exec</Czech>
             <French>Cible Exec</French>
-            <Spanish>Ejecutiva de Objetivo</Spanish>
+            <Spanish>Ejec. objetivo</Spanish>
             <Italian>Esegui Remoto</Italian>
             <Polish>Wykonaj na celu</Polish>
             <Russian>На цели</Russian>
@@ -152,6 +152,7 @@
             <English>Refresh rate target watcher field</English>
             <Czech>Pole cílového sledování obnovovací frekvence</Czech>
             <French>Taux de rafraîchissement champ de l'observateur cible</French>
+            <Spanish>Frecuencia de actualización de los campos de observación de objetivos</Spanish>
             <Russian>Частота обновления поля отслеживания цели</Russian>
             <German>Aktualisierungsrate für Zielüberwachungfelder</German>
             <Korean>대상 관찰자 필드 새로 고침 빈도</Korean>
@@ -163,6 +164,7 @@
             <English>Refresh rate (in seconds) for the CBA target watcher fields to the right of the debug console.</English>
             <Czech>Obnovovací frekvence (v sekundách) pro pole sledování cíle CBA napravo od konzole ladění.</Czech>
             <French>Taux de rafraîchissement (en secondes) des champs d'observation de la cible CBA à droite de la console de débogage.</French>
+            <Spanish>Frecuencia de actualización (en segundos) de los campos de observación de objetivos de CBA situados a la derecha de la consola de depuración.</Spanish>
             <Russian>Частота обновления в секундах для CBA полей отслеживания справа от консоли отладки.</Russian>
             <German>Aktualisierungsrate (in Sekunden) für die CBA-Zielüberwachungsfelder auf der rechten Seite der Debug-Konsole.</German>
             <Korean>디버그 콘솔 오른쪽에 있는 CBA의 대상 관찰자 필드의 새로 고침 빈도입니다. (초 단위)</Korean>

--- a/addons/disposable/stringtable.xml
+++ b/addons/disposable/stringtable.xml
@@ -5,6 +5,7 @@
             <English>Community Base Addons - Disposable Weapons</English>
             <Czech>Community Base Addons - Jednorázové zbraně</Czech>
             <French>Community Base Addons - Armes à usage unique</French>
+            <Spanish>Community Base Addons - Armas de un solo uso</Spanish>
             <Italian>Community Base Addons - Armi monouso</Italian>
             <Polish>Community Base Addons - Bronie jednorazowe</Polish>
             <Russian>Community Base Addons - Одноразовое оружие</Russian>
@@ -19,6 +20,7 @@
             <English>AI Only</English>
             <Czech>Pouze AI</Czech>
             <French>IA seulement</French>
+            <Spanish>Solo la IA</Spanish>
             <Italian>Solo AI</Italian>
             <Polish>Tylko AI</Polish>
             <Russian>Только ИИ</Russian>
@@ -33,6 +35,7 @@
             <English>Only AI drops the used disposable launcher.</English>
             <Czech>Pouze AI odhodí použitý jednorázový raketomet.</Czech>
             <French>Seules les unités IA lâchent leur lanceur après emploi.</French>
+            <Spanish>Solo la IA suelta el lanzador de un solo uso ya utilizado.</Spanish>
             <Italian>Solo le unità AI buttano il lanciatore usato.</Italian>
             <Polish>Tylko AI wyrzuca wyrzutnie jednorazową.</Polish>
             <Russian>Только ИИ выбрасывает использованный одноразовый гранатомёт.</Russian>
@@ -47,6 +50,7 @@
             <English>Never</English>
             <Czech>Nikdy</Czech>
             <French>Jamais</French>
+            <Spanish>Nunca</Spanish>
             <Italian>Mai</Italian>
             <Polish>Nigdy</Polish>
             <Russian>Никогда</Russian>
@@ -61,6 +65,7 @@
             <English>Don't automatically drop the used disposable launcher.</English>
             <Czech>Automaticky neodhazovat použitý jednorázový raketomet.</Czech>
             <French>Ne lâche jamais automatiquement le lanceur usagé.</French>
+            <Spanish>No soltar automáticamente el lanzador de un solo uso ya utilizado.</Spanish>
             <Italian>Non buttare automaticamente il lanciatore usato.</Italian>
             <Polish>Nie wyrzucaj automatycznie wyrzutni jednorazowej.</Polish>
             <Russian>Не выбрасывать автоматически использованный одноразовый гранатомёт.</Russian>
@@ -75,6 +80,7 @@
             <English>Selected Another Weapon</English>
             <Czech>Vybrána jiná zbraň</Czech>
             <French>Si autre arme sélectionnée</French>
+            <Spanish>Al seleccionar otra arma</Spanish>
             <Italian>Seleziona un'altra arma</Italian>
             <Polish>Wybierz inną Broń</Polish>
             <Russian>Выбрано другое оружие</Russian>
@@ -89,6 +95,7 @@
             <English>Automatically drop the used disposable launcher as soon as another weapon is selected.</English>
             <Czech>Automaticky odhodit použitý jednorázový raketomet, jakmile je zvolena jiná zbraň.</Czech>
             <French>Lâche automatiquement le lanceur usagé dès qu'une autre arme est sélectionnée.</French>
+            <Spanish>Suelta automáticamente el lanzador de un solo uso ya utilizado en cuanto se selecciona otra arma.</Spanish>
             <Italian>Butta automaticamente il lanciatore usato non appena un'altra arma viene selezionata</Italian>
             <Polish>Automatycznie wyrzucaj wyrzutnie jednorazową gdy tylko zostanie wybrana kolejna broń.</Polish>
             <Russian>Автоматически выбрасывать использованный одноразовый гранатомёт, как только будет выбрано другие оружие.</Russian>
@@ -103,6 +110,7 @@
             <English>Drop Used Disposable Launcher</English>
             <Czech>Odhodit použitý jednorázový raketomet</Czech>
             <French>Lâcher le lanceur usagé</French>
+            <Spanish>Soltar el lanzador de un solo uso utilizado</Spanish>
             <Italian>Butta lanciatore usato</Italian>
             <Polish>Wyrzuć zużyty przedmiot</Polish>
             <Russian>Выбрасывать использованный одноразовый гранатомёт</Russian>
@@ -117,6 +125,7 @@
             <English>Replace Disposable Launcher</English>
             <Czech>Vyměnit jednorázový raketomet</Czech>
             <French>Remplacer le lanceur à usage unique</French>
+            <Spanish>Sustituir los lanzadores de un solo uso</Spanish>
             <Italian>Sostituisci lanciatore monouso</Italian>
             <Polish>Zamien wyrzutnie jednorazową</Polish>
             <Russian>Заменять одноразовые гранатомёты</Russian>
@@ -131,6 +140,7 @@
             <English>If enabled, disposable launchers can only be used once. Ammunition for disposable launchers in containers and vehicles will be replaced with loaded disposable launchers. If disabled, disposable launchers can be reloaded after use.</English>
             <Czech>Pokud je tato možnost zapnuta, jednorázové raketomety mohou být použity pouze jednou. Munice pro jednorázové raketomety v bednách a vozidlech budou vyměněny za nabité jednorázové raketomety. Pokud je tato možnost vypnuta, jednorázové raketomety mohou být přebity po použití.</Czech>
             <French>Si activé, les lanceurs à usage unique ne peuvent être utilisés qu'une seule fois. Les munitions pour lanceurs à usage unique situés dans les conteneurs et les véhicules seront remplacées par des lanceurs à usage unique chargés. Si désactivé, les lanceurs à usage unique peuvent être rechargés après emploi.</French>
+            <Spanish>Si se activa, los lanzadores de un solo uso solo pueden emplearse una vez. La munición para lanzadores de un solo uso que haya en contenedores y vehículos se sustituirá por lanzadores de un solo uso cargados. Si se desactiva, los lanzadores de un solo uso pueden recargarse tras su uso.</Spanish>
             <Italian>Se abilitato, i lanciatori monouso possono essere usati una sola volta. Le munizioni per i lanciatori monouso che si trovano nei contenitori e nei veicoli saranno sostituiti con lanciatori monouso carichi. Se disabilitato, i lanciatori monouso possono essere ricaricati dopo l'uso.</Italian>
             <Polish>Gdy ta opcja jest włączona wyrzutnie jednorazowe mogą być użyte tylko raz, Amunicja do wyrzutni jednorazowych dostępna w kontenerach i pojazdach zostanie zamieniona w załadowaną wyrzutnie jednorazową. Jeżeli ta opcja jest wyłączona, wtedy wyrzutnie jednorazowe nie zostaną przeładowane po użyciu.</Polish>
             <Russian>Если включено, одноразовые гранатомёты могут быть использованы лишь один раз. Боеприпасы для них в контейнерах и технике будут заменены на соответствующие им заряженные одноразовые гранатомёты. Если выключено, одноразовые гранатомёты могут быть перезаряжены и использованы повторно.</Russian>

--- a/addons/events/stringtable.xml
+++ b/addons/events/stringtable.xml
@@ -5,6 +5,7 @@
             <English>Community Base Addons - Events</English>
             <Czech>Community Base Addons - Události</Czech>
             <French>Community Base Addons - Événements</French>
+            <Spanish>Community Base Addons - Eventos</Spanish>
             <Italian>Community Base Addons - Eventi</Italian>
             <Polish>Community Base Addons - Zdarzenia</Polish>
             <Russian>Community Base Addons - События</Russian>
@@ -19,6 +20,7 @@
             <English>Weapon Repetition Mode</English>
             <Czech>Mód opakování zbraně</Czech>
             <French>Mode de réarmement</French>
+            <Spanish>Modo de repetición del arma</Spanish>
             <Italian>Modalità di ricarica dell'arma</Italian>
             <Polish>Tryb powtarzania strzału</Polish>
             <Russian>Режим повторной стрельбы</Russian>
@@ -33,6 +35,7 @@
             <English>Leave Optics View</English>
             <Czech>Opustit pohled optiky</Czech>
             <French>Maintenir vue lunette</French>
+            <Spanish>Salir de la vista de la óptica</Spanish>
             <Italian>Esci dalla vista ottica</Italian>
             <Polish>Opuszczenie optyki</Polish>
             <Russian>Выход из прицела</Russian>
@@ -47,6 +50,7 @@
             <English>Bolt or rack weapon by leaving optics view.</English>
             <Czech>Natáhnout zbraň opuštěním pohledu optiky.</Czech>
             <French>Réarme l'arme tout en maintenant la visée dans la lunette.</French>
+            <Spanish>Acciona el cerrojo o la corredera del arma al salir de la vista de la óptica.</Spanish>
             <Italian>Ricarica l'arma uscendo dalla vista dell'ottica.</Italian>
             <Polish>Przeładowanie/ryglowanie broni nastąpi po opuszczeniu widoku optyki.</Polish>
             <Russian>Перезаряжать оружие после выхода из прицела.</Russian>
@@ -61,6 +65,7 @@
             <English>Mode of bolting or pumping weapons.</English>
             <Czech>Mód natahování nebo pumpování zbraní.</Czech>
             <French>Mode de réarmement des armes à verrou et à pompe.</French>
+            <Spanish>Modo de accionamiento del cerrojo o de la corredera de las armas.</Spanish>
             <Italian>Modalità di ricarica o riarmo delle armi.</Italian>
             <Polish>Tryb przeładowania/ryglowania broni po wystrzale.</Polish>
             <Russian>Режим повторной стрельбы помпового оружия или оружия с продольно-скользящим затвором.</Russian>
@@ -75,6 +80,7 @@
             <English>Press Trigger</English>
             <Czech>Zmáčknout spoušť</Czech>
             <French>Presser la détente</French>
+            <Spanish>Apretar el gatillo</Spanish>
             <Italian>Premi il grilletto</Italian>
             <Polish>Wciśnięcie spustu</Polish>
             <Russian>Нажатие курка</Russian>
@@ -89,6 +95,7 @@
             <English>Bolt or rack weapon by pressing the trigger again.</English>
             <Czech>Natáhnout zbraň dalším zmáčkutím spouště.</Czech>
             <French>Réarme l'arme en pressant la détente encore une fois.</French>
+            <Spanish>Acciona el cerrojo o la corredera del arma al volver a apretar el gatillo.</Spanish>
             <Italian>Ricarica l'arma premendo nuovamente il grilletto</Italian>
             <Polish>Przeładowanie/ryglowanie nastąpi po ponownym wciśnięciu spustu.</Polish>
             <Russian>Перезаряжать оружие повторным нажатием на курок.</Russian>
@@ -103,6 +110,7 @@
             <English>Release Trigger</English>
             <Czech>Pustit spoušť</Czech>
             <French>Relâcher la détente</French>
+            <Spanish>Soltar el gatillo</Spanish>
             <Italian>Rilascia il grilletto</Italian>
             <Polish>Puszczenie spustu</Polish>
             <Russian>Отпускание курка</Russian>
@@ -117,6 +125,7 @@
             <English>Bolt or rack weapon by releasing trigger (hold trigger to prevent immediate action).</English>
             <Czech>Natáhnout zbraň puštěním spouště (podržte spoušť k zabránění okamžitému natáhnutí zbraně).</Czech>
             <French>Réarme l'arme au relâchement de la détente (maintenir la détente enfoncée pour éviter le réarmement immédiat).</French>
+            <Spanish>Acciona el cerrojo o la corredera del arma al soltar el gatillo (mantener el gatillo apretado para evitar el accionamiento inmediato).</Spanish>
             <Italian>Ricarica l'arma rilasciando il grilletto (mantieni premuto il grilletto per prevenire la ricarica immediata).</Italian>
             <Polish>Przeładowanie/ryglowanie nastąpi po puszczeniu spustu (przytrzymaj spust aby nie przełdowywać).</Polish>
             <Russian>Перезаряжать оружие после отпускания курка (держите курок чтобы не перезаряжать).</Russian>

--- a/addons/hashes/stringtable.xml
+++ b/addons/hashes/stringtable.xml
@@ -5,6 +5,7 @@
             <English>Community Base Addons - Hashes</English>
             <Czech>Community Base Addons - Hashe</Czech>
             <French>Community Base Addons - Hashes</French>
+            <Spanish>Community Base Addons - Hashes</Spanish>
             <Italian>Community Base Addons - Hash</Italian>
             <Polish>Community Base Addons - Hashe</Polish>
             <Russian>Community Base Addons - Хэши</Russian>

--- a/addons/help/stringtable.xml
+++ b/addons/help/stringtable.xml
@@ -21,7 +21,7 @@
             <English>Credits</English>
             <Czech>Tvůrci</Czech>
             <French>Credits</French>
-            <Spanish>Credits</Spanish>
+            <Spanish>Créditos</Spanish>
             <Italian>Riconoscimenti</Italian>
             <Polish>Twórcy</Polish>
             <Russian>Создатели</Russian>
@@ -37,6 +37,7 @@
             <English>Community Base Addons - Help</English>
             <Czech>Community Base Addons - Pomoc</Czech>
             <French>Community Base Addons - Aide</French>
+            <Spanish>Community Base Addons - Ayuda</Spanish>
             <Italian>Community Base Addons - Aiuto</Italian>
             <Polish>Community Base Addons - Pomoc</Polish>
             <Portuguese>Extensões de Base Comunitária - Ajuda</Portuguese>
@@ -52,7 +53,7 @@
             <English>Keybindings</English>
             <Czech>Klávesy</Czech>
             <French>Raccourcis clavier</French>
-            <Spanish>Keybindings</Spanish>
+            <Spanish>Atajos de teclado</Spanish>
             <Italian>Tasti</Italian>
             <Polish>Klawisze</Polish>
             <Russian>Назначения клавиш</Russian>

--- a/addons/jam/stringtable.xml
+++ b/addons/jam/stringtable.xml
@@ -5,7 +5,7 @@
             <English>Caliber: 7.62x51 mm&lt;br/&gt;Rounds: 150</English>
             <Czech>Ráže: 7.62x51 mm&lt;br/&gt;Munice: 150</Czech>
             <French>Calibre: 7,62x51 mm&lt;br/&gt;Munitions: 150</French>
-            <Spanish>Calibre: 7,62x51 mm&lt;br/&gt;Cargas: 150</Spanish>
+            <Spanish>Calibre: 7,62x51 mm&lt;br/&gt;Cartuchos: 150</Spanish>
             <Italian>Calibro: 7,62x51 mm&lt;br/&gt;Munizioni: 150</Italian>
             <Polish>Kaliber: 7,62x51 mm&lt;br/&gt;Pociski: 150</Polish>
             <Portuguese>Calibre: 7,62 x 51 mm&lt;br/&gt;Balas: 150r</Portuguese>
@@ -21,7 +21,7 @@
             <English>Caliber: 7.62x51 mm Tracer - Green&lt;br/&gt;Rounds: 150</English>
             <Czech>Ráže: 7.62x51 mm stopovky - zelené&lt;br/&gt;Munice: 150</Czech>
             <French>Calibre: 7,62x51 mm traçant - Vert&lt;br/&gt;Munitions: 150</French>
-            <Spanish>Calibre: 7,62x51 mm trazadora (verde)&lt;br/&gt;Cargas: 150</Spanish>
+            <Spanish>Calibre: 7,62x51 mm trazadora - verde&lt;br/&gt;Cartuchos: 150</Spanish>
             <Italian>Calibro: tracciante 7,62x51 mm - verde&lt;br /&gt;Munizioni: 150</Italian>
             <Polish>Kaliber: 7,62x51 mm smugowy - zielony&lt;br/&gt;Pociski: 150</Polish>
             <Portuguese>Calibre: Traçante 7,62 x 51 mm – Verde&lt;br/&gt;Balas: 150r</Portuguese>
@@ -37,6 +37,7 @@
             <English>Community Base Addons - Joint Ammo Magazines</English>
             <Czech>Community Base Addons - Společné zásobníky a munice</Czech>
             <French>Community Base Addons - Munitions et chargeurs</French>
+            <Spanish>Community Base Addons - Munición y cargadores compartidos</Spanish>
             <Polish>Community Base Addons - Wspólna Amunicja oraz Magazynki</Polish>
             <Russian>Community Base Addons - Общие патроны и магазины</Russian>
             <German>Community Base Addons - Gemeinsame Munition und Magazine</German>

--- a/addons/jr/stringtable.xml
+++ b/addons/jr/stringtable.xml
@@ -5,6 +5,7 @@
             <English>Community Base Addons - Joint Rails</English>
             <Czech>Community Base Addons - Joint Rails</Czech>
             <French>Community Base Addons - Rails d'accessoires</French>
+            <Spanish>Community Base Addons - Rieles de montaje compartidos</Spanish>
             <Italian>Community Base Addons - Joint Rails</Italian>
             <Polish>Community Base Addons - Wspólne Szyny Montażowe</Polish>
             <Russian>Community Base Addons - Система Joint Rails</Russian>
@@ -19,7 +20,7 @@
             <English>Sound Suppressor MG</English>
             <Czech>Tlumič hluku MG</Czech>
             <French>Silencieux pour mitrailleuse</French>
-            <Spanish>Silenciador MG</Spanish>
+            <Spanish>Silenciador para ametralladora</Spanish>
             <Italian>Silenziatore MG</Italian>
             <Polish>Tłumik KM</Polish>
             <Portuguese>Metralhadora silenciador</Portuguese>

--- a/addons/keybinding/stringtable.xml
+++ b/addons/keybinding/stringtable.xml
@@ -5,6 +5,7 @@
             <English>Community Base Addons - Keybinding</English>
             <Czech>Community Base Addons - Klávesy</Czech>
             <French>Community Base Addons - Configuration des touches</French>
+            <Spanish>Community Base Addons - Atajos de teclado</Spanish>
             <Italian>Community Base Addons - Configurazione Tasti</Italian>
             <Polish>Community Base Addons - Klawisze</Polish>
             <Portuguese>Extensões de Base Comunitária - Configuração de Chaves</Portuguese>
@@ -20,6 +21,7 @@
             <English>Configure Addons</English>
             <Czech>Konfigurovat addony</Czech>
             <French>Configurer les addons</French>
+            <Spanish>Configurar los addons</Spanish>
             <Italian>Configura gli addon</Italian>
             <Polish>Konfiguracja addonów</Polish>
             <Portuguese>Configure as Extensões</Portuguese>
@@ -35,6 +37,7 @@
             <English>Configure Base</English>
             <Czech>Konfigurovat základ</Czech>
             <French>Configurer la base</French>
+            <Spanish>Configurar el juego base</Spanish>
             <Italian>Configura il gioco base</Italian>
             <Polish>Konfiguracja bazy</Polish>
             <Portuguese>Configure as Bases</Portuguese>
@@ -50,6 +53,7 @@
             <English>Unknown Key %1</English>
             <Czech>Neznámá klávesa %1</Czech>
             <French>Touche inconnue %1</French>
+            <Spanish>Tecla desconocida %1</Spanish>
             <Italian>"%1" è un tasto sconosciuto</Italian>
             <Polish>Nieznany klawisz %1</Polish>
             <Portuguese>Chave desconhecida %1</Portuguese>

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -5,6 +5,7 @@
             <English>CBA Team</English>
             <Czech>CBA tým</Czech>
             <French>Équipe CBA</French>
+            <Spanish>CBA Team</Spanish>
             <Italian>Squadra CBA</Italian>
             <Polish>Zespół CBA</Polish>
             <Portuguese>Time CBA</Portuguese>
@@ -20,6 +21,7 @@
             <English>ADDON:</English>
             <Czech>ADDON:</Czech>
             <French>ADDON:</French>
+            <Spanish>ADDON:</Spanish>
             <Italian>ADDON:</Italian>
             <Polish>ADDON:</Polish>
             <Russian>Дополнение:</Russian>
@@ -34,6 +36,7 @@
             <English>Community Base Addons - Main Component</English>
             <Czech>Community Base Addons - Hlavní součást</Czech>
             <French>Community Base Addons - Composant principal</French>
+            <Spanish>Community Base Addons - Componente principal</Spanish>
             <Italian>Community Base Addons - Componente Principale</Italian>
             <Polish>Community Base Addons - Główny Komponent</Polish>
             <Portuguese>Extensões de Base Comunitária - Componente Principal</Portuguese>
@@ -49,6 +52,7 @@
             <English>Community Base Addons</English>
             <Czech>Community Base Addons</Czech>
             <French>Community Base Addons</French>
+            <Spanish>Community Base Addons</Spanish>
             <Italian>Community Base Addons</Italian>
             <Polish>Community Base Addons</Polish>
             <Portuguese>Extensões de Base Comunitária</Portuguese>
@@ -64,6 +68,7 @@
             <English>Community Base Addons - Optional Component</English>
             <Czech>Community Base Addons - Volitelná součást</Czech>
             <French>Community Base Addons - Composant facultatif</French>
+            <Spanish>Community Base Addons - Componente opcional</Spanish>
             <Italian>Community Base Addons - Componente Opzionale</Italian>
             <Polish>Community Base Addons - Komponent Opcjonalny</Polish>
             <Portuguese>Extensões de Base Comunitária - Componente Opcional</Portuguese>

--- a/addons/modules/stringtable.xml
+++ b/addons/modules/stringtable.xml
@@ -5,6 +5,7 @@
             <English>Allow Override</English>
             <Czech>Povolit přepsání</Czech>
             <French>Autoriser l'écrasement</French>
+            <Spanish>Permitir anulación</Spanish>
             <Italian>Permettere Sovrascrittura</Italian>
             <Polish>Zezwalaj na nadpisanie</Polish>
             <Russian>Разрешить Переопределение</Russian>
@@ -19,6 +20,7 @@
             <English>Allow the module to remove old waypoints and assign an attack waypoint</English>
             <Czech>Povolit modulu odstranit staré waypointy a přiřadit waypoint k útoku</Czech>
             <French>Permettre au module de supprimer les anciens points de passage et à attribuer un point de passage d'attaque.</French>
+            <Spanish>Permite que el módulo elimine los puntos de ruta anteriores y asigne un punto de ruta de ataque</Spanish>
             <Italian>Permette al modulo di togliere waypoint precedenti e assegnarne uno di attacco.</Italian>
             <Polish>Zezwalaj aby moduł nadpisał stare punkty nawigacyjnych rozkazem ataku</Polish>
             <Russian>Разрешить модулю удалять старые путевые точки и назначать путевую точку атаки</Russian>
@@ -33,6 +35,7 @@
             <English>Array</English>
             <Czech>Pole</Czech>
             <French>Tableau</French>
+            <Spanish>Array</Spanish>
             <Italian>Array</Italian>
             <Polish>Tablica</Polish>
             <Russian>Массив</Russian>
@@ -47,6 +50,7 @@
             <English>Attack</English>
             <Czech>Útok</Czech>
             <French>Attaquer</French>
+            <Spanish>Ataque</Spanish>
             <Italian>Attaccare</Italian>
             <Polish>Atak</Polish>
             <Russian>Атака</Russian>
@@ -61,6 +65,7 @@
             <English>Attack Location Type</English>
             <Czech>Typ lokace útoku</Czech>
             <French>Type du lieu d'attaque</French>
+            <Spanish>Tipo de posición de ataque</Spanish>
             <Italian>Tipo di posizione per l'attacco</Italian>
             <Polish>Typ lokalizacji ataku</Polish>
             <Russian>Тип Местоположения Атаки</Russian>
@@ -75,6 +80,7 @@
             <English>Set what kind of object is being passed as the center point</English>
             <Czech>Určit, jaký typ objektu je nastaven jako centrální bod</Czech>
             <French>Définit quel type d'objet est passé comme point central.</French>
+            <Spanish>Define qué tipo de objeto se pasa como punto central</Spanish>
             <Italian>Scegliere quale oggetto passare al punto centrale</Italian>
             <Polish>Określ jaki obiekt jest przekazywany jako punkt centralny</Polish>
             <Russian>Укажите, какой объект передаётся как центральная точка</Russian>
@@ -89,6 +95,7 @@
             <English>Sync to leader of group to attack a parsed location</English>
             <Czech>Synchronizovat s velitelem skupiny k útoku na danou lokaci</Czech>
             <French>Synchroniser avec un chef du groupe pour attaquer un emplacement désigné.</French>
+            <Spanish>Sincronizar con el líder del grupo para atacar la posición indicada</Spanish>
             <Italian>Sincronizza con un capogruppo per attaccare una posizione designata.</Italian>
             <Polish>Zsynchronizuj z liderem grupy aby zaatakować określoną lokalizacje</Polish>
             <Russian>Синхронизируйте с лидером группы, чтобы атаковать указанное местоположение</Russian>
@@ -103,6 +110,7 @@
             <English>Attack Position</English>
             <Czech>Pozice útoku</Czech>
             <French>Position de l'attaque</French>
+            <Spanish>Posición de ataque</Spanish>
             <Italian>Posizione per l'attacco</Italian>
             <Polish>Pozycja Ataku</Polish>
             <Russian>Позиция Атаки</Russian>
@@ -117,6 +125,7 @@
             <English>Enter an array with brackets or name without quotes</English>
             <Czech>Zadejte pole hodnot se závorkami nebo jméno bez závorek</Czech>
             <French>Entrer un tableau avec des crochets ou un nom sans guillemets.</French>
+            <Spanish>Introducir un array entre corchetes o un nombre sin comillas</Spanish>
             <Italian>Inserire un array in parentesi quadre o nome in doppi apici.</Italian>
             <Polish>Wprowadź tablicę wraz z nawiasami lub nazwę bez cudzysłowów</Polish>
             <Russian>Введите массив с помощью скобок или имя без кавычек</Russian>
@@ -131,6 +140,7 @@
             <English>Patrol Chance</English>
             <Czech>Šance hlídky</Czech>
             <French>Chance de patrouiller</French>
+            <Spanish>Probabilidad de patrullar</Spanish>
             <Italian>Probabilità di pattugliare</Italian>
             <Polish>Szasna na Patrol</Polish>
             <Russian>Шанс Патрулирования</Russian>
@@ -145,6 +155,7 @@
             <English>Chance for each unit to patrol instead of garrison</English>
             <Czech>Šance, že bude jednotka hlídkovat (místo tvorby opevnění)</Czech>
             <French>Probabilité pour chaque unité de patrouiller au lieu de rester en garnison.</French>
+            <Spanish>Probabilidad de que cada unidad patrulle en lugar de guarnecerse</Spanish>
             <Italian>Probabilità per ogni unità di pattugliare invece che presidiare.</Italian>
             <Polish>Szansa dla każdej jednostki na to że przeprowadzi patrol zamiast garnizonowania budynku</Polish>
             <Russian>Шанс для каждого подразделения пойти патрулировать, вместо того, чтобы находиться в гарнизоне</Russian>
@@ -159,6 +170,7 @@
             <English>CBA Modules</English>
             <Czech>CBA Moduly</Czech>
             <French>CBA - Modules</French>
+            <Spanish>Módulos de CBA</Spanish>
             <Italian>CBA - Moduli</Italian>
             <Polish>Moduły CBA</Polish>
             <Russian>Модули CBA</Russian>
@@ -173,6 +185,7 @@
             <English>Community Base Addons - Modules</English>
             <Czech>Community Base Addons - Moduly</Czech>
             <French>Community Base Addons - Modules</French>
+            <Spanish>Community Base Addons - Módulos</Spanish>
             <Italian>Community Base Addons - Moduli</Italian>
             <Polish>Community Base Addons - Komponent Modułów</Polish>
             <Russian>Community Base Addons - Компонент Модулей</Russian>
@@ -187,6 +200,7 @@
             <English>Defend</English>
             <Czech>Bránit</Czech>
             <French>Défendre</French>
+            <Spanish>Defensa</Spanish>
             <Italian>Difendere</Italian>
             <Polish>Obrona</Polish>
             <Russian>Оборона</Russian>
@@ -201,6 +215,7 @@
             <English>Sync to leader of group to defend a parsed location</English>
             <Czech>Synchronizovat s velitelem skupiny k obraně dané lokace</Czech>
             <French>Synchroniser avec un chef du groupe pour défendre un emplacement désigné.</French>
+            <Spanish>Sincronizar con el líder del grupo para defender la posición indicada</Spanish>
             <Italian>Sincronizza con un capogruppo per difendere una posizione designata.</Italian>
             <Polish>Zsynchronizuj z liderem grupy aby bronić określonej lokalizacji</Polish>
             <Russian>Синхронизируйте с лидером группы, чтобы защищать указанное местоположение</Russian>
@@ -215,6 +230,7 @@
             <English>Defend Position</English>
             <Czech>Bránit pozici</Czech>
             <French>Position de la défense</French>
+            <Spanish>Posición a defender</Spanish>
             <Italian>Difendere Posizione</Italian>
             <Polish>Pozycja Obronna</Polish>
             <Russian>Защищать Позицию</Russian>
@@ -229,6 +245,7 @@
             <English>Defend Position Type</English>
             <Czech>Typ pozice útoku</Czech>
             <French>Type du lieu à défendre</French>
+            <Spanish>Tipo de posición a defender</Spanish>
             <Italian>Tipo di posizione per la difesa</Italian>
             <Polish>Rodzaj Pozycji Obronnej</Polish>
             <Russian>Тип Позиции Защиты</Russian>
@@ -243,6 +260,7 @@
             <English>Set what kind of object is being passed as the center point</English>
             <Czech>Určit, jaký typ objektu je nastaven jako centrální bod</Czech>
             <French>Définit quel type d'objet est passé comme point central.</French>
+            <Spanish>Define qué tipo de objeto se pasa como punto central</Spanish>
             <Italian>Scegliere quale oggetto passare al punto centrale</Italian>
             <Polish>Określ jaki obiekt jest przekazywany jako punkt centralny obrony</Polish>
             <Russian>Установить, какой тип объекта будет передан как центральная точка</Russian>
@@ -257,6 +275,7 @@
             <English>Enter an array with brackets or name without quotes</English>
             <Czech>Zadejte pole hodnot se závorkami nebo jméno bez závorek</Czech>
             <French>Entrer un tableau avec des crochets ou un nom sans guillemets.</French>
+            <Spanish>Introducir un array entre corchetes o un nombre sin comillas</Spanish>
             <Italian>Inserire un array in parentesi quadre o nome in doppi apici.</Italian>
             <Polish>Wprowadź tablicę wraz z nawiasami lub nazwę bez cudzysłowów</Polish>
             <Russian>Введите массив с помощью скобок или имя без кавычек</Russian>
@@ -271,6 +290,7 @@
             <English>Defend Radius</English>
             <Czech>Rádius obrany</Czech>
             <French>Rayon de défense</French>
+            <Spanish>Radio de defensa</Spanish>
             <Italian>Raggio di Difesa</Italian>
             <Polish>Obszar Obrony</Polish>
             <Russian>Радиус Защиты</Russian>
@@ -285,6 +305,7 @@
             <English>The max distance to defend from the center point</English>
             <Czech>Maximální vzdálenost obrany od centrálního bodu</Czech>
             <French>Définit la distance maximale à défendre, en partant du point central.</French>
+            <Spanish>Distancia máxima a la que defender desde el punto central</Spanish>
             <Italian>Distanza massima dal punto centrale entro cui difendere.</Italian>
             <Polish>Maksymalny dystans od punktu centralnego na jakim będzie prowadzona obrona</Polish>
             <Russian>Максимальное расстояние для защиты от центральной точки</Russian>
@@ -299,6 +320,7 @@
             <English>Code to Execute</English>
             <Czech>Kód k vykonání</Czech>
             <French>Code à exécuter</French>
+            <Spanish>Código a ejecutar</Spanish>
             <Italian>Codice da eseguire</Italian>
             <Polish>Kod do wykonania</Polish>
             <Russian>Код для Выполнения</Russian>
@@ -313,6 +335,7 @@
             <English>Any code to run at waypoints</English>
             <Czech>Jakýkoliv kód, který bude vykonán na waypointech</Czech>
             <French>Tout code à exécuter aux points de passage.</French>
+            <Spanish>Código que se ejecutará en los puntos de ruta</Spanish>
             <Italian>Codice da eseguire alla destinazione.</Italian>
             <Polish>Kod do wykonania po osiągnięciu punktów nawigacyjnych</Polish>
             <Russian>Любой код для запуска в путевых точках</Russian>
@@ -327,6 +350,7 @@
             <English>Group</English>
             <Czech>Skupina</Czech>
             <French>Groupe</French>
+            <Spanish>Grupo</Spanish>
             <Italian>Gruppo</Italian>
             <Polish>Grupa</Polish>
             <Russian>Группа</Russian>
@@ -341,6 +365,7 @@
             <English>Loiter</English>
             <Czech>Postávat</Czech>
             <French>Flâner</French>
+            <Spanish>Merodear</Spanish>
             <Italian>Indugiare</Italian>
             <Polish>Krąż</Polish>
             <Russian>Слоняться без дела</Russian>
@@ -355,6 +380,7 @@
             <English>Marker</English>
             <Czech>Značka</Czech>
             <French>Marqueur</French>
+            <Spanish>Marcador</Spanish>
             <Italian>Indicatore</Italian>
             <Polish>Marker</Polish>
             <Russian>Маркер</Russian>
@@ -369,6 +395,7 @@
             <English>Module Position</English>
             <Czech>Pozice modulu</Czech>
             <French>Position du module</French>
+            <Spanish>Posición del módulo</Spanish>
             <Italian>Posizione del modulo</Italian>
             <Polish>Pozycja Modułu</Polish>
             <Russian>Расположение Модуля</Russian>
@@ -383,6 +410,7 @@
             <English>Move</English>
             <Czech>Pohyb</Czech>
             <French>Se déplacer</French>
+            <Spanish>Mover</Spanish>
             <Italian>Muovere</Italian>
             <Polish>Przemieść</Polish>
             <Russian>Выдвинуться</Russian>
@@ -397,6 +425,7 @@
             <English>Object/Location</English>
             <Czech>Objekt/Lokace</Czech>
             <French>Objet/Lieu</French>
+            <Spanish>Objeto/Localización</Spanish>
             <Italian>Posizione oggetto</Italian>
             <Polish>Obiekt/Lokacja</Polish>
             <Russian>Объект/Локация</Russian>
@@ -411,6 +440,7 @@
             <English>Patrol</English>
             <Czech>Hlídka</Czech>
             <French>Patrouille</French>
+            <Spanish>Patrulla</Spanish>
             <Italian>Pattugliare</Italian>
             <Polish>Patrol</Polish>
             <Russian>Патрулирование</Russian>
@@ -425,6 +455,7 @@
             <English>Patrol Center Type</English>
             <Czech>Typ centra hlídky</Czech>
             <French>Type du centre de patrouille</French>
+            <Spanish>Tipo de punto central de la patrulla</Spanish>
             <Italian>Tipo del centro del pattugliamento</Italian>
             <Polish>Patrol - rodzaj centrum</Polish>
             <Russian>Патрулирование - Тип Центра</Russian>
@@ -439,6 +470,7 @@
             <English>Set what kind of object is being passed as the center point</English>
             <Czech>Určit, jaký typ objektu je nastaven jako centrální bod</Czech>
             <French>Définit quel type d'objet est passé comme point central.</French>
+            <Spanish>Define qué tipo de objeto se pasa como punto central</Spanish>
             <Italian>Imposta il tipo di oggetto che viene usato come punto centrale.</Italian>
             <Polish>Określ jaki obiekt jest przekazowany jako punkt centralny patrolu</Polish>
             <Russian>Укажите, какой тип объекта будет передан как центральная точка</Russian>
@@ -453,6 +485,7 @@
             <English>Sync to leader of group to patrol a parsed location</English>
             <Czech>Synchronizovat s velitelem skupiny k hlídkování v dané lokaci</Czech>
             <French>Synchroniser avec un chef du groupe pour défendre un emplacement désigné.</French>
+            <Spanish>Sincronizar con el líder del grupo para patrullar la posición indicada</Spanish>
             <Italian>Sincronizza con un capogruppo per pattugliare una posizione designata.</Italian>
             <Polish>Zsynchronizuj z liderem grupy aby patrolować określoną lokalizację</Polish>
             <Russian>Синхронизируйте с лидером группы, чтобы патрулировать указанное местоположение</Russian>
@@ -467,6 +500,7 @@
             <English>Center Point</English>
             <Czech>Centrální bod</Czech>
             <French>Point central</French>
+            <Spanish>Punto central</Spanish>
             <Italian>Punto Centrale</Italian>
             <Polish>Punkt Centralny</Polish>
             <Russian>Центральная точка</Russian>
@@ -481,6 +515,7 @@
             <English>Enter an array with brackets or name without quotes</English>
             <Czech>Zadejte pole hodnot se závorkami nebo jméno bez závorek</Czech>
             <French>Entrer un tableau avec des crochets ou un nom sans guillemets.</French>
+            <Spanish>Introducir un array entre corchetes o un nombre sin comillas</Spanish>
             <Italian>Inserire un array in parentesi quadre o nome in doppi apici.</Italian>
             <Polish>Wprowadź tablicę wraz z nawiasami lub nazwę bez cudzysłowów</Polish>
             <Russian>Введите массив с помощью скобок или имя без кавычек</Russian>
@@ -495,6 +530,7 @@
             <English>Patrol Radius</English>
             <Czech>Rádius hlídky</Czech>
             <French>Rayon de patrouille</French>
+            <Spanish>Radio de patrulla</Spanish>
             <Italian>Raggio di Pattugliamento</Italian>
             <Polish>Obszar Patrolu</Polish>
             <Russian>Радиус патрулирования</Russian>
@@ -509,6 +545,7 @@
             <English>The distance to patrol from the center point</English>
             <Czech>Nastavit vzdálenost od centrálního bodu k hlídce</Czech>
             <French>La distance à parcourir en patrouille depuis le point central.</French>
+            <Spanish>Distancia a la que patrullar desde el punto central</Spanish>
             <Italian>La distanza da pattugliare dal punto centrale.</Italian>
             <Polish>Rozmar obszaru do Patrolowania w okół punktu centralnego</Polish>
             <Russian>На какое расстояние будет происходить патрулирование от центральной точки</Russian>
@@ -523,6 +560,7 @@
             <English>Seek and Destroy</English>
             <Czech>Najít a zničit</Czech>
             <French>Rechercher et détruire</French>
+            <Spanish>Buscar y destruir</Spanish>
             <Italian>Cercare e Distruggere</Italian>
             <Polish>Znajdź i zniszcz</Polish>
             <Russian>Найти и уничтожить</Russian>
@@ -537,6 +575,7 @@
             <English>Search Radius</English>
             <Czech>Rádius hledání</Czech>
             <French>Rayon de recherche</French>
+            <Spanish>Radio de búsqueda</Spanish>
             <Italian>Raggio di ricerca</Italian>
             <Polish>Obszar Przeszukania</Polish>
             <Russian>Радиус поиска</Russian>
@@ -551,6 +590,7 @@
             <English>Enter a number for size of the radius to search</English>
             <Czech>Vložte číslo pro velikost rádiu hledání</Czech>
             <French>Définit la taille du rayon de recherche.</French>
+            <Spanish>Introducir un número para el tamaño del radio de búsqueda</Spanish>
             <Italian>Immettere un numero per la dimensione del raggio in cui cercare</Italian>
             <Polish>Wprowadź liczbę jako rozmiar obszaru do przeszukania</Polish>
             <Russian>Введите число для задания размера радиуса поиска</Russian>
@@ -565,6 +605,7 @@
             <English>Set Position</English>
             <Czech>Nastavit pozici</Czech>
             <French>Configurer la position</French>
+            <Spanish>Posición definida</Spanish>
             <Italian>Posiziona</Italian>
             <Polish>Ustaw Pozycję</Polish>
             <Russian>Укажите позицию</Russian>
@@ -579,6 +620,7 @@
             <English>Hold Chance</English>
             <Czech>Šance držení</Czech>
             <French>Chance de tenir</French>
+            <Spanish>Probabilidad de mantener la posición</Spanish>
             <Italian>Probabilità di tenuta</Italian>
             <Polish>Szansa na Utrzymanie</Polish>
             <Russian>Шанс удерживания</Russian>
@@ -593,6 +635,7 @@
             <English>Chance for each unit to hold their garrison in combat</English>
             <Czech>Šance, že bude jednotka držet své opevnění v boji</Czech>
             <French>Possibilité pour chaque unité de maintenir sa garnison au combat.</French>
+            <Spanish>Probabilidad de que cada unidad mantenga su guarnición en combate</Spanish>
             <Italian>Probabilità per ogni unità di tenere il presidio durante il combattimento.</Italian>
             <Polish>Szansa dla każdej jednostki że będzie utrzymywać swój garnizon w trakcie walki</Polish>
             <Russian>Шанс для каждого подразделения удерживать свой гарнизон в бою</Russian>
@@ -607,6 +650,7 @@
             <English>Task</English>
             <Czech>Úkol</Czech>
             <French>Tâche</French>
+            <Spanish>Tarea</Spanish>
             <Italian>Incarico</Italian>
             <Polish>Zadanie</Polish>
             <Russian>Задача</Russian>
@@ -621,6 +665,7 @@
             <English>Building Size Threshold</English>
             <Czech>Práh velikosti stavby</Czech>
             <French>Seuil de taille du bâtiment</French>
+            <Spanish>Umbral de tamaño de edificio</Spanish>
             <Italian>Soglia Dimensione Edificio</Italian>
             <Polish>Próg Rozmiaru Budynku</Polish>
             <Russian>Порог размера здания</Russian>
@@ -635,6 +680,7 @@
             <English>Smaller the number the more buildings available</English>
             <Czech>Čím menší číslo tím více budov je k dispozici</Czech>
             <French>Plus le nombre est petit, plus il y'a de bâtiments disponibles.</French>
+            <Spanish>Cuanto menor sea el número, más edificios estarán disponibles</Spanish>
             <Italian>Più piccolo il numero più edifici saranno disponibili</Italian>
             <Polish>Im mniejsza wartość tym więcej budynków będzie dostępnych</Polish>
             <Russian>Чем меньше число, тем больше доступных зданий</Russian>
@@ -649,6 +695,7 @@
             <English>Timeout</English>
             <Czech>Přestávka</Czech>
             <French>Temporisation</French>
+            <Spanish>Tiempo de espera</Spanish>
             <Italian>Tempo di attesa</Italian>
             <Polish>Czas przerwania</Polish>
             <Russian>Тайм-аут</Russian>
@@ -663,6 +710,7 @@
             <English>[Min, Med, Max] Time to wait at waypoints</English>
             <Czech>[Min., Stř., Max.] Čas čekání na waypointech</Czech>
             <French>[Min, Moy, Max] Temps d'attente aux points de passage.</French>
+            <Spanish>[Mín., Med., Máx.] Tiempo de espera en los puntos de ruta</Spanish>
             <Italian>[Min, Med, Mass] Tempo di attesa alla destinazione.</Italian>
             <Polish>[Minimalny, Średni, Maksymalny] Czas oczekiwania na punktach nawigacyjnych</Polish>
             <Russian>[Минимум, Средний, Максимум] Тайм-аут ожидания на путевых точках</Russian>
@@ -677,6 +725,7 @@
             <English>Waypoint Count</English>
             <Czech>Počet waypointů</Czech>
             <French>Nombre de points de passage</French>
+            <Spanish>Número de puntos de ruta</Spanish>
             <Italian>Numero di destinazioni</Italian>
             <Polish>Ilosć punktów nawigacyjnych</Polish>
             <Russian>Количество путевых точек</Russian>
@@ -691,6 +740,7 @@
             <English>The amount of waypoints to create</English>
             <Czech>Kolik waypointů bude vytvořeno</Czech>
             <French>La quantité de points de passage à créer.</French>
+            <Spanish>Cantidad de puntos de ruta que se crearán</Spanish>
             <Italian>Quantità di destinazioni da creare.</Italian>
             <Polish>Ilość punktu nawigacyjnych do utworzenia</Polish>
             <Russian>Сколько создать путевых точек</Russian>
@@ -705,6 +755,7 @@
             <English>Waypoint Type</English>
             <Czech>Typ waypointu</Czech>
             <French>Type de point de passage</French>
+            <Spanish>Tipo de punto de ruta</Spanish>
             <Italian>Tipo di destinazioni</Italian>
             <Polish>Rodzaj Punktu nawigacyjnego</Polish>
             <Russian>Тип путевой точки</Russian>
@@ -719,6 +770,7 @@
             <English>The type of waypoint to be used</English>
             <Czech>Typ waypointu, který bude použit</Czech>
             <French>Le type de point de passage à utiliser.</French>
+            <Spanish>Tipo de punto de ruta que se utilizará</Spanish>
             <Italian>Il tipo di destinazione da usare.</Italian>
             <Polish>Rodzaj Punktu nawigacyjnego do wykorzystania</Polish>
             <Russian>Тип используемой путевой точки</Russian>

--- a/addons/music/stringtable.xml
+++ b/addons/music/stringtable.xml
@@ -5,6 +5,7 @@
             <English>Community Base Addons - Music</English>
             <Czech>Community Base Addons - Hudba</Czech>
             <French>Community Base Addons - Musique</French>
+            <Spanish>Community Base Addons - Música</Spanish>
             <Italian>Community Base Addons - Musica</Italian>
             <Polish>Community Base Addons - Muzyka</Polish>
             <Portuguese>Extensões de Base Comunitária - Música</Portuguese>

--- a/addons/network/stringtable.xml
+++ b/addons/network/stringtable.xml
@@ -5,6 +5,7 @@
             <English>Network</English>
             <Czech>Síť</Czech>
             <French>Réseau</French>
+            <Spanish>Red</Spanish>
             <Italian>Rete</Italian>
             <Polish>Sieć</Polish>
             <Portuguese>Rede</Portuguese>
@@ -20,6 +21,7 @@
             <English>Community Base Addons - Network</English>
             <Czech>Community Base Addons - Síť</Czech>
             <French>Community Base Addons - Réseau</French>
+            <Spanish>Community Base Addons - Red</Spanish>
             <Italian>Community Base Addons - Rete</Italian>
             <Polish>Community Base Addons - Sieć</Polish>
             <Portuguese>Extensões de Base Comunitária - Rede</Portuguese>
@@ -35,6 +37,7 @@
             <English>Loadout Validation</English>
             <Czech>Ověření výbavy</Czech>
             <French>Vérification de l'équipement</French>
+            <Spanish>Validación del equipamiento</Spanish>
             <Italian>Verifica l'equipaggiamento</Italian>
             <Polish>Sprawdzenie wyposażenia</Polish>
             <Russian>Проверять снаряжение</Russian>
@@ -48,6 +51,7 @@
             <English>Validate loadout of units. Fixes an issue where units appear naked after changing locality.</English>
             <Czech>Ověřovat výbavu jednotek. Opravuje problém s nahými jednotkami když mění lokálnost.</Czech>
             <French>Vérifie l'équipement des unités. Correction d'un bug où les unités se retrouvaient nues après avoir changé de localité.</French>
+            <Spanish>Valida el equipamiento de las unidades. Corrige un problema por el que las unidades aparecen desnudas tras un cambio de localidad de red.</Spanish>
             <Italian>Verifica l'equipaggiamento delle unità. Corregge un bug che faceva apparire un'unità nuda dopo aver cambiato località.</Italian>
             <Polish>Sprawdza wyposażenie jednostek. Naprawia problem, który powodował pojawianie się jednostek nagich, przy zmianie lokalności.</Polish>
             <Russian>Проверять снаряжение юнитов. Исправляет проблемы, когда юниты становятся голыми после смены локальности.</Russian>
@@ -61,6 +65,7 @@
             <English>Never</English>
             <Czech>Nikdy</Czech>
             <French>Jamais</French>
+            <Spanish>Nunca</Spanish>
             <Italian>Mai</Italian>
             <Polish>Nigdy</Polish>
             <Russian>Никогда</Russian>
@@ -74,6 +79,7 @@
             <English>Never validate loadouts</English>
             <Czech>Nikdy neověřovat výbavu</Czech>
             <French>Ne jamais vérifier les équipements</French>
+            <Spanish>No validar nunca los equipamientos</Spanish>
             <Italian>Non validare mai gli equipaggiamenti</Italian>
             <Polish>Nigdy nie sprawdzaj wyposażenia</Polish>
             <Russian>Никогда не проверять снаряжение</Russian>
@@ -87,6 +93,7 @@
             <English>All units</English>
             <Czech>Všechny jednotky</Czech>
             <French>Pour toutes les unités</French>
+            <Spanish>Todas las unidades</Spanish>
             <Italian>Tutte le unità</Italian>
             <Polish>Wszystkie jednostki</Polish>
             <Russian>Все юниты</Russian>
@@ -100,6 +107,7 @@
             <English>Validate loadout of all units</English>
             <Czech>Ověřovat výbavu všech jednotek</Czech>
             <French>Vérifier l'équipement de toutes les unités</French>
+            <Spanish>Validar el equipamiento de todas las unidades</Spanish>
             <Italian>Valida l'equipaggiamento di tutte unità</Italian>
             <Polish>Sprawdza wyposażenie wszystkich jednostek</Polish>
             <Russian>Проверять снаряжение всех юнитов</Russian>
@@ -113,6 +121,7 @@
             <English>Playable units only</English>
             <Czech>Pouze hratelné jednotky</Czech>
             <French>Pour les unités jouables</French>
+            <Spanish>Solo unidades jugables</Spanish>
             <Italian>Solo unità giocabili</Italian>
             <Polish>Tylko grywalne jednostki</Polish>
             <Russian>Только игровые юниты</Russian>
@@ -126,6 +135,7 @@
             <English>Validate only loadout of playable units</English>
             <Czech>Ověřovat pouze výbavu hratelných jednotek</Czech>
             <French>Vérifier uniquement l'équipement des unités jouables</French>
+            <Spanish>Validar solo el equipamiento de las unidades jugables</Spanish>
             <Italian>Valida solo le unità giocabili</Italian>
             <Polish>Sprawdza wyposażenie tylko jednostek oznaczonych jako grywalne</Polish>
             <Russian>Проверять снаряжение только игровых юнитов</Russian>

--- a/addons/optics/stringtable.xml
+++ b/addons/optics/stringtable.xml
@@ -5,6 +5,7 @@
             <English>Community Base Addons - Optics</English>
             <Czech>Community Base Addons - Optika</Czech>
             <French>Community Base Addons - Optiques</French>
+            <Spanish>Community Base Addons - Ópticas</Spanish>
             <Italian>Community Base Addons - Ottiche</Italian>
             <Polish>Community Base Addons - Optyka</Polish>
             <Russian>Community Base Addons - Оптика</Russian>
@@ -19,6 +20,7 @@
             <English>Use Picture-in-Picture Optics</English>
             <Czech>Používat PiP (obraz-v-obrazu) optiky</Czech>
             <French>Utiliser les optiques "picture in picture"</French>
+            <Spanish>Usar ópticas de imagen en imagen (PiP)</Spanish>
             <Italian>Usa ottiche on Picture-in-Picture</Italian>
             <Polish>Używaj optyki typu Obraz w obrazie (PIP)</Polish>
             <Russian>Использовать оптические прицелы в режиме "Картинка в картинке" (PIP)</Russian>
@@ -33,6 +35,7 @@
             <English>Toggle Reticle</English>
             <Czech>Zapnout retikulum</Czech>
             <French>Commuter le réticule</French>
+            <Spanish>Cambiar retícula</Spanish>
             <Italian>Cambia reticolo</Italian>
             <Polish>Przełącz siatke przyrządu</Polish>
             <Russian>Переключение сетки</Russian>
@@ -47,6 +50,7 @@
             <English>Manually switch the reticle of the optic.</English>
             <Czech>Manuálně přepnout retikulum optiky</Czech>
             <French>Commuter manuellement le réticule de l'optique.</French>
+            <Spanish>Cambia manualmente la retícula de la óptica.</Spanish>
             <Italian>Cambia manualmente il reticolo dell'ottica.</Italian>
             <Polish>Ręcznie przełącz siatkę przyrządu optycznego</Polish>
             <Russian>Вручную переключать сетку оптического прицела.</Russian>

--- a/addons/pid/stringtable.xml
+++ b/addons/pid/stringtable.xml
@@ -3,6 +3,7 @@
     <Package name="PID">
         <Key ID="STR_cba_pid_Component">
             <English>Community Base Addons - PID</English>
+            <Spanish>Community Base Addons - PID</Spanish>
             <Japanese>Community Base Addons - PID</Japanese>
         </Key>
     </Package>

--- a/addons/quicktime/stringtable.xml
+++ b/addons/quicktime/stringtable.xml
@@ -5,6 +5,7 @@
             <English>Community Base Addons - Quick-Time Events</English>
             <Czech>Community Base Addons - Quick-Time Events</Czech>
             <French>Community Base Addons - Quick-Time-Events</French>
+            <Spanish>Community Base Addons - Quick-Time Events</Spanish>
             <Russian>Community Base Addons - Quick-Time Events</Russian>
             <German>Community Base Addons - Quick-Time-Events</German>
             <Korean>커뮤니티 베이스 애드온 - 퀵 타임 이벤트 (QTE)</Korean>
@@ -14,6 +15,7 @@
             <English>Single Key press</English>
             <Czech>Jednoduchý stisk klávesy</Czech>
             <French>Appui d'une seule touche</French>
+            <Spanish>Pulsación de una sola tecla</Spanish>
             <Russian>Одиночное нажатие клавиши</Russian>
             <German>Einmaliger Tastendruck</German>
             <Korean>한 번만 누르기</Korean>
@@ -23,6 +25,7 @@
             <English>When enabled, all Quick-Time Events will be shortened to a single key press.</English>
             <Czech>Pokud je povoleno, všechny události Quick-Time budou zkráceny na jedno stisknutí klávesy.</Czech>
             <French>Lorsqu'ils sont activés, tous les événements Quick Time ne nécessitent qu'une seule pression de touche.</French>
+            <Spanish>Si se activa, todos los Quick-Time Events se reducirán a la pulsación de una sola tecla.</Spanish>
             <Russian>Когда включено, все QTE будут упрощены до одиночного нажатия клавиши.</Russian>
             <German>Wenn aktiviert, benötigen alle Quick-Time-Events nur einen einzigen Tastendruck.</German>
             <Korean>활성화 시 모든 QTE가 한 번의 키 입력으로 단축됩니다.</Korean>
@@ -32,6 +35,7 @@
             <English>Down key used in Quick-Time Events.</English>
             <Czech>Dolní klávesa použitá v událostech Quick-Time.</Czech>
             <French>Touche du bas utilisée dans les Quick-Time Events.</French>
+            <Spanish>Tecla de abajo utilizada en los Quick-Time Events.</Spanish>
             <Russian>Клавиша вниз для QTE.</Russian>
             <German>Taste in Quick-Time-Events für unten.</German>
             <Korean>QTE에 사용되는 아래쪽 키입니다.</Korean>
@@ -41,6 +45,7 @@
             <English>CBA Quick-Time Events</English>
             <Czech>CBA Quick-Time Events</Czech>
             <French>Événements CBA Quick-Time</French>
+            <Spanish>CBA Quick-Time Events</Spanish>
             <Russian>CBA Quick-Time Events</Russian>
             <German>CBA Quick-Time-Events</German>
             <Korean>CBA 퀵 타임 이벤트 (QTE)</Korean>
@@ -50,6 +55,7 @@
             <English>Left key used in Quick-Time Events.</English>
             <Czech>Levá klávesa použitá v událostech Quick-Time.</Czech>
             <French>Touche de gauche utilisée dans les Quick-Time Events.</French>
+            <Spanish>Tecla de izquierda utilizada en los Quick-Time Events.</Spanish>
             <Russian>Клавиша влево для QTE.</Russian>
             <German>Taste in Quick-Time-Events für links.</German>
             <Korean>QTE에 사용되는 왼쪽 키입니다.</Korean>
@@ -59,6 +65,7 @@
             <English>Right key used in Quick-Time Events.</English>
             <Czech>Pravá klávesa použitá v událostech Quick-Time.</Czech>
             <French>Touche de droite utilisée dans les Quick-Time Events.</French>
+            <Spanish>Tecla de derecha utilizada en los Quick-Time Events.</Spanish>
             <Russian>Клавиша вправо для QTE.</Russian>
             <German>Taste in Quick-Time-Events für rechts.</German>
             <Korean>QTE에 사용되는 오른쪽 키입니다.</Korean>
@@ -68,6 +75,7 @@
             <English>Up key used in Quick-Time Events.</English>
             <Czech>Horní klávesa použitá v událostech Quick-Time.</Czech>
             <French>Touche du haut utilisée dans les événements Quick-Time.</French>
+            <Spanish>Tecla de arriba utilizada en los Quick-Time Events.</Spanish>
             <Russian>Клавиша вверх для QTE.</Russian>
             <German>Taste in Quick-Time-Events für oben.</German>
             <Korean>QTE에 사용되는 위쪽 키입니다.</Korean>
@@ -77,6 +85,7 @@
             <English>Quick-Time Events</English>
             <Czech>Quick-Time Events</Czech>
             <French>Quick-Time-Events</French>
+            <Spanish>Quick-Time Events</Spanish>
             <Russian>Quick-Time Events</Russian>
             <German>Quick-Time-Events</German>
             <Korean>퀵 타임 이벤트 (QTE)</Korean>

--- a/addons/settings/stringtable.xml
+++ b/addons/settings/stringtable.xml
@@ -5,6 +5,7 @@
             <English>Addon Options...</English>
             <Czech>Možnosti addonu...</Czech>
             <French>Ajuster les paramètres des addons...</French>
+            <Spanish>Opciones de addons...</Spanish>
             <Italian>Opzioni per gli addon ...</Italian>
             <Polish>Ustawienia addonów...</Polish>
             <Portuguese>Opções ded Extensão...</Portuguese>
@@ -20,6 +21,7 @@
             <English>Client</English>
             <Czech>Klient</Czech>
             <French>Client</French>
+            <Spanish>Cliente</Spanish>
             <Italian>Client</Italian>
             <Polish>Klient</Polish>
             <Portuguese>Cliente</Portuguese>
@@ -35,6 +37,7 @@
             <English>Edit your local settings.</English>
             <Czech>Upravit vaše lokální nastavení.</Czech>
             <French>Modifier vos paramètres locaux.</French>
+            <Spanish>Editar la configuración local.</Spanish>
             <Italian>Cambia le tue impostazioni locali.</Italian>
             <Polish>Edytuj swoje lokalne ustawienia.</Polish>
             <Portuguese>Edite as configurações locais.</Portuguese>
@@ -50,6 +53,7 @@
             <English>Export</English>
             <Czech>Export</Czech>
             <French>Exporter</French>
+            <Spanish>Exportar</Spanish>
             <Italian>Esporta</Italian>
             <Polish>Eksport</Polish>
             <Portuguese>Exportar</Portuguese>
@@ -65,6 +69,7 @@
             <English>Export settings to clipboard.</English>
             <Czech>Exportovat nastavení do schránky.</Czech>
             <French>Exporter les paramètres dans le presse-papier.</French>
+            <Spanish>Exportar la configuración al portapapeles.</Spanish>
             <Italian>Esporta le impostazioni negli appunti.</Italian>
             <Polish>Eksport ustawień do schowka.</Polish>
             <Portuguese>Exportar configurações para a prancheta.</Portuguese>
@@ -80,6 +85,7 @@
             <English>Import</English>
             <Czech>Import</Czech>
             <French>Importer</French>
+            <Spanish>Importar</Spanish>
             <Italian>Importa</Italian>
             <Polish>Import</Polish>
             <Portuguese>Importar</Portuguese>
@@ -95,6 +101,7 @@
             <English>Import settings from clipboard.</English>
             <Czech>Importovat nastavení ze schránky.</Czech>
             <French>Importer les paramètres depuis le presse-papier.</French>
+            <Spanish>Importar la configuración desde el portapapeles.</Spanish>
             <Italian>Importa le impostazioni dagli appunti.</Italian>
             <Polish>Import ustawień ze schowka.</Polish>
             <Portuguese>Importar configurações da prancheta.</Portuguese>
@@ -110,6 +117,7 @@
             <English>Load settings from preset.</English>
             <Czech>Načíst nastavení z předvolby.</Czech>
             <French>Charger les paramètres à partir d'un préréglage.</French>
+            <Spanish>Cargar la configuración desde un preajuste.</Spanish>
             <Italian>Carica le impostazioni da quelle predefinite</Italian>
             <Polish>Załaduj ustawienia z szablonu.</Polish>
             <Portuguese>Carregue as configurações padrão.</Portuguese>
@@ -125,6 +133,7 @@
             <English>Local</English>
             <Czech>Lokální</Czech>
             <French>Local</French>
+            <Spanish>Local</Spanish>
             <Italian>Locale</Italian>
             <Polish>Lokalne</Polish>
             <Portuguese>Local</Portuguese>
@@ -140,6 +149,7 @@
             <English>Mission</English>
             <Czech>Mise</Czech>
             <French>Mission</French>
+            <Spanish>Misión</Spanish>
             <Italian>Missione</Italian>
             <Polish>Misja</Polish>
             <Portuguese>Missão</Portuguese>
@@ -155,6 +165,7 @@
             <English>Look at the mission's settings.</English>
             <Czech>Podívejte se na nastavení mise.</Czech>
             <French>Permet de visualiser les paramètres de la mission.</French>
+            <Spanish>Consultar la configuración de la misión.</Spanish>
             <Italian>Visualizza le impostazioni della missione.</Italian>
             <Polish>Zobacz ustawienia misji.</Polish>
             <Portuguese>Olhe as configurações de missão.</Portuguese>
@@ -170,6 +181,7 @@
             <English>Edit the mission's settings.</English>
             <Czech>Upravit nastavení mise.</Czech>
             <French>Editer les paramètres de la mission.</French>
+            <Spanish>Editar la configuración de la misión.</Spanish>
             <Italian>Cambia le impostazioni della missione.</Italian>
             <Polish>Edytuj ustawienia misji.</Polish>
             <Portuguese>Edite as configurações de missões.</Portuguese>
@@ -185,6 +197,7 @@
             <English>Save current settings as preset.</English>
             <Czech>Uložit nynější nastavení jako předvolbu.</Czech>
             <French>Enregistrer un préréglage des paramètres actuels.</French>
+            <Spanish>Guardar la configuración actual como preajuste.</Spanish>
             <Italian>Salva le impostazioni attuali come predefinite</Italian>
             <Polish>Zapisz obecne ustawienia do szablonu.</Polish>
             <Portuguese>Salvar as configurações atuais como padrões.</Portuguese>
@@ -198,12 +211,14 @@
         </Key>
         <Key ID="STR_cba_settings_ButtonSearch_tooltip">
             <English>Search settings.</English>
+            <Spanish>Buscar ajustes.</Spanish>
             <Japanese>検索設定</Japanese>
         </Key>
         <Key ID="STR_cba_settings_ButtonServer">
             <English>Server</English>
             <Czech>Server</Czech>
             <French>Serveur</French>
+            <Spanish>Servidor</Spanish>
             <Italian>Server</Italian>
             <Polish>Serwer</Polish>
             <Portuguese>Servidor</Portuguese>
@@ -219,6 +234,7 @@
             <English>Look at the server's settings. Log in as admin to change.</English>
             <Czech>Podívejte se na nastavení serveru. Přihlaste se jako admin pro změnu.</Czech>
             <French>Permet de visualiser les paramètres du serveur. Se connecter en tant qu'administrateur pour les changer.</French>
+            <Spanish>Consultar la configuración del servidor. Iniciar sesión como administrador para modificarla.</Spanish>
             <Italian>Visualizza le impostazioni del server. Entra come amministratore per cambiarle.</Italian>
             <Polish>Zobacz ustawienia serwera. Zaloguj się jako administrator aby zmienić.</Polish>
             <Portuguese>Olhe as configurações dos servidores. Acesse como administrador para alterá-las.</Portuguese>
@@ -234,6 +250,7 @@
             <English>Community Base Addons - Settings</English>
             <Czech>Community Base Addons - Nastavení</Czech>
             <French>Community Base Addons - Paramètres</French>
+            <Spanish>Community Base Addons - Ajustes</Spanish>
             <Italian>Community Base Addons - Impostazioni</Italian>
             <Polish>Community Base Addons - Komponent Ustawień</Polish>
             <Portuguese>Extensões de Base Comunitária - Componente das Configurações</Portuguese>
@@ -247,12 +264,14 @@
         </Key>
         <Key ID="STR_cba_settings_Search_tooltip">
             <English>Filter addons and settings. Matches names, descriptions, setting variable names and option labels.\nCtrl + F to focus, right click to clear.</English>
+            <Spanish>Filtra addons y ajustes. Busca coincidencias en nombres, descripciones, nombres de variables de ajustes y etiquetas de opciones.\nCtrl + F para enfocar, clic derecho para borrar.</Spanish>
             <Japanese>アドオンと設定をフィルタリングします。名前、説明、設定変数名、オプションラベルに一致するものを検索します。\nCtrl + F でフォーカス、右クリックでクリア。</Japanese>
         </Key>
         <Key ID="STR_cba_settings_applies">
             <English>This setting applies.</English>
             <Czech>Toto nastavení je aktuální.</Czech>
             <French>Ce paramètre s'applique.</French>
+            <Spanish>Este ajuste se aplica.</Spanish>
             <Italian>Prevale questa impostazione.</Italian>
             <Polish>To ustawienie dotyczy.</Polish>
             <Russian>Этот параметр применён.</Russian>
@@ -267,6 +286,7 @@
             <English>Configure Addons</English>
             <Czech>Konfigurovat addony</Czech>
             <French>Configurer les addons</French>
+            <Spanish>Configurar los addons</Spanish>
             <Italian>Configura gli addon</Italian>
             <Polish>Konfiguracja addonów</Polish>
             <Portuguese>Configurar as Extensões</Portuguese>
@@ -282,6 +302,7 @@
             <English>Configure Base</English>
             <Czech>Konfigurovat základ</Czech>
             <French>Configurer la base</French>
+            <Spanish>Configurar el juego base</Spanish>
             <Italian>Configura il gioco base</Italian>
             <Polish>Konfiguracja bazy</Polish>
             <Portuguese>Configurar as Bases</Portuguese>
@@ -297,6 +318,7 @@
             <English>Copy to clipboard</English>
             <Czech>Kopírovat do schránky</Czech>
             <French>Copier</French>
+            <Spanish>Copiar al portapapeles</Spanish>
             <Italian>Copia negli appunti</Italian>
             <Polish>Skopiuj do schowka</Polish>
             <Russian>Скопировать в буфер обмена</Russian>
@@ -311,6 +333,7 @@
             <English>Reset to default value.</English>
             <Czech>Resetovat na původní hodnotu.</Czech>
             <French>Réinitialiser à la valeur par défaut.</French>
+            <Spanish>Restablecer el valor predeterminado.</Spanish>
             <Italian>Reimposta ai valori originali.</Italian>
             <Polish>Przywróć domyślne wartości.</Polish>
             <Portuguese>Resetar para os valores padrões.</Portuguese>
@@ -324,12 +347,14 @@
         </Key>
         <Key ID="STR_cba_settings_general">
             <English>General</English>
+            <Spanish>General</Spanish>
             <Japanese>全般</Japanese>
         </Key>
         <Key ID="STR_cba_settings_menu_button">
             <English>Addon Options</English>
             <Czech>Možnosti addonu</Czech>
             <French>Options des addons</French>
+            <Spanish>Opciones de addons</Spanish>
             <Italian>Opzioni degli addon</Italian>
             <Polish>Ustawienia addonów</Polish>
             <Portuguese>Opções de Extensão</Portuguese>
@@ -345,6 +370,7 @@
             <English>Adjust addon settings.</English>
             <Czech>Upravit nastavení addonu.</Czech>
             <French>Permet d'ajuster les paramètres des addons.</French>
+            <Spanish>Ajustar la configuración de los addons.</Spanish>
             <Italian>Aggiusta le impostazioni per gli addon</Italian>
             <Polish>Zmień ustawienia addonów.</Polish>
             <Russian>Изменить настройки дополнений.</Russian>
@@ -359,6 +385,7 @@
             <English>This setting applies after the next mission restart.</English>
             <Czech>Toto nastavení bude aplikováno po restartu mise.</Czech>
             <French>Ce paramètre s'appliquera au prochain redémarrage de la mission.</French>
+            <Spanish>Este ajuste se aplicará tras reiniciar la misión.</Spanish>
             <Italian>Questa impostazione sarà valida dopo il riavvio della missione.</Italian>
             <Polish>To ustawienie zostanie zastosowanie po restarcie misji.</Polish>
             <Russian>Этот параметр будет применён после рестарта миссии.</Russian>
@@ -373,6 +400,7 @@
             <English>Overwrite\nClients</English>
             <Czech>Přepsat \nClients</Czech>
             <French>Ecraser\nClients</French>
+            <Spanish>Sobrescribir\nclientes</Spanish>
             <Italian>Sovrascrive\ni client</Italian>
             <Polish>Nadpisz\nKlienci</Polish>
             <Portuguese>Sobrescrever \nClientes</Portuguese>
@@ -386,12 +414,14 @@
         </Key>
         <Key ID="STR_cba_settings_overwrite_clients_short">
             <English>Clients</English>
+            <Spanish>Clientes</Spanish>
             <Japanese>クライアント</Japanese>
         </Key>
         <Key ID="STR_cba_settings_overwrite_mission">
             <English>Overwrite\nMission</English>
             <Czech>Přepsat \nMission</Czech>
             <French>Ecraser\nMission</French>
+            <Spanish>Sobrescribir\nmisión</Spanish>
             <Italian>Sovrascrive\nla missione</Italian>
             <Polish>Nadpisz\nMisja</Polish>
             <Portuguese>Sobrescrever \nMissão</Portuguese>
@@ -405,12 +435,14 @@
         </Key>
         <Key ID="STR_cba_settings_overwrite_mission_short">
             <English>Mission</English>
+            <Spanish>Misión</Spanish>
             <Japanese>ミッション</Japanese>
         </Key>
         <Key ID="STR_cba_settings_overwrite_server">
             <English>Overwrite\nServer</English>
             <Czech>Přepsat \nServer</Czech>
             <French>Ecraser\nServeur</French>
+            <Spanish>Sobrescribir\nservidor</Spanish>
             <Italian>Sovrascrive\nil server</Italian>
             <Polish>Nadpisz\nSerwer</Polish>
             <Portuguese>Sobrescrever \nServidor</Portuguese>
@@ -424,12 +456,14 @@
         </Key>
         <Key ID="STR_cba_settings_overwrites">
             <English>Overwrites:</English>
+            <Spanish>Sobrescribe:</Spanish>
             <Japanese>上書き:</Japanese>
         </Key>
         <Key ID="STR_cba_settings_overwritten_by_client_equal_tooltip">
             <English>Overwritten by client with the same value.</English>
             <Czech>Toto nastavení je přepsáno klienty stejnou hodnotou.</Czech>
             <French>Écrasé par le client, avec la même valeur.</French>
+            <Spanish>Sobrescrito por el cliente con el mismo valor.</Spanish>
             <Italian>Sovrascritto dal client con lo stesso valore.</Italian>
             <Polish>Nadpisane przez klienta z taką samą wartością.</Polish>
             <Russian>Перезаписано клиентом с таким же значением.</Russian>
@@ -443,6 +477,7 @@
             <English>This setting is overwritten by the clients.</English>
             <Czech>Toto nastavení je přepsáno klienty.</Czech>
             <French>Ce paramètre est écrasé par les clients.</French>
+            <Spanish>Este ajuste lo sobrescriben los clientes.</Spanish>
             <Italian>I client sovrascrivono questa impostazione.</Italian>
             <Polish>Ta wartość została nadpisana przez klientów.</Polish>
             <Portuguese>Esta configuração é sobrescrita pelos clientes.</Portuguese>
@@ -458,6 +493,7 @@
             <English>This setting is overwritten by the clients and only applies to the server.</English>
             <Czech>Toto nastavení je přepsáno klienty a platí pouze na serveru.</Czech>
             <French>Ce paramètre est écrasé par les clients et ne s'applique qu'au serveur.</French>
+            <Spanish>Este ajuste lo sobrescriben los clientes y solo se aplica al servidor.</Spanish>
             <Italian>Questa impostazione è sovrascritta dai client e si applica solo al server.</Italian>
             <Polish>Ta wartość została nadpisana przez klientów i ma zastosowanie tylko na serwerze.</Polish>
             <Portuguese>Esta configuração é sobrescrita pelos clientes e é apenas aplicada no servidor.</Portuguese>
@@ -473,6 +509,7 @@
             <English>Overwritten by mission with the same value.</English>
             <Czech>Toto nastavení je přepsáno misí stejnou hodnotou.</Czech>
             <French>Écrasé par la mission, avec la même valeur.</French>
+            <Spanish>Sobrescrito por la misión con el mismo valor.</Spanish>
             <Italian>Sovrascritto dalla missione con lo stesso valore.</Italian>
             <Polish>Nadpisane przez misję z taką samą wartością.</Polish>
             <Russian>Перезаписано миссией с таким же значением.</Russian>
@@ -486,6 +523,7 @@
             <English>This setting is overwritten by the mission.</English>
             <Czech>Toto nastavení je přepsáno misí.</Czech>
             <French>Ce paramètre est écrasé par la mission.</French>
+            <Spanish>Este ajuste lo sobrescribe la misión.</Spanish>
             <Italian>La missione sovrascrive questa impostazione.</Italian>
             <Polish>Ta wartośc została nadpisana przez misję.</Polish>
             <Portuguese>Esta configuração é sobrescrita pela missão.</Portuguese>
@@ -501,6 +539,7 @@
             <English>Overwritten by server with the same value.</English>
             <Czech>Toto nastavení je přepsáno serverem stejnou hodnotou.</Czech>
             <French>Écrasé par le serveur, avec la même valeur.</French>
+            <Spanish>Sobrescrito por el servidor con el mismo valor.</Spanish>
             <Italian>Sovrascritto dal server con lo stesso valore.</Italian>
             <Polish>Nadpisane przez serwer z taką samą wartością.</Polish>
             <Russian>Перезаписано сервером с таким же значением.</Russian>
@@ -514,6 +553,7 @@
             <English>This setting is overwritten by the server.</English>
             <Czech>Toto nastavení je přepsáno serverem.</Czech>
             <French>Ce paramètre est écrasé par le serveur.</French>
+            <Spanish>Este ajuste lo sobrescribe el servidor.</Spanish>
             <Italian>Il server sovrascrive questa impostazione.</Italian>
             <Polish>Ta wartość została nadpisana przez serwer.</Polish>
             <Portuguese>Esta configuração é sobrescrita pelo servidor.</Portuguese>
@@ -529,6 +569,7 @@
             <English>Show default values:</English>
             <Czech>Ukázat původní hodnoty:</Czech>
             <French>Afficher les valeurs par défaut:</French>
+            <Spanish>Mostrar valores predeterminados:</Spanish>
             <Italian>Mostra i valori originali:</Italian>
             <Polish>Pokaż domyślnę wartości:</Polish>
             <Russian>Показать настройки по умолчанию:</Russian>
@@ -541,12 +582,14 @@
         </Key>
         <Key ID="STR_cba_settings_subCategory_tooltip">
             <English>Show or hide the settings in this group.</English>
+            <Spanish>Mostrar u ocultar los ajustes de este grupo.</Spanish>
             <Japanese>このグループの設定を表示または非表示にします。</Japanese>
         </Key>
         <Key ID="STR_cba_settings_volatile">
             <English>Changes will not persist after server restart</English>
             <Czech>Změny nebudou trvalé po restartu serveru</Czech>
             <French>Les modifications ne persistent pas après le redémarrage du serveur</French>
+            <Spanish>Los cambios no se conservarán tras reiniciar el servidor</Spanish>
             <Polish>Zmiany nie zostaną zachowane po restarcie serwera</Polish>
             <Russian>Изменения не будут сохранены после рестарта сервера</Russian>
             <German>Änderungen bleiben nach einem Serverneustart nicht erhalten</German>
@@ -557,6 +600,7 @@
             <English>The server is configured to not persist changes to settings between server restarts.\nChanges will persist between mission restarts.</English>
             <Czech>Server je nastaven tak, aby nezachovával změny v nastavení mezi restarty serveru.\nZměny budou zachovány mezi restarty mise.</Czech>
             <French>Le serveur est configuré pour ne pas conserver les modifications apportées aux paramètres entre les redémarrages du serveur.\nLes modifications seront conservées entre les redémarrages de la mission.</French>
+            <Spanish>El servidor está configurado para no conservar los cambios de los ajustes entre reinicios del servidor.\nLos cambios sí se conservarán entre reinicios de misión.</Spanish>
             <Polish>Serwer jest skonfigurowany tak, aby odrzucać wszystkie zmiany w ustawieniach gdy zostanie zrestartowany.\nZmiany zostaną zachowane między restartami misji.</Polish>
             <Russian>Сервер настроен не сохранять изменения настроек между рестартами сервера.\nИзменения будут сохранены между рестартами миссий.</Russian>
             <German>Der Server ist so konfiguriert, dass Änderungen an den Einstellungen zwischen Serverneustarts nicht erhalten bleiben.\nDie Änderungen zwischen Missionsneustarts bleiben erhalten.</German>
@@ -565,26 +609,32 @@
         </Key>
         <Key ID="STR_cba_settings_discardChanges">
             <English>There are %1 unsaved setting changes.</English>
+            <Spanish>Hay %1 cambios de ajustes sin guardar.</Spanish>
             <Japanese>保存されていない設定変更が%1件あります。</Japanese>
         </Key>
         <Key ID="STR_cba_settings_discardChanges_one">
             <English>There is 1 unsaved setting change.</English>
+            <Spanish>Hay 1 cambio de ajuste sin guardar.</Spanish>
             <Japanese>保存されていない設定変更が1件あります。</Japanese>
         </Key>
         <Key ID="STR_cba_settings_discardChanges_confirm">
             <English>Discard</English>
+            <Spanish>Descartar</Spanish>
             <Japanese>破棄</Japanese>
         </Key>
         <Key ID="STR_cba_settings_discardChanges_more">
             <English>...and %1 more</English>
+            <Spanish>...y %1 más</Spanish>
             <Japanese>... 他 %1 件</Japanese>
         </Key>
         <Key ID="STR_cba_settings_discardChanges_keep">
             <English>Keep Editing</English>
+            <Spanish>Seguir editando</Spanish>
             <Japanese>編集を継続</Japanese>
         </Key>
         <Key ID="STR_cba_settings_discardChanges_title">
             <English>Unsaved Changes</English>
+            <Spanish>Cambios sin guardar</Spanish>
             <Japanese>保存されていない変更</Japanese>
         </Key>
     </Package>

--- a/addons/statemachine/stringtable.xml
+++ b/addons/statemachine/stringtable.xml
@@ -5,6 +5,7 @@
             <English>Community Base Addons - State Machine</English>
             <Czech>Community Base Addons - State Machine</Czech>
             <French>Community Base Addons - Machine d'états</French>
+            <Spanish>Community Base Addons - Máquina de estados</Spanish>
             <Italian>Community Base Addons - Macchina a stati finiti</Italian>
             <Polish>Community Base Addons - Komponent Maszyny Stanów</Polish>
             <Portuguese>Extensões de Base Comunitária - Component da Máquina de Estado</Portuguese>

--- a/addons/statuseffects/stringtable.xml
+++ b/addons/statuseffects/stringtable.xml
@@ -3,6 +3,7 @@
     <Package name="StatusEffects">
         <Key ID="STR_CBA_StatusEffects_Component">
             <English>Community Base Addons - Status Effects Component</English>
+            <Spanish>Community Base Addons - Componente de efectos de estado</Spanish>
             <Japanese>Community Base Addons - ステータス効果コンポーネント</Japanese>
         </Key>
     </Package>

--- a/addons/strings/stringtable.xml
+++ b/addons/strings/stringtable.xml
@@ -37,6 +37,7 @@
             <English>Community Base Addons - Strings</English>
             <Czech>Community Base Addons - Texty</Czech>
             <French>Community Base Addons - Textes</French>
+            <Spanish>Community Base Addons - Cadenas de texto</Spanish>
             <Italian>Community Base Addons - Stringhe</Italian>
             <Polish>Community Base Addons - Ciągi znaków</Polish>
             <Portuguese>Extensões de Base Comunitária - Palavras</Portuguese>

--- a/addons/ui/stringtable.xml
+++ b/addons/ui/stringtable.xml
@@ -5,7 +5,7 @@
             <English>Adjusting group order...</English>
             <Czech>Upravuji pořadí skupiny...</Czech>
             <French>Modification de l'ordre des groupes...</French>
-            <Spanish>Ajustar el orden del grupo...</Spanish>
+            <Spanish>Ajustando el orden del grupo...</Spanish>
             <Italian>Riordinando il gruppo...</Italian>
             <Polish>Dostosowywanie kolejności w lobby...</Polish>
             <Russian>Изменение порядка групп...</Russian>
@@ -66,7 +66,7 @@
             <English>Contact the server admin.</English>
             <Czech>Kontaktujte správce serveru.</Czech>
             <French>Contacter l'administrateur du serveur.</French>
-            <Spanish>Póngase en contacto con el administrador del servidor</Spanish>
+            <Spanish>Contacta con el administrador del servidor.</Spanish>
             <Italian>Contatta l'amministratore del server.</Italian>
             <Polish>Kontakt z administratorem serwera</Polish>
             <Russian>Уведомить администратора сервера.</Russian>
@@ -111,7 +111,7 @@
             <English>Passwords are not stored when connecting to a multiplayer server. Already stored passwords are deleted from the profile.</English>
             <Czech>Hesla nejsou ukládána, když se připojujete k multiplayerovému serveru. Hesla, která již byla uložena, jsou smazána z profilu.</Czech>
             <French>Les mots de passe ne sont pas stockés lors de la connexion à un serveur multijoueur. Les mots de passe déjà enregistrés sont supprimés du profil.</French>
-            <Spanish>Las contraseñas no se almacenan cuando se conecta a un servidor multijugador. Las contraseñas ya almacenadas se eliminan del perfil.</Spanish>
+            <Spanish>Las contraseñas no se almacenan al conectarse a un servidor multijugador. Las contraseñas ya almacenadas se eliminan del perfil.</Spanish>
             <Italian>Quando ci si collega ad un server multiplayer, le password non verranno salvate. Non saranno usate password precedentemente salvate.</Italian>
             <Polish>Hasła nie są zapisywane podczas łączenia do serwerów. Już zapisane hasła zostaną usunięte z profilu.</Polish>
             <Russian>Пароли не сохраняются при входе на сервера. Уже сохранённые пароли будут удалены.</Russian>
@@ -126,7 +126,7 @@
             <English>Do not save passwords</English>
             <Czech>Neukládat hesla</Czech>
             <French>Ne pas sauvegarder les mots de passe</French>
-            <Spanish>No guarde las contraseñas</Spanish>
+            <Spanish>No guardar las contraseñas</Spanish>
             <Italian>Non salvare le password</Italian>
             <Polish>Nie zapisuj haseł</Polish>
             <Russian>Не сохранять пароли</Russian>
@@ -141,7 +141,7 @@
             <English>Passwords are not stored when connecting to a multiplayer server. Already stored passwords will not be automatically entered.</English>
             <Czech>Hesla nejsou ukládána, když se připojujete k multiplayerovému serveru. Hesla, která již byla uložena, nebudou automaticky zadávána.</Czech>
             <French>Les mots de passe ne sont pas stockés lors de la connexion à un serveur multijoueur. Les mots de passe déjà enregistrés ne seront pas automatiquement entrés.</French>
-            <Spanish>Las contraseñas no se almacenan cuando se conecta a un servidor multijugador. Las contraseñas ya almacenadas no se ingresarán automáticamente.</Spanish>
+            <Spanish>Las contraseñas no se almacenan al conectarse a un servidor multijugador. Las contraseñas ya almacenadas no se introducirán automáticamente.</Spanish>
             <Italian>Quando ci si collega ad un server multiplayer, le password non verranno salvate. Le password precedentemente salvate non verranno immesse automaticamente.</Italian>
             <Polish>Hasła nie są zapisywane podczas łączenia do serwerów. Już zapisane hasła nie bedą wykorzystywane.</Polish>
             <Russian>Пароли не сохраняются при входе на сервера. Уже сохранённые пароли не будут автоматически вставлены.</Russian>
@@ -156,7 +156,7 @@
             <English>Lobby Manager</English>
             <Czech>Manažer lobby</Czech>
             <French>Gestionnaire de Lobby</French>
-            <Spanish>Gerente de lobby</Spanish>
+            <Spanish>Gestor del lobby</Spanish>
             <Italian>Gestore lobby.</Italian>
             <Polish>Menadżer Lobby</Polish>
             <Russian>Менеджер лобби</Russian>
@@ -170,7 +170,7 @@
             <English>Back up mission before using this tool.</English>
             <Czech>Zálohujte misi před použitím tohoto nástroje.</Czech>
             <French>Sauvegardez la mission avant d'utiliser cet outil.</French>
-            <Spanish>Haga una copia de seguridad de la misión antes de usar esta herramienta</Spanish>
+            <Spanish>Haz una copia de seguridad de la misión antes de usar esta herramienta.</Spanish>
             <Italian>Salva una copia della missione prima di usare questo strumento.</Italian>
             <Polish>Wykonaj kopię zapasową misji przed użyciem tego narzędzia.</Polish>
             <Russian>Создайте резервную копию мисии перед использованием этого инструмента.</Russian>
@@ -184,7 +184,7 @@
             <English>Textual feedback to the player.</English>
             <Czech>Textová zpětná vazba hráči.</Czech>
             <French>Notification textuelle au joueur.</French>
-            <Spanish>Comentarios textuales para el jugador</Spanish>
+            <Spanish>Información textual para el jugador.</Spanish>
             <Italian>Notifica testuale al giocatore.</Italian>
             <Polish>Tekstowa informacja dla gracza.</Polish>
             <Russian>Текстовая информация для игрока.</Russian>
@@ -229,7 +229,7 @@
             <English>Notification display duration in seconds.</English>
             <Czech>Jak dlouho bude upozornění ukázáno (v sekundách).</Czech>
             <French>Durée d'affichage des notifications, en secondes.</French>
-            <Spanish>Duración de la visualización de notificaciones en segundos</Spanish>
+            <Spanish>Duración en pantalla de las notificaciones, en segundos.</Spanish>
             <Italian>Durata della notifica in secondi.</Italian>
             <Polish>Ilość czasu przez który widoczne jest powiadomienie</Polish>
             <Russian>Время в секундах, в течении которого будет видно уведомление.</Russian>
@@ -289,7 +289,7 @@
             <English>Passwords are stored when connecting to a multiplayer server.</English>
             <Czech>Hesla jsou uložena, když se připojujete k multiplayerovému serveru.</Czech>
             <French>Les mots de passe sont stockés lors de la connexion à un serveur multijoueur.</French>
-            <Spanish>Las contraseñas se almacenan cuando se conecta a un servidor multijugador</Spanish>
+            <Spanish>Las contraseñas se almacenan al conectarse a un servidor multijugador.</Spanish>
             <Italian>Quando ci si connette ad un server multiplayer, le password verranno salvate.</Italian>
             <Polish>Hasła są zapisywane podczas łaczenia do serwerów.</Polish>
             <Russian>Пароли будут сохраняться при входе на сервера.</Russian>
@@ -319,7 +319,7 @@
             <English>Setting to store the passwords entered when connecting to a multiplayer server.</English>
             <Czech>Uloží zadané heslo, když se připojujete k multiplayerovému serveru.</Czech>
             <French>Paramètre permettant de stocker les mots de passe saisis lors de la connexion à un serveur multijoueur.</French>
-            <Spanish>Configuración para almacenar las contraseñas ingresadas al conectarse a un servidor multijugador.</Spanish>
+            <Spanish>Configuración para almacenar las contraseñas introducidas al conectarse a un servidor multijugador.</Spanish>
             <Italian>Impostazione per salvare le password immesse quando ci si collega a server multiplayer.</Italian>
             <Polish>Opcja zapamiętywania wprowadzonych haseł do serwerów.</Polish>
             <Russian>Параметр запоминания паролей сервера при входе на них.</Russian>

--- a/addons/vectors/stringtable.xml
+++ b/addons/vectors/stringtable.xml
@@ -5,6 +5,7 @@
             <English>Community Base Addons - Vectors</English>
             <Czech>Community Base Addons - Vektory</Czech>
             <French>Community Base Addons - Vecteurs</French>
+            <Spanish>Community Base Addons - Vectores</Spanish>
             <Italian>Community Base Addons - Vettori</Italian>
             <Polish>Community Base Addons - Wektory</Polish>
             <Portuguese>Extensões de Base Comunitária - Vetores</Portuguese>

--- a/addons/versioning/stringtable.xml
+++ b/addons/versioning/stringtable.xml
@@ -5,6 +5,7 @@
             <English>Community Base Addons - Versioning</English>
             <Czech>Community Base Addons - Verzování</Czech>
             <French>Community Base Addons - Version</French>
+            <Spanish>Community Base Addons - Versionado</Spanish>
             <Italian>Community Base Addons - Versionamento</Italian>
             <Polish>Community Base Addons - Wersjonowanie</Polish>
             <Portuguese>Extensões de Base Comunitária - Versionamento</Portuguese>

--- a/addons/xeh/stringtable.xml
+++ b/addons/xeh/stringtable.xml
@@ -5,6 +5,7 @@
             <English>Community Base Addons - Extended Event Handlers</English>
             <Czech>Community Base Addons - Rozšířené ovladače událostí</Czech>
             <French>Community Base Addons - Gestionnaire d'événements étendu</French>
+            <Spanish>Community Base Addons - Manejadores de eventos extendidos</Spanish>
             <Italian>Community Base Addons - Gestore di Eventi Esteso</Italian>
             <Polish>Community Base Addons - Rozszerzona Obsługa Zdarzeń</Polish>
             <Portuguese>Extensões de Base Comunitária - Manipuladores Extendidos de Eventos</Portuguese>

--- a/optionals/legacy_jr/stringtable.xml
+++ b/optionals/legacy_jr/stringtable.xml
@@ -5,6 +5,7 @@
             <English>Community Base Addons - Legacy Joint Rails</English>
             <Czech>Community Base Addons - Legacy Joint Rails</Czech>
             <French>Community Base Addons - Legacy Joint Rails</French>
+            <Spanish>Community Base Addons - Rieles de montaje compartidos (heredados)</Spanish>
             <Polish>Community Base Addons - Legacy Joint Rails</Polish>
             <Russian>Community Base Addons - Legacy Joint Rails</Russian>
             <German>Community Base Addons - Legacy-Joint Rails</German>


### PR DESCRIPTION
**When merged this pull request will:**
- Add the 175 missing `<Spanish>` entries, bringing Spanish from 23% (55/230) to full coverage (230/230) across all 30 stringtables
- Add Spanish to `cba_settings` (50 keys) and `cba_modules` (52 keys), which previously had none at all despite being the most user-facing components
- Revise 34 pre-existing Spanish strings that were mistranslated or inconsistent

### Why

Spanish was one of the least covered languages in the repo — below Turkish (180), Italian (199) and every other major language, ahead of only Portuguese and Hungarian. In practice a Spanish-language player saw most of the CBA interface in English, because the game falls back to English whenever a `<Spanish>` tag is missing.

### Revisions to existing strings

These fix meaning, not just style:

| Key | Before | After |
| --- | --- | --- |
| `STR_CBA_AI_BuildingPos` | Posición del edificio de IA | Posición de IA en edificio |
| `STR_CBA_Diagnostic_TargetExec` | Ejecutiva de Objetivo | Ejec. objetivo |
| `STR_CBA_Diagnostic_ConsoleIndentType` | Espaciado de la Consola de Depuración | Sangría de la consola de depuración |
| `STR_CBA_UI_LobbyManager` | Gerente de lobby | Gestor del lobby |
| `STR_CBA_UI_NotificationPositionDescription` | Comentarios textuales para el jugador | Información textual para el jugador. |
| `STR_CBA_JAM_*_description` | Cargas: 150 | Cartuchos: 150 |
| `STR_CBA_JR_cfgweapons_muzzle_snds_h_mg` | Silenciador MG | Silenciador para ametralladora |
| `STR_CBA_Credits`, `STR_CBA_Help_Keys` | *(left in English)* | Créditos, Atajos de teclado |

`STR_CBA_AI_BuildingPos` marks the AI position *inside* a building — matching what the Polish, Russian and Japanese entries already say — rather than the position of an "AI building". `Target Exec` had been rendered with "Exec" as a noun. In the JAM descriptions, *Rounds* is `cartuchos`, in line with the French (`Munitions`), German (`Patronen`) and Polish (`Pociski`) entries.

The rest normalises register to impersonal forms, applies Spanish sentence case, and replaces the American *ingresar* with peninsular *introducir*.

Incidentally, this removes non-ASCII from the two strings that `ui/fnc_initDisplayMessageBox.sqf` and `diagnostic/fnc_initTargetDebugConsole.sqf` pass through `toUpper`. Since Arma's `toUpper` is ASCII-only, the previous `Póngase en contacto…` rendered as `PóNGASE…`.

### Conventions followed

- `<Spanish>` inserted after `<French>`, matching the tag order used throughout the repo
- `Community Base Addons` left untranslated in `CfgPatches >> name`, with only the descriptive suffix translated, as the existing Spanish entries already did
- Data-type names (`Arrays`, `Hashes`) kept in English, as Italian does; framework names with descriptive expansions (`Joint Ammo Magazines`, `Joint Rails`) translated, as French, German, Polish, Russian, Czech and Turkish do
- Placeholders (`%1`), escapes (`\n`) and markup (`<br/>`) preserved and verified against the English source
- CRLF line endings, UTF-8 without BOM, and existing indentation untouched

### Verification

- All 30 stringtables parse as well-formed XML; exactly one `<Spanish>` per `<Key>`
- `python3 tools/check_strings.py` — 0 undefined strings
- `python3 tools/stringtablediag.py` — Spanish at 100% for every component
- Diff is 209 insertions / 34 deletions across 30 files, every changed line a `<Spanish>` element; no key, package or container structure touched
