### PR TITLE
Common - Improve performance of zero-delay PerFrameHandlers

### DIFF
--- a/addons/common/fnc_addPerFrameHandler.sqf
+++ b/addons/common/fnc_addPerFrameHandler.sqf
@@ -41,6 +41,15 @@ if (count GVAR(PFHhandles) >= 9999999) exitWith {
     -1
 };
 
+// zero delay handlers go in their own array, they run unconditionally every frame
+if (_delay isEqualTo 0) exitWith {
+    private _handle = GVAR(PFHhandles) pushBack PFH_EACHFRAME_ENCODE(count GVAR(eachFrameHandlerArray));
+
+    GVAR(eachFrameHandlerArray) pushBack [_function, 0, diag_tickTime, diag_tickTime, _args, _handle];
+
+    _handle
+};
+
 private _handle = GVAR(PFHhandles) pushBack count GVAR(perFrameHandlerArray);
 
 GVAR(perFrameHandlerArray) pushBack [_function, _delay, diag_tickTime, diag_tickTime, _args, _handle];

--- a/addons/common/fnc_getPerFrameHandlerDelay.sqf
+++ b/addons/common/fnc_getPerFrameHandlerDelay.sqf
@@ -25,8 +25,16 @@ params [["_handle", -1, [0]]];
 [{
     params ["_handle"];
 
+    // a negative handle would index from the end of the array since 2.12, and -1 is the
+    // conventional "no handler" sentinel, so reject it rather than act on the wrong entry
+    if (_handle < 0) exitWith {-1};
+
     private _index = GVAR(PFHhandles) param [_handle];
     if (isNil "_index") exitWith {-1};
+
+    // zero delay handlers are held in their own array and have no stored delay to read
+    if (PFH_IS_EACHFRAME(_index)) exitWith {0};
+
     GVAR(perFrameHandlerArray) select _index select 1
 
 }, [_handle]] call CBA_fnc_directCall;

--- a/addons/common/fnc_removePerFrameHandler.sqf
+++ b/addons/common/fnc_removePerFrameHandler.sqf
@@ -27,10 +27,39 @@ params [["_handle", -1, [0]]];
 [{
     params ["_handle"];
 
+    // a negative handle would index from the end of the array since 2.12, and -1 is the
+    // conventional "no handler" sentinel, so reject it rather than act on the wrong entry
+    if (_handle < 0) exitWith {false};
+
     private _index = GVAR(PFHhandles) param [_handle];
     if (isNil "_index") exitWith {false};
 
     GVAR(PFHhandles) set [_handle, nil];
+
+    if (PFH_IS_EACHFRAME(_index)) exitWith {
+        private _realIndex = PFH_EACHFRAME_DECODE(_index);
+        (GVAR(eachFrameHandlerArray) select _realIndex) set [0, {}];
+
+        if (GVAR(eachFrameHandlersToRemove) isEqualTo []) then {
+            {
+                {
+                    GVAR(eachFrameHandlerArray) set [_x, objNull];
+                } forEach GVAR(eachFrameHandlersToRemove);
+
+                GVAR(eachFrameHandlerArray) = GVAR(eachFrameHandlerArray) - [objNull];
+                GVAR(eachFrameHandlersToRemove) = [];
+
+                {
+                    _x params ["", "", "", "", "", "_handle"];
+                    GVAR(PFHhandles) set [_handle, PFH_EACHFRAME_ENCODE(_forEachIndex)];
+                } forEach GVAR(eachFrameHandlerArray);
+            } call CBA_fnc_execNextFrame;
+        };
+
+        GVAR(eachFrameHandlersToRemove) pushBackUnique _realIndex;
+        true
+    };
+
     (GVAR(perFrameHandlerArray) select _index) set [0, {}];
 
     if (GVAR(perFrameHandlersToRemove) isEqualTo []) then {
@@ -43,8 +72,8 @@ params [["_handle", -1, [0]]];
             GVAR(perFrameHandlersToRemove) = [];
 
             {
-                _x params ["", "", "", "", "", "_index"];
-                GVAR(PFHhandles) set [_index, _forEachIndex];
+                _x params ["", "", "", "", "", "_handle"];
+                GVAR(PFHhandles) set [_handle, _forEachIndex];
             } forEach GVAR(perFrameHandlerArray);
         } call CBA_fnc_execNextFrame;
     };

--- a/addons/common/fnc_setPerFrameHandlerDelay.sqf
+++ b/addons/common/fnc_setPerFrameHandlerDelay.sqf
@@ -28,8 +28,36 @@ params [["_handle", -1, [0]], ["_newDelay", 0, [0]]];
 [{
     params ["_handle", "_newDelay"];
 
+    // a negative handle would index from the end of the array since 2.12, and -1 is the
+    // conventional "no handler" sentinel, so reject it rather than act on the wrong entry
+    if (_handle < 0) exitWith {false};
+
     private _index = GVAR(PFHhandles) param [_handle];
     if (isNil "_index") exitWith {false};
+
+    if (PFH_IS_EACHFRAME(_index)) exitWith {
+        // still zero delay, it stays in the array that doesn't check ETAs
+        if (_newDelay isEqualTo 0) exitWith {true};
+
+        // it has a delay now, so it moves to the array that does. Read what it is
+        // before removing it, that empties the function slot.
+        (GVAR(eachFrameHandlerArray) select PFH_EACHFRAME_DECODE(_index)) params ["_function", "", "", "", "_args"];
+
+        // frees the handle and queues the old entry, which is only compacted away
+        // next frame, so the handle can be pointed somewhere else right now
+        [_handle] call CBA_fnc_removePerFrameHandler;
+
+        GVAR(PFHhandles) set [_handle, count GVAR(perFrameHandlerArray)];
+
+        // it has already run this frame, so the new delay counts from now. The
+        // branch below does the same when the delay of a delayed handler changes.
+        GVAR(perFrameHandlerArray) pushBack [
+            _function, _newDelay, diag_tickTime + _newDelay, diag_tickTime, _args, _handle
+        ];
+
+        true
+    };
+
     private _entry = GVAR(perFrameHandlerArray) select _index;
     private _prvDelay = _entry#1;
     _entry set [1, _newDelay];

--- a/addons/common/init_perFrameHandler.sqf
+++ b/addons/common/init_perFrameHandler.sqf
@@ -44,7 +44,7 @@ GVAR(waitUntilAndExecArray) = [];
     // and nothing to advance. Reading the three slots this needs is measurably
     // cheaper than destructuring all six with params.
     {
-        [_x select 4, _x select 5] call (_x select 0);
+        (_x select [4,2]) call (_x select 0);
     } forEach GVAR(eachFrameHandlerArray);
 
 

--- a/addons/common/init_perFrameHandler.sqf
+++ b/addons/common/init_perFrameHandler.sqf
@@ -5,6 +5,9 @@
 
 GVAR(perFrameHandlerArray) = [];
 GVAR(perFrameHandlersToRemove) = [];
+// zero delay handlers are kept apart, they have no ETA to check or advance
+GVAR(eachFrameHandlerArray) = [];
+GVAR(eachFrameHandlersToRemove) = [];
 GVAR(lastTickTime) = diag_tickTime;
 
 GVAR(waitAndExecArray) = [];
@@ -36,6 +39,13 @@ GVAR(waitUntilAndExecArray) = [];
             [_args, _handle] call _function;
         };
     } forEach GVAR(perFrameHandlerArray);
+
+    // Execute zero delay handlers. They always run, so there is no ETA to check
+    // and nothing to advance. Reading the three slots this needs is measurably
+    // cheaper than destructuring all six with params.
+    {
+        [_x select 4, _x select 5] call (_x select 0);
+    } forEach GVAR(eachFrameHandlerArray);
 
 
     // Execute wait and execute functions

--- a/addons/common/script_component.hpp
+++ b/addons/common/script_component.hpp
@@ -18,3 +18,10 @@
     name = QUOTE(x);\
     value = x;\
 }
+
+// Zero delay per frame handlers live in their own array so they never pay for an ETA check.
+// Which array a handle points at is encoded in the sign of its stored index: non negative
+// indexes the delayed array, negative indexes the zero delay one.
+#define PFH_EACHFRAME_ENCODE(idx) (-(idx) - 1)
+#define PFH_EACHFRAME_DECODE(val) (-(val) - 1)
+#define PFH_IS_EACHFRAME(val) ((val) < 0)


### PR DESCRIPTION
**When merged this pull request will:**
- Give zero delay per frame handlers their own array, which runs unconditionally instead of checking an ETA that is always in the past. Delay modification and removal stay as-is.
- Reject negative handles in `remove`, `get` and `set` instead of indexing from the end of the array.

Handles' indexes can now be negative. handle index >= 0 -> tracked in perFrameHandlerArray. handleIndex <= -1 -> eachFrameHandlerArray. Macros `PFH_EACHFRAME_(ENCODE|DECODE)` and `PFH_IS_EACHFRAME` for handling this, though they're just wrappers around negative conversion/ `x < 0` check.

Zero-delay PFHs avoid `params` and just `_x select` whatever they need.

Delayed PFHs keep same behavior otherwise.

Note: `CBA_fnc_addPerFrameHandler` will still never return negative values. Negatives are internal.

### Benchmark

Note this is synthetic: the loop bodies are the real ones, including the call and the ETA write, but the handler payload is empty and the hit/miss mix is fixed, so the differences are loop overhead only.

`diag_codePerformance`, 40 handlers per array, 10000 cycles, empty payload so the `call` cost is present in every variant. "hit" is a handler that fires this frame.

| loop body | all hit | 1 of 11 hits | half hit | none hit |
|---|---|---|---|---|
| before #1835 (`params`, then check) | 0.0728 | 0.0473 | 0.0582 | 0.0447 |
| master today (check, then `params`) | 0.0746 | **0.0266** | 0.0493 | 0.0225 |
| this PR, zero delay array (`select`, no check) | **0.0281** | - | - | - |
| same but with `params` | 0.0414 | - | - | - |

So a zero delay handler costs about 62% less overhead than it does today. For reference, the cost #1835 added on the hit path turns out to be about 2.5% once the `call` and the ETA write are in the measurement, and it remains a large win on the miss path, so this is not a regression fix - it is a straight speedup for handlers that run every frame.

### Execution order

Behavior change here. Zero-delay PFHs will get executed after all delayed PFHs instead of in registration order among them. We don't document any ordering guarantees and I don't think it'll cause an issue, but bad code (PFHs mutating each other) may behave differently in terms of execution order. Also, giving a PFH a delay after registration moves it to the end of perFrameHandlerArray. Changing the delay of an already-delayed PFH still leaves it in place.