### PR TITLE
Settings - Fix Settings UI checkbox display, code cleanup

### DIFF
--- a/addons/settings/fnc_check.sqf
+++ b/addons/settings/fnc_check.sqf
@@ -42,7 +42,7 @@ switch (toUpper _settingType) do {
     };
     case "TIME": {
         _settingData params ["_min", "_max"];
-        _value isEqualType 0 && {_value >= _min} && {_value <= _max} && {round _value == _value} 
+        _value isEqualType 0 && {_value >= _min} && {_value <= _max} && {round _value == _value}
     };
     default {false};
 };

--- a/addons/settings/fnc_gui_addonChanged.sqf
+++ b/addons/settings/fnc_gui_addonChanged.sqf
@@ -27,11 +27,10 @@ if !(_selectedAddon in _optionsGroups) then {
 // toggle lists
 {
     private _isSelected = _x isEqualTo _selectedAddon;
-    private _optionsGroup = _optionsGroups get _x;
-    
-    _optionsGroup ctrlEnable _isSelected;
-    _optionsGroup ctrlShow _isSelected;
-} forEach (keys _optionsGroups);
+
+    _y ctrlEnable _isSelected;
+    _y ctrlShow _isSelected;
+} forEach _optionsGroups;
 
 // the category was built for whichever source was shown when it was created
 call FUNC(gui_refresh);

--- a/addons/settings/fnc_gui_configure.sqf
+++ b/addons/settings/fnc_gui_configure.sqf
@@ -72,6 +72,14 @@ if !(ctrlShown _ctrlAddonsGroup) then {
     //--- change button text
     _ctrlToggleButton ctrlSetText LLSTRING(configureBase);
 
+    //--- showing the addons group shows every category built inside it, only the
+    //--- selected one may stay. Its own rows are put back once the source is known.
+    private _selectedCategory = uiNamespace getVariable [QGVAR(addon), ""];
+
+    {
+        _y ctrlShow (_x isEqualTo _selectedCategory);
+    } forEach (_display getVariable [QGVAR(optionsGroups), createHashMap]);
+
     //--- emulate scope selection
     private _previousSelectedSource = uiNamespace getVariable QGVAR(source);
 
@@ -109,8 +117,13 @@ if !(ctrlShown _ctrlAddonsGroup) then {
         _ctrlServerButton
     ];
 
+    //--- points the rows at that source again, which is also what hides the
+    //--- overwrite checkboxes showing the group above brought back
     _ctrlPreviousButton call FUNC(gui_sourceChanged);
     ctrlSetFocus _ctrlPreviousButton;
+
+    //--- and so are the rows a search or a folded sub-category had hidden
+    [_display, false] call FUNC(gui_filterSettings);
 } else {
     //--- enable and show default menu
     _ctrlGeneralGroup ctrlEnable true;

--- a/addons/settings/fnc_gui_filterSettings.sqf
+++ b/addons/settings/fnc_gui_filterSettings.sqf
@@ -55,7 +55,14 @@ private _shownRows = [];
 
     // a header is kept for as long as the search left it anything, folded or not
     _x setVariable [QGVAR(matched), _matched];
-    _x ctrlShow _show;
+
+    // showing a row shows every control inside it, so the overwrite checkboxes
+    // the source it is pointed at doesn't use have to be hidden again. Rows that
+    // stay where they are keep theirs, this runs on every keystroke of the search.
+    if (_show isNotEqualTo (ctrlShown _x)) then {
+        _x ctrlShow _show;
+        _x call FUNC(gui_setOverwriteVisible);
+    };
 
     if (_show) then {
         _shownRows pushBack _x;

--- a/addons/settings/fnc_gui_retargetRow.sqf
+++ b/addons/settings/fnc_gui_retargetRow.sqf
@@ -40,11 +40,11 @@ private _enabled = _controlsGroup call FUNC(gui_setRowEnabled);
 // ----- which overwrite checkboxes a row has depends on the source it shows
 _controlsGroup call FUNC(gui_setOverwriteVisible);
 
-private _isGlobal = _controlsGroup getVariable [QGVAR(isGlobal), 0];
+private _isGlobal = _controlsGroup getVariable [QGVAR(isGlobal), SETTING_LOCAL_OVERRIDABLE];
 private _ctrlOverwriteClient = _controlsGroup controlsGroupCtrl IDC_SETTING_OVERWRITE_CLIENT;
 
 // "overwrite clients" is forced for global settings, so it can't be unticked
-_ctrlOverwriteClient setVariable [QGVAR(cbEnabled), !(_isGlobal > 0 && _source isNotEqualTo "mission")];
+_ctrlOverwriteClient setVariable [QGVAR(cbEnabled), !(_isGlobal isNotEqualTo SETTING_LOCAL_OVERRIDABLE && _source isNotEqualTo "mission")];
 
 // what "overwrite clients" goes back to belongs to the source that was shown
 _ctrlOverwriteClient setVariable [QGVAR(state), nil];

--- a/addons/settings/fnc_gui_retargetRow.sqf
+++ b/addons/settings/fnc_gui_retargetRow.sqf
@@ -38,13 +38,10 @@ _controlsGroup setVariable [QGVAR(source), _source];
 private _enabled = _controlsGroup call FUNC(gui_setRowEnabled);
 
 // ----- which overwrite checkboxes a row has depends on the source it shows
+_controlsGroup call FUNC(gui_setOverwriteVisible);
+
 private _isGlobal = _controlsGroup getVariable [QGVAR(isGlobal), 0];
-
 private _ctrlOverwriteClient = _controlsGroup controlsGroupCtrl IDC_SETTING_OVERWRITE_CLIENT;
-private _ctrlOverwriteMission = _controlsGroup controlsGroupCtrl IDC_SETTING_OVERWRITE_MISSION;
-
-[_ctrlOverwriteClient, _source isNotEqualTo "client" && {_isGlobal < 2}] call FUNC(gui_setOverwriteVisible);
-[_ctrlOverwriteMission, _source isEqualTo "server" && {_isGlobal < 2}] call FUNC(gui_setOverwriteVisible);
 
 // "overwrite clients" is forced for global settings, so it can't be unticked
 _ctrlOverwriteClient setVariable [QGVAR(cbEnabled), !(_isGlobal > 0 && _source isNotEqualTo "mission")];

--- a/addons/settings/fnc_gui_setOverwriteVisible.sqf
+++ b/addons/settings/fnc_gui_setOverwriteVisible.sqf
@@ -27,13 +27,13 @@ Author:
 
 params ["_controlsGroup"];
 
-// a global setting always overwrites the clients and a local one never leaves
-// the client it is set on, neither of them has anything to point anywhere
-private _isGlobal = _controlsGroup getVariable [QGVAR(isGlobal), 0];
+// a local setting never leaves the client it is set on, so it has nothing to
+// point anywhere
+private _isLocalOnly = ROW_IS_LOCAL_ONLY(_controlsGroup);
 private _source = ROW_SOURCE(_controlsGroup);
 
-private _showClient = _source isNotEqualTo "client" && _isGlobal < 2;
-private _showMission = _source isEqualTo "server" && _isGlobal < 2;
+private _showClient = _source isNotEqualTo "client" && !_isLocalOnly;
+private _showMission = _source isEqualTo "server" && !_isLocalOnly;
 
 private _ctrlOverwriteClient = _controlsGroup controlsGroupCtrl IDC_SETTING_OVERWRITE_CLIENT;
 private _ctrlOverwriteMission = _controlsGroup controlsGroupCtrl IDC_SETTING_OVERWRITE_MISSION;

--- a/addons/settings/fnc_gui_setOverwriteVisible.sqf
+++ b/addons/settings/fnc_gui_setOverwriteVisible.sqf
@@ -42,7 +42,7 @@ _ctrlOverwriteClient ctrlShow _showClient;
 _ctrlOverwriteMission ctrlShow _showMission;
 
 // a checkbox that isn't there can't be ticked either. Whether the ones that are
-// can be is not this function's to answer, so it only ever takes that away -
+// can be is not this function's task to answer, so it only ever takes that away -
 // FUNC(gui_setRowEnabled) and the row's updateUI_priority own the other half.
 _ctrlOverwriteClient ctrlEnable (_showClient && ctrlEnabled _ctrlOverwriteClient);
 _ctrlOverwriteMission ctrlEnable (_showMission && ctrlEnabled _ctrlOverwriteMission);

--- a/addons/settings/fnc_gui_setOverwriteVisible.sqf
+++ b/addons/settings/fnc_gui_setOverwriteVisible.sqf
@@ -3,28 +3,46 @@
 Internal Function: CBA_settings_fnc_gui_setOverwriteVisible
 
 Description:
-    Shows or hides one of the "overwrite" checkboxes of a settings menu row.
+    Shows the "overwrite" checkboxes that the source a settings menu row is
+    pointed at can use, and hides the rest.
 
-    Which of them a row has depends on the source it is showing, so this has to
-    be reversible.
+    Which of them a row has depends on that source, so this has to be reversible.
+    It also has to be repeatable: showing a row shows every control inside it,
+    the hidden checkboxes included, so whoever shows one puts them back.
 
 Parameters:
-    _ctrl - Overwrite checkbox <CONTROL>
-    _show - Show the checkbox <BOOL>
+    _controlsGroup - Setting controls group <CONTROL>
 
 Returns:
     None
 
 Examples:
     (begin example)
-        [_ctrlOverwriteMission, false] call CBA_settings_fnc_gui_setOverwriteVisible;
+        _ctrlSettingGroup call CBA_settings_fnc_gui_setOverwriteVisible;
     (end)
 
 Author:
     LinkIsGrim
 ---------------------------------------------------------------------------- */
 
-params ["_ctrl", "_show"];
+params ["_controlsGroup"];
 
-_ctrl ctrlShow _show;
-_ctrl ctrlEnable _show;
+// a global setting always overwrites the clients and a local one never leaves
+// the client it is set on, neither of them has anything to point anywhere
+private _isGlobal = _controlsGroup getVariable [QGVAR(isGlobal), 0];
+private _source = ROW_SOURCE(_controlsGroup);
+
+private _showClient = _source isNotEqualTo "client" && _isGlobal < 2;
+private _showMission = _source isEqualTo "server" && _isGlobal < 2;
+
+private _ctrlOverwriteClient = _controlsGroup controlsGroupCtrl IDC_SETTING_OVERWRITE_CLIENT;
+private _ctrlOverwriteMission = _controlsGroup controlsGroupCtrl IDC_SETTING_OVERWRITE_MISSION;
+
+_ctrlOverwriteClient ctrlShow _showClient;
+_ctrlOverwriteMission ctrlShow _showMission;
+
+// a checkbox that isn't there can't be ticked either. Whether the ones that are
+// can be is not this function's to answer, so it only ever takes that away -
+// FUNC(gui_setRowEnabled) and the row's updateUI_priority own the other half.
+_ctrlOverwriteClient ctrlEnable (_showClient && ctrlEnabled _ctrlOverwriteClient);
+_ctrlOverwriteMission ctrlEnable (_showMission && ctrlEnabled _ctrlOverwriteMission);

--- a/addons/settings/fnc_gui_setRowEnabled.sqf
+++ b/addons/settings/fnc_gui_setRowEnabled.sqf
@@ -30,9 +30,14 @@ params ["_controlsGroup"];
 private _setting = ROW_SETTING(_controlsGroup);
 private _source = ROW_SOURCE(_controlsGroup);
 
+// a local setting is never overwritten by the mission, so there is nothing a
+// mission maker could set from here. The server keeps it: a server is a client
+// too, and FUNC(set) writes both when it is set there.
+private _isLocalOnly = ROW_IS_LOCAL_ONLY(_controlsGroup);
+
 private _enabled = switch (_source) do {
     case "client": {CAN_SET_CLIENT_SETTINGS && {isNil {GVAR(userconfig) getVariable _setting}}};
-    case "mission": {CAN_SET_MISSION_SETTINGS && {isNil {GVAR(missionConfig) getVariable _setting}}};
+    case "mission": {CAN_SET_MISSION_SETTINGS && !_isLocalOnly && {isNil {GVAR(missionConfig) getVariable _setting}}};
     case "server": {CAN_SET_SERVER_SETTINGS && {isNil {GVAR(serverConfig) getVariable _setting}}};
     default {false};
 };

--- a/addons/settings/fnc_gui_settingOverwrite.sqf
+++ b/addons/settings/fnc_gui_settingOverwrite.sqf
@@ -31,7 +31,8 @@ _controlsGroup setVariable [QFUNC(auto_check_overwrite), {
 
     // a local only setting has no "overwrite clients" to tick, and a priority
     // ticked in here would be sanitized away again the moment it is saved
-    if (_source isEqualTo "mission" && !ROW_IS_LOCAL_ONLY(_controlsGroup)) then {
+    private _isLocalOnly = ROW_IS_LOCAL_ONLY(_controlsGroup);
+    if (_source isEqualTo "mission" && !_isLocalOnly) then {
         private _ctrlOverwriteClient = _controlsGroup controlsGroupCtrl IDC_SETTING_OVERWRITE_CLIENT;
 
         if (!cbChecked _ctrlOverwriteClient) then {

--- a/addons/settings/fnc_gui_settingOverwrite.sqf
+++ b/addons/settings/fnc_gui_settingOverwrite.sqf
@@ -29,7 +29,9 @@ _ctrlOverwriteClient setVariable [QFUNC(event), {
 _controlsGroup setVariable [QFUNC(auto_check_overwrite), {
     params ["_controlsGroup", "_source"];
 
-    if (_source isEqualTo "mission") then {
+    // a local only setting has no "overwrite clients" to tick, and a priority
+    // ticked in here would be sanitized away again the moment it is saved
+    if (_source isEqualTo "mission" && !ROW_IS_LOCAL_ONLY(_controlsGroup)) then {
         private _ctrlOverwriteClient = _controlsGroup controlsGroupCtrl IDC_SETTING_OVERWRITE_CLIENT;
 
         if (!cbChecked _ctrlOverwriteClient) then {

--- a/addons/settings/script_component.hpp
+++ b/addons/settings/script_component.hpp
@@ -237,8 +237,18 @@
 // str and format ["%1", ] on their own can only do either.
 #define TO_STRING(var) (call {private _str = var; if (_str isEqualType "") then {_str = str _str}; format ["%1", _str]})
 
-#define IS_GLOBAL_SETTING(setting) (GVAR(default) getVariable [setting, []] param [7, 0] == 1)
-#define IS_LOCAL_SETTING(setting)  (GVAR(default) getVariable [setting, []] param [7, 0] == 2)
+// A setting's _isGlobal, as it is registered and as a settings menu row stores it.
+// Every client has their own value unless something overwrites it, GLOBAL_ONLY is
+// always overwritten for everyone, LOCAL_ONLY can't be overwritten at all.
+#define SETTING_LOCAL_OVERRIDABLE 0
+#define SETTING_GLOBAL_ONLY 1
+#define SETTING_LOCAL_ONLY 2
+
+#define IS_GLOBAL_SETTING(setting) (GVAR(default) getVariable [setting, []] param [7, 0] == SETTING_GLOBAL_ONLY)
+#define IS_LOCAL_SETTING(setting)  (GVAR(default) getVariable [setting, []] param [7, 0] == SETTING_LOCAL_ONLY)
+
+// the same question asked of a row, which keeps its setting's _isGlobal
+#define ROW_IS_LOCAL_ONLY(group) ((group getVariable [ARR_2(QGVAR(isGlobal),SETTING_LOCAL_OVERRIDABLE)]) == SETTING_LOCAL_ONLY)
 
 #define SANITIZE_PRIORITY(setting,priority,source) (call {\
     private _priority = priority;\

--- a/addons/settings/test.sqf
+++ b/addons/settings/test.sqf
@@ -5,7 +5,7 @@
 #define DEBUG_MODE_FULL
 #include "script_component.hpp"
 
-#define TESTS ["parse"]
+#define TESTS ["parse", "gui"]
 
 SCRIPT(test-settings);
 

--- a/addons/settings/test_gui.sqf
+++ b/addons/settings/test_gui.sqf
@@ -45,12 +45,12 @@ private _testSettings = [];
 
     _testSettings pushBack _setting;
 } forEach [
-    ["a1", _testCategoryA, "", 0],
-    ["a2", _testCategoryA, "Folded", 0],
-    ["a3", _testCategoryA, "Folded", 1], // global, forced to overwrite the clients
-    ["a4", _testCategoryA, "Folded", 2], // local, can't overwrite anything
-    ["b1", _testCategoryB, "", 0],
-    ["b2", _testCategoryB, "", 0]
+    ["a1", _testCategoryA, "", SETTING_LOCAL_OVERRIDABLE],
+    ["a2", _testCategoryA, "Folded", SETTING_LOCAL_OVERRIDABLE],
+    ["a3", _testCategoryA, "Folded", SETTING_GLOBAL_ONLY], // always overwrites the clients
+    ["a4", _testCategoryA, "Folded", SETTING_LOCAL_ONLY], // can't be overwritten
+    ["b1", _testCategoryB, "", SETTING_LOCAL_OVERRIDABLE],
+    ["b2", _testCategoryB, "", SETTING_LOCAL_OVERRIDABLE]
 ];
 
 // ----- every visible row's checkboxes have to match the source it is showing
@@ -69,11 +69,11 @@ private _fnc_check = {
         // then is invisible either way
         if (ctrlShown _x) then {
             private _setting = ROW_SETTING(_x);
-            private _isGlobal = _x getVariable [QGVAR(isGlobal), 0];
+            private _isGlobal = _x getVariable [QGVAR(isGlobal), SETTING_LOCAL_OVERRIDABLE];
             private _enabled = ROW_ENABLED(_x);
 
-            private _showClient = _source isNotEqualTo "client" && _isGlobal < 2;
-            private _showMission = _source isEqualTo "server" && _isGlobal < 2;
+            private _showClient = _source isNotEqualTo "client" && _isGlobal isNotEqualTo SETTING_LOCAL_ONLY;
+            private _showMission = _source isEqualTo "server" && _isGlobal isNotEqualTo SETTING_LOCAL_ONLY;
 
             private _ctrlOverwriteClient = _x controlsGroupCtrl IDC_SETTING_OVERWRITE_CLIENT;
             private _ctrlOverwriteMission = _x controlsGroupCtrl IDC_SETTING_OVERWRITE_MISSION;
@@ -98,6 +98,11 @@ private _fnc_check = {
             // and neither of them may switch a locked row back on
             if (!_enabled && {ctrlEnabled _ctrlOverwriteClient || ctrlEnabled _ctrlOverwriteMission}) then {
                 _bad pushBack [_setting, "checkbox on, locked row"];
+            };
+
+            // the mission can't overwrite a local only setting, so it can't set one
+            if (_source isEqualTo "mission" && _isGlobal isEqualTo SETTING_LOCAL_ONLY && _enabled) then {
+                _bad pushBack [_setting, "local only row editable from mission"];
             };
         };
     } forEach (_ctrlOptionsGroup getVariable [QGVAR(rows), []]);

--- a/addons/settings/test_gui.sqf
+++ b/addons/settings/test_gui.sqf
@@ -1,0 +1,224 @@
+// ----------------------------------------------------------------------------
+#define DEBUG_MODE_FULL
+#include "script_component.hpp"
+
+SCRIPT(test_settings_gui);
+
+// ----------------------------------------------------------------------------
+
+LOG('Testing Settings GUI');
+
+// Showing a controls group shows every control inside it, nested ones included,
+// so anything a row hid by itself comes back with it. These tests walk the menu
+// the way a user does and check that the overwrite checkboxes of every visible
+// row still match the source it is pointed at.
+
+private _parentDisplay = findDisplay 46;
+
+if (isNull _parentDisplay) exitWith {
+    WARNING("Settings GUI test needs to run in a mission, skipped.");
+};
+
+// ----- settings to test against. Every CBA setting lives in one category, and
+// ----- the menu needs more than one of them to have something to switch to.
+private _previousAddon = uiNamespace getVariable [QGVAR(addon), ""];
+private _previousSource = uiNamespace getVariable [QGVAR(source), ""];
+
+private _testCategoryA = "CBA Settings Test A";
+private _testCategoryB = "CBA Settings Test B";
+private _testSettings = [];
+
+{
+    _x params ["_name", "_category", "_subCategory", "_isGlobal"];
+
+    // an empty sub-category is the same as not passing one at all
+    private _setting = format ["%1_%2", QGVAR(test_gui), _name];
+
+    [
+        _setting,
+        "CHECKBOX",
+        ["-test setting-", "-test setting-"],
+        [_category, _subCategory],
+        false,
+        _isGlobal
+    ] call CBA_fnc_addSetting;
+
+    _testSettings pushBack _setting;
+} forEach [
+    ["a1", _testCategoryA, "", 0],
+    ["a2", _testCategoryA, "Folded", 0],
+    ["a3", _testCategoryA, "Folded", 1], // global, forced to overwrite the clients
+    ["a4", _testCategoryA, "Folded", 2], // local, can't overwrite anything
+    ["b1", _testCategoryB, "", 0],
+    ["b2", _testCategoryB, "", 0]
+];
+
+// ----- every visible row's checkboxes have to match the source it is showing
+private _fnc_check = {
+    params ["_tag"];
+
+    private _display = uiNamespace getVariable [QGVAR(display), displayNull];
+    private _category = uiNamespace getVariable [QGVAR(addon), ""];
+    private _source = uiNamespace getVariable [QGVAR(source), ""];
+    private _optionsGroups = _display getVariable [QGVAR(optionsGroups), createHashMap];
+    private _ctrlOptionsGroup = _optionsGroups getOrDefault [_category, controlNull];
+    private _bad = [];
+
+    {
+        // a folded or filtered out row is hidden itself, what its checkboxes say
+        // then is invisible either way
+        if (ctrlShown _x) then {
+            private _setting = ROW_SETTING(_x);
+            private _isGlobal = _x getVariable [QGVAR(isGlobal), 0];
+            private _enabled = ROW_ENABLED(_x);
+
+            private _showClient = _source isNotEqualTo "client" && _isGlobal < 2;
+            private _showMission = _source isEqualTo "server" && _isGlobal < 2;
+
+            private _ctrlOverwriteClient = _x controlsGroupCtrl IDC_SETTING_OVERWRITE_CLIENT;
+            private _ctrlOverwriteMission = _x controlsGroupCtrl IDC_SETTING_OVERWRITE_MISSION;
+
+            if ((ctrlShown _ctrlOverwriteClient) isNotEqualTo _showClient) then {
+                _bad pushBack [_setting, "client shown", ctrlShown _ctrlOverwriteClient];
+            };
+
+            if ((ctrlShown _ctrlOverwriteMission) isNotEqualTo _showMission) then {
+                _bad pushBack [_setting, "mission shown", ctrlShown _ctrlOverwriteMission];
+            };
+
+            // a checkbox that isn't there must not be reachable either
+            if (!_showClient && ctrlEnabled _ctrlOverwriteClient) then {
+                _bad pushBack [_setting, "client on while hidden"];
+            };
+
+            if (!_showMission && ctrlEnabled _ctrlOverwriteMission) then {
+                _bad pushBack [_setting, "mission on while hidden"];
+            };
+
+            // and neither of them may switch a locked row back on
+            if (!_enabled && {ctrlEnabled _ctrlOverwriteClient || ctrlEnabled _ctrlOverwriteMission}) then {
+                _bad pushBack [_setting, "checkbox on, locked row"];
+            };
+        };
+    } forEach (_ctrlOptionsGroup getVariable [QGVAR(rows), []]);
+
+    // only the selected category may be drawn
+    private _shownCategories = 0;
+
+    {
+        if (ctrlShown _y) then {_shownCategories = _shownCategories + 1};
+    } forEach _optionsGroups;
+
+    if (_shownCategories > 1) then {
+        _bad pushBack ["-", "categories drawn at once", _shownCategories];
+    };
+
+    // the message can't be built inside the macro, its commas would split the arguments
+    private _message = format ["settings menu (%1): %2", _tag, _bad];
+
+    TEST_TRUE(_bad isEqualTo [],_message);
+};
+
+// ----- open the menu on the first category
+[_parentDisplay] call FUNC(openSettingsMenu);
+
+private _display = uiNamespace getVariable [QGVAR(display), displayNull];
+private _ctrlAddonList = _display displayCtrl IDC_ADDONS_LIST;
+
+["opened"] call _fnc_check;
+
+// ----- every source shows its own set of checkboxes
+{
+    _x params ["_idc", "_name"];
+
+    (_display displayCtrl _idc) call FUNC(gui_sourceChanged);
+
+    [format ["source %1", _name]] call _fnc_check;
+} forEach [[IDC_BTN_SERVER, "server"], [IDC_BTN_MISSION, "mission"], [IDC_BTN_CLIENT, "client"]];
+
+// ----- a category is built for the source that was shown when it was created,
+// ----- and every category after the first is created while another one is shown
+(_display displayCtrl IDC_BTN_MISSION) call FUNC(gui_sourceChanged);
+
+private _testIndices = [];
+
+for "_index" from 0 to (lbSize _ctrlAddonList) - 1 do {
+    [_ctrlAddonList, _index] call FUNC(gui_addonChanged);
+
+    [format ["category %1", _index]] call _fnc_check;
+
+    if ((uiNamespace getVariable [QGVAR(addon), ""]) in [toLower _testCategoryA, toLower _testCategoryB]) then {
+        _testIndices pushBack _index;
+    };
+};
+
+// ----- searching hides rows and clearing the search brings them back
+private _ctrlSearch = _display displayCtrl IDC_SEARCH_EDIT;
+
+_ctrlSearch ctrlSetText "test setting";
+_display call FUNC(gui_search);
+
+["searched"] call _fnc_check;
+
+_ctrlSearch ctrlSetText "";
+_display call FUNC(gui_search);
+
+["search cleared"] call _fnc_check;
+
+// ----- folding a sub-category away hides its rows, unfolding brings them back
+[_ctrlAddonList, _testIndices param [0, 0]] call FUNC(gui_addonChanged);
+
+private _category = uiNamespace getVariable [QGVAR(addon), ""];
+private _ctrlOptionsGroup = (_display getVariable [QGVAR(optionsGroups), createHashMap]) getOrDefault [_category, controlNull];
+private _rowOrder = _ctrlOptionsGroup getVariable [QGVAR(rowOrder), []];
+private _headerIndex = _rowOrder findIf {!isNil {_x getVariable QGVAR(members)}};
+
+if (_headerIndex == -1) then {
+    WARNING("No sub-category to fold, part of the settings GUI test was skipped.");
+} else {
+    private _ctrlHeaderGroup = _rowOrder select _headerIndex;
+
+    [_ctrlHeaderGroup] call FUNC(gui_toggleSubCategory);
+    ["folded"] call _fnc_check;
+
+    [_ctrlHeaderGroup] call FUNC(gui_toggleSubCategory);
+    ["unfolded"] call _fnc_check;
+};
+
+// ----- switching to the base game menu and back shows the addons group again,
+// ----- and with it everything that was ever built inside it
+private _ctrlToggleButton = _display displayCtrl IDC_BTN_CONFIGURE_ADDONS;
+
+// FUNC(openSettingsMenu) hides the button, this doesn't go through it
+_ctrlToggleButton ctrlEnable true;
+_ctrlToggleButton ctrlShow true;
+
+_ctrlToggleButton call FUNC(gui_configure);
+_ctrlToggleButton call FUNC(gui_configure);
+
+["configure round trip"] call _fnc_check;
+
+// ----- close without keeping any of it
+_display closeDisplay IDC_CANCEL;
+
+// ----- and take the test settings back out
+{
+    GVAR(default) setVariable [_x, nil];
+    GVAR(client) setVariable [_x, nil];
+    GVAR(mission) setVariable [_x, nil];
+    missionNamespace setVariable [_x, nil];
+
+    if (isServer && {!isNull GVAR(server)}) then {
+        GVAR(server) setVariable [_x, nil, true];
+    };
+
+    GVAR(allSettings) deleteAt (GVAR(allSettings) find _x);
+} forEach _testSettings;
+
+// the menu indices still list them, they are rebuilt when it is next opened
+GVAR(searchIndex) = nil;
+GVAR(categorySettings) = nil;
+GVAR(subCategories) = nil;
+
+uiNamespace setVariable [QGVAR(addon), _previousAddon];
+uiNamespace setVariable [QGVAR(source), _previousSource];


### PR DESCRIPTION
**When merged this pull request will:**
- Replace #1839.
- Fix the greyed out "Mission" overwrite checkboxes appearing on the Mission and Client tabs after changing category, by putting the checkboxes back after the row's controls group is shown, rather than by skipping the `ctrlShow`.
- Handle other edge cases:
  - Clearing the search bar, or unfolding a sub-category, on the Mission or Client tab. Both bring a row back with `ctrlShow`, which shows every control inside it again, so the checkboxes the source doesn't use reappeared. 
  - Toggling "Configure Base Game" and back to "Configure Addons" from the vanilla options menu. `ctrlShow true` on the addons group shows every category built inside it, so all of them were drawn on top of each other, and every row a search or a folded sub-category had hidden came back. Only the selected category is shown now, and its rows are re-filtered once the source is known again.
  - The "Overwrite mission" checkbox enabling itself on a row that can't be edited. `gui_setOverwriteVisible` used to `ctrlEnable _show` unconditionally, undoing `gui_setRowEnabled` for a setting locked by userconfig, the mission or the server config. It now only ever takes the enable away, so it can't fight `gui_setRowEnabled` or the row's `updateUI_priority` when it is re-applied.

- Cleanup:
  - `gui_setOverwriteVisible` takes the row instead of a single checkbox and works both out from the row's own source and `isGlobal`, so it is repeatable and there is one place that knows which checkboxes a source uses. Removes the duplicated condition in `gui_retargetRow`.
  - `gui_addonChanged` iterates the options groups hashmap directly instead of `keys` + `get`.
  - Trailing whitespace in `fnc_check.sqf` and `fnc_gui_addonChanged.sqf`.
