### PR TITLE
Strings - Cleanup + Optimize string functions

### DIFF
--- a/addons/strings/fnc_capitalize.sqf
+++ b/addons/strings/fnc_capitalize.sqf
@@ -25,19 +25,34 @@ Author:
 ---------------------------------------------------------------------------- */
 SCRIPT(capitalize);
 
-forceUnicode 0;
-
 params [["_string", "", [""]]];
 
-if (_string isNotEqualTo "") then {
-    // Take first character and Upper case
-    private _string1 = toUpper (_string select [0, 1]);
+if (_string isEqualTo "") exitWith {""};
 
-    // Take rest and lower it
-    private _string2 = toLower (_string select [1]);
+// Detect if and how unicode support was forced
+private _unicode = count "д" == 1;
+private _forceUnicode = count "д" == 1;
 
-    // Compile string
-    _string = _string1 + _string2;
+// Force unicode support
+forceUnicode 0;
+
+// Take first character and convert to upper case
+private _string1 = toUpper (_string select [0, 1]);
+
+// Take rest and convert to lower case
+private _string2 = toLower (_string select [1]);
+
+// Compile string
+_string = _string1 + _string2;
+
+// Revert unicode support if necessary
+switch (true) do {
+    // Force unicode (already has been, so don't do it again)
+    case (_forceUnicode): {};
+    // Unicode flag is reset right after any of the supported commands executed or the end of script, whichever comes earlier
+    case (_unicode): {forceUnicode 1};
+    // Reset unicode flag
+    default {forceUnicode -1};
 };
 
 _string // return

--- a/addons/strings/fnc_capitalize.sqf
+++ b/addons/strings/fnc_capitalize.sqf
@@ -6,10 +6,10 @@ Description:
     Upper case the first letter of the string, lower case the rest.
 
 Parameters:
-    _string - String to capitalize [String]
+    _string - String to capitalize <STRING>
 
 Returns:
-    Capitalized string [String].
+    Capitalized string <STRING>
 
 Examples:
     (begin example)
@@ -25,16 +25,19 @@ Author:
 ---------------------------------------------------------------------------- */
 SCRIPT(capitalize);
 
-params ["_string"];
+forceUnicode 0;
 
-private _charCount = count _string;
-if (_charCount > 0) then {
-    // Take first Char and Upper case
-    private _string1 = (toUpper _string) select [0, 1];
+params [["_string", "", [""]]];
+
+if (_string isNotEqualTo "") then {
+    // Take first character and Upper case
+    private _string1 = toUpper (_string select [0, 1]);
+
     // Take rest and lower it
-    private _string2 = (toLower _string) select [1];
-    // Compile String
+    private _string2 = toLower (_string select [1]);
+
+    // Compile string
     _string = _string1 + _string2;
 };
 
-_string
+_string // return

--- a/addons/strings/fnc_capitalize.sqf
+++ b/addons/strings/fnc_capitalize.sqf
@@ -31,7 +31,7 @@ if (_string isEqualTo "") exitWith {""};
 
 // Detect if and how unicode support was forced
 private _unicode = count "д" == 1;
-private _forceUnicode = count "д" == 1;
+private _forceUnicode = count "д" == 1; // differs from _unicode if forceUnicode was 1
 
 // Force unicode support
 forceUnicode 0;

--- a/addons/strings/fnc_decodeURL.sqf
+++ b/addons/strings/fnc_decodeURL.sqf
@@ -9,7 +9,7 @@ Parameters:
     _string - URL encoded text <STRING>
 
 Returns:
-    _return - Human readable text <STRING>
+    Human readable text <STRING>
 
 Examples:
     (begin example)
@@ -19,12 +19,14 @@ Examples:
 Author:
     commy2
 ---------------------------------------------------------------------------- */
+SCRIPT(decodeURL);
 
 params [["_string", "", [""]]];
+
 if (_string isEqualTo "") exitWith {""};
 
-private _cache = missionNamespace getVariable [QGVAR(URLCache), objNull];
-private _return = _cache getVariable _string;
+if (isNil QGVAR(URLCache)) then {
+    GVAR(URLCache) = createHashMap;
 
 if (isNil "_return") then {
     _return = _string;
@@ -35,12 +37,8 @@ if (isNil "_return") then {
             _return = ([_return] + _x) call CBA_fnc_replace;
         } forEach UTF8_TABLE;
     };
-    if (isNull _cache) then {
-        _cache = [] call CBA_fnc_createNamespace;
-        missionNamespace setVariable [QGVAR(URLCache), _cache];
-    };
 
-    _cache setVariable [_string, _return];
+    GVAR(URLCache) set [_string, _return];
 };
 
-_return
+_return // return

--- a/addons/strings/fnc_decodeURL.sqf
+++ b/addons/strings/fnc_decodeURL.sqf
@@ -27,6 +27,9 @@ if (_string isEqualTo "") exitWith {""};
 
 if (isNil QGVAR(URLCache)) then {
     GVAR(URLCache) = createHashMap;
+};
+
+private _return = GVAR(URLCache) get _string;
 
 if (isNil "_return") then {
     _return = _string;

--- a/addons/strings/fnc_find.sqf
+++ b/addons/strings/fnc_find.sqf
@@ -4,15 +4,16 @@ Function: CBA_fnc_find
 
 Description:
     Finds a string within another string.
+    Reliably supports strings with ANSI characters only.
 
 Parameters:
-    _haystack - String in which to search [String or ASCII char array]
-    _needle - String to search for [String or ASCII char array]
+    _haystack     - String in which to search <STRING>
+    _needle       - String to search for <STRING>
     _initialIndex - Initial character index within _haystack to start the
-    search at [Number: 0+, defaults to 0].
+    search at, should be >= 0 (optional, default: 0) <SCALAR>
 
 Returns:
-    First position of string. Returns -1 if not found [Number]
+    First position of string. Returns -1 if not found <SCALAR>
 
 Examples:
     (begin example)
@@ -36,19 +37,4 @@ params ["_haystack", "_needle", ["_initialIndex", 0]];
 if !(_haystack isEqualType "") exitWith {-1};
 if !(_needle isEqualType "") exitWith {-1};
 
-private _return = -1;
-
-if (_initialIndex < 1) then {
-    _return = _haystack find _needle;
-} else {
-    if (_initialIndex > count _haystack) exitWith {};
-
-    private _tempString = [_haystack, _initialIndex] call CBA_fnc_substr;
-    _return = _tempString find _needle;
-
-    if (_return > -1) then {
-        _return = _return + _initialIndex;
-    };
-};
-
-_return
+_haystack find [_needle, _initialIndex max 0] // return

--- a/addons/strings/fnc_floatToString.sqf
+++ b/addons/strings/fnc_floatToString.sqf
@@ -10,14 +10,11 @@ Description:
     This function is as barebones as possible. Inline macro version of this
     function can be used with FLOAT_TO_STRING(num).
 
-Limitations:
-
-
 Parameters:
-    _number - Number to format [Number]
+    _number - Number to format <SCALAR>
 
 Returns:
-    The number formatted into a string.
+    The number formatted into a string <STRING>
 
 Examples:
     (begin example)
@@ -29,4 +26,4 @@ Author:
     Nou
 ---------------------------------------------------------------------------- */
 
-if (_this == 0) then {"0"} else {str parseNumber (str (_this % _this) + str floor abs _this) + "." + (str (abs _this - floor abs _this) select [2]) + "0"};
+if (_this == 0) then {"0"} else {str parseNumber (str (_this % _this) + str floor abs _this) + "." + (str (abs _this - floor abs _this) select [2]) + "0"}

--- a/addons/strings/fnc_formatElapsedTime.sqf
+++ b/addons/strings/fnc_formatElapsedTime.sqf
@@ -1,3 +1,5 @@
+#define DEBUG_MODE_NORMAL
+#include "script_component.hpp"
 /* -----------------------------------------------------------------------------
 Function: CBA_fnc_formatElapsedTime
 
@@ -7,27 +9,21 @@ Description:
     Intended to show time elapsed, rather than time-of-day.
 
 Parameters:
-    _seconds - Number of seconds to format, for example from 'time' command [number]
-    _format - Format to put time into [String: "H:MM:SS", "M:SS",
-        "H:MM:SS.mmm" or "M:SS.mmm"; defaults to "H:MM:SS"]
+    _seconds - Number of seconds to format, for example from 'time' command <SCALAR>
+    _format  - Format to put time into "H:MM:SS", "M:SS",
+        "H:MM:SS.mmm" or "M:SS.mmm" (optional, default: "H:MM:SS") <STRING>
 
 Returns:
-    Formatted time [String]
+    Formatted time <STRING>
 
 Author:
     Spooner
 ---------------------------------------------------------------------------- */
-
-#define DEBUG_MODE_NORMAL
-#include "script_component.hpp"
-
 SCRIPT(formatElapsedTime);
-
-// -----------------------------------------------------------------------------
 
 params ["_seconds", ["_format", "H:MM:SS"]];
 
-// Discover all the digits to use.
+// Discover all the digits to use
 private _hours = floor (_seconds / 3600);
 _seconds = _seconds - (_hours * 3600);
 private _minutes = floor (_seconds / 60);
@@ -39,30 +35,34 @@ private _elapsed = switch (_format) do {
         format ["%1:%2:%3",
             _hours,
             [_minutes, 2] call CBA_fnc_formatNumber,
-            [floor _seconds, 2] call CBA_fnc_formatNumber];
+            [floor _seconds, 2] call CBA_fnc_formatNumber
+        ]
     };
     case "M:SS": {
         format ["%1:%2",
             _minutes,
-            [floor _seconds, 2] call CBA_fnc_formatNumber];
+            [floor _seconds, 2] call CBA_fnc_formatNumber
+        ]
     };
     case "H:MM:SS.mmm": {
         format ["%1:%2:%3",
             _hours,
             [_minutes, 2] call CBA_fnc_formatNumber,
-            [_seconds, 2, 3] call CBA_fnc_formatNumber];
+            [_seconds, 2, 3] call CBA_fnc_formatNumber
+        ]
     };
     case "M:SS.mmm": {
         format ["%1:%2",
             _minutes,
-            [_seconds, 2, 3] call CBA_fnc_formatNumber];
+            [_seconds, 2, 3] call CBA_fnc_formatNumber
+        ]
     };
     default {
         private "_msg";
         _msg = format ["%1: %2", _msg, _format];
         ERROR(_msg);
-        _msg;
+        _msg
     };
 };
 
-_elapsed; // Return.
+_elapsed // return

--- a/addons/strings/fnc_formatNumber.sqf
+++ b/addons/strings/fnc_formatNumber.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /* -----------------------------------------------------------------------------
 Function: CBA_fnc_formatNumber
 
@@ -20,16 +21,16 @@ Limitations:
     output might not be as EXPECTED after about eight significant figures.
 
 Parameters:
-    _number - Number to format [Number]
+    _number - Number to format <SCALAR>
     _integerWidth - Minimum width of integer part of number, padded with 0s,
-        [Number: >= 0, defaults to 1]
+        should be >= 0 (optional, default: 1) <SCALAR>
     _decimalPlaces - Number of decimal places, padded with trailing 0s,
-        if necessary [Number: >= 0, defaults to 0]
+        if necessary, should be >= 0 (optional, default: 0) <SCALAR>
     _separateThousands - True to separate each three digits with a comma
-        [Boolean, defaults to false]
+        <BOOL> (default: false)
 
 Returns:
-    The number formatted into a string.
+    The number formatted into a string <STRING>
 
 Examples:
     (begin example)
@@ -55,8 +56,6 @@ Examples:
 Author:
     Spooner, PabstMirror
 ---------------------------------------------------------------------------- */
-#define DEBUG_MODE_NORMAL
-#include "script_component.hpp"
 
 #define DEFAULT_INTEGER_WIDTH 1
 #define DEFAULT_DECIMAL_PLACES 0
@@ -70,25 +69,30 @@ private _isNegative = _number < 0;
 private _return = (abs _number) toFixed _decimalPlaces;
 private _dotIndex = if (_decimalPlaces == 0) then {count _return} else {_return find "."};
 
-
-while {_integerWidth > _dotIndex} do { // pad with leading zeros
+// Pad with leading zeros
+while {_integerWidth > _dotIndex} do {
     _return = "0" + _return;
     _dotIndex = _dotIndex + 1;
 };
+
+// toFixed always adds zero left of decimal point, remove it
 if ((_integerWidth == 0) && {_return select [0, 1] == "0"}) then {
-    _return = _return select [1]; // toFixed always adds zero left of decimal point, remove it
+    _return = _return select [1];
 };
-if (_separateThousands) then { // add localized thousands seperator "1,000"
+
+// Add localized thousands seperator "1,000"
+if (_separateThousands) then {
     private _thousandsSeparator = localize "STR_CBA_FORMAT_NUMBER_THOUSANDS_SEPARATOR";
+
     for "_index" from (_dotIndex - 3) to 1 step -3 do {
         _return = (_return select [0, _index]) + _thousandsSeparator + (_return select [_index]);
         _dotIndex = _dotIndex + 1;
     };
 };
 
-// Re-add negative sign if there is at least one decimal place != 0.
-if (_isNegative && {toArray _return arrayIntersect toArray "123456789" isNotEqualTo []}) then {
+// Re-add negative sign if there is at least one decimal place != 0
+if (_isNegative && {((toArray _return) arrayIntersect (toArray "123456789")) isNotEqualTo []}) then {
     _return = "-" + _return;
 };
 
-_return
+_return // return

--- a/addons/strings/fnc_leftTrim.sqf
+++ b/addons/strings/fnc_leftTrim.sqf
@@ -26,8 +26,6 @@ Author:
 ---------------------------------------------------------------------------- */
 SCRIPT(leftTrim);
 
-forceUnicode 0;
-
 params ["_string", ["_trim", "", [""]]];
 
 // Trim all whitespace characters by default

--- a/addons/strings/fnc_leftTrim.sqf
+++ b/addons/strings/fnc_leftTrim.sqf
@@ -9,11 +9,11 @@ Description:
     See <CBA_fnc_rightTrim> and <CBA_fnc_trim>.
 
 Parameters:
-    _string - String to trim [String]
-    _trim - Characters to trim [String] (default: "")
+    _string - String to trim <STRING>
+    _trim   - Characters to trim (optional, default: "") <STRING>
 
 Returns:
-    Trimmed string [String]
+    Trimmed string <STRING>
 
 Example:
     (begin example)
@@ -26,22 +26,13 @@ Author:
 ---------------------------------------------------------------------------- */
 SCRIPT(leftTrim);
 
-params ["_string", ["_trim", "", [""]]];
+forceUnicode 0;
 
-private _chars = toArray _string;
-private _numChars = count _chars;
+params ["_string", ["_trim", "", [""]]];
 
 // Trim all whitespace characters by default
 if (_trim == "") then {
-    _trim = WHITE_SPACE;
-} else {
-    _trim = toArray _trim;
+    _trim = toString WHITE_SPACE;
 };
 
-// We have to process the string in array form because it could differ in length (if there are non-ASCII characters)
-private _trimIndex = count _chars;
-{
-    if !(_x in _trim) exitWith { _trimIndex = _forEachIndex; };
-} forEach _chars;
-
-toString (_chars select [_trimIndex, _numChars - _trimIndex])
+_string trim [_trim, 1] // return

--- a/addons/strings/fnc_prettyFormat.sqf
+++ b/addons/strings/fnc_prettyFormat.sqf
@@ -9,7 +9,7 @@ Parameters:
     _array     - Array to format <ARRAY>
     _indents   - Indentation string (optional, default: "    ") <STRING>
     _lineBreak - Seperator string (optional, default: endl) <STRING>
-    _depth     - Initial indentation count (optional, default: 0) <NUMBER>
+    _depth     - Initial indentation count (optional, default: 0) <SCALAR>
 
 Returns:
     Formatted string <STRING>
@@ -48,6 +48,8 @@ Author:
    Terra, Dystopian, commy2
 
 ---------------------------------------------------------------------------- */
+SCRIPT(prettyFormat);
+
 params [
     ["_array", [], [[]]],
     ["_indent", "    ", [""]],

--- a/addons/strings/fnc_replace.sqf
+++ b/addons/strings/fnc_replace.sqf
@@ -6,12 +6,12 @@ Description:
     Replaces substrings within a string. Case-dependent.
 
 Parameters:
-    _string - String to make replacement in [String]
-    _pattern - Substring to replace [String]
-    _replacement - String to replace the _pattern with [String]
+    _string      - String to make replacement in <STRING>
+    _pattern     - Substring to replace <STRING>
+    _replacement - String to replace the _pattern with <STRING>
 
 Returns:
-    String with replacements made [String]
+    String with replacements made <STRING>
 
 Example:
     (begin example)
@@ -25,7 +25,9 @@ Author:
 SCRIPT(replace);
 
 params [["_string", "", [""]], ["_find", "", [""]], ["_replace", "", [""]]];
-if (_find == "") exitWith {_string}; // "1" find "" -> 0
+
+// "1" find "" -> 0
+if (_find == "") exitWith {_string};
 
 private _result = "";
 private _offset = count (_find splitString "");

--- a/addons/strings/fnc_replace.sqf
+++ b/addons/strings/fnc_replace.sqf
@@ -29,14 +29,25 @@ params [["_string", "", [""]], ["_find", "", [""]], ["_replace", "", [""]]];
 // "1" find "" -> 0
 if (_find == "") exitWith {_string};
 
-private _result = "";
-private _offset = count (_find splitString "");
+// building the pattern costs more than this check, and most calls don't match
+if (_string find _find == -1) exitWith {_string};
 
-while {_string find _find != -1} do {
-    private _index = _string find _find;
+// what is searched for is a literal, regexReplace wants a pattern
+private _pattern = _find call CBA_fnc_escapeRegex;
 
-    _result = _result + (_string select [0, _index]) + _replace;
-    _string = _string select [_index + _offset];
+// and what it is replaced with is a literal too, but the replacement is not a
+// pattern - it is Perl format, where "$" starts a substitution ($&, $1) and "\"
+// starts an escape (\U, \L). Doubling both is what writes them out as themselves.
+private _format = _replace;
+
+if (_format find "\" != -1) then {
+    _format = _format regexReplace ["\\", "\\\\"];
 };
 
-_result + _string
+if (_format find "$" != -1) then {
+    _format = _format regexReplace ["\$", "$$$$"];
+};
+
+// with no flags the engine defaults to "gi", and this function is case-dependent,
+// so global has to be asked for explicitly to get case-sensitive with it
+_string regexReplace [_pattern + "/g", _format] // return

--- a/addons/strings/fnc_rightTrim.sqf
+++ b/addons/strings/fnc_rightTrim.sqf
@@ -9,11 +9,11 @@ Description:
     See <CBA_fnc_leftTrim> and <CBA_fnc_trim>.
 
 Parameters:
-    _string - String to trim [String]
-    _trim - Characters to trim [String] (default: "")
+    _string - String to trim <STRING>
+    _trim   - Characters to trim (optional, default: "") <STRING>
 
 Returns:
-    Trimmed string [String]
+    Trimmed string <STRING>
 
 Example:
     (begin example)
@@ -26,28 +26,13 @@ Author:
 ---------------------------------------------------------------------------- */
 SCRIPT(rightTrim);
 
+forceUnicode 0;
+
 params ["_string", ["_trim", "", [""]]];
-
-private _chars = toArray _string;
-private _numChars = count _chars;
-
-// Trim from the right
-reverse _chars;
 
 // Trim all whitespace characters by default
 if (_trim == "") then {
-    _trim = WHITE_SPACE;
-} else {
-    _trim = toArray _trim;
+    _trim = toString WHITE_SPACE;
 };
 
-// We have to process the string in array form because it could differ in length (if there are non-ASCII characters)
-private _trimIndex = count _chars;
-{
-    if !(_x in _trim) exitWith { _trimIndex = _forEachIndex; };
-} forEach _chars;
-
-// Convert string back to original order
-reverse _chars;
-
-toString (_chars select [0, _numChars - _trimIndex])
+_string trim [_trim, 2] // return

--- a/addons/strings/fnc_rightTrim.sqf
+++ b/addons/strings/fnc_rightTrim.sqf
@@ -26,8 +26,6 @@ Author:
 ---------------------------------------------------------------------------- */
 SCRIPT(rightTrim);
 
-forceUnicode 0;
-
 params ["_string", ["_trim", "", [""]]];
 
 // Trim all whitespace characters by default

--- a/addons/strings/fnc_sanitizeHTML.sqf
+++ b/addons/strings/fnc_sanitizeHTML.sqf
@@ -19,6 +19,7 @@ Example:
 Author:
     commy2
 --------------------------------------------------------------------------- */
+SCRIPT(sanitizeHTML);
 
 params ["_string"];
 

--- a/addons/strings/fnc_split.sqf
+++ b/addons/strings/fnc_split.sqf
@@ -6,12 +6,12 @@ Description:
     Splits a string into substrings using a separator. Inverse of <CBA_fnc_join>.
 
 Parameters:
-    _string - String to split up [String]
+    _string    - String to split up <STRING>
     _separator - String to split around. If an empty string, "", then split
-        every character into a separate string [String, defaults to ""]
+        every character into a separate string (optional, default: "") <STRING>
 
 Returns:
-    The split string [Array of Strings]
+    The split string <ARRAY of STRINGS>
 
 Examples:
     (begin example)
@@ -35,19 +35,23 @@ private _inputCount = count _input;
 private _separatorCount = count _separator;
 
 // Corner cases
-if (_separatorCount == 0 && _inputCount == 0) exitWith {[]};
+if (_separatorCount == 0 && {_inputCount == 0}) exitWith {[]};
 if (_separatorCount == 0) exitWith {_input splitString ""};
-if (_inputCount > 0 && _separatorCount > _inputCount) exitWith {[_input]};
-if (_input == _separator) exitWith {["",""]};
+if (_inputCount > 0 && {_separatorCount > _inputCount}) exitWith {[_input]};
+if (_input == _separator) exitWith {["", ""]};
 
 private _lastWasSeperator = true;
+
 while {_index < _inputCount} do {
     private _find = (_input select [_index]) find _separator;
 
     if (_find == 0) then {
         _index = _index + _separatorCount;
 
-        if (_lastWasSeperator) then {_split pushBack "";};
+        if (_lastWasSeperator) then {
+            _split pushBack "";
+        };
+
         _lastWasSeperator = true;
     } else {
         _lastWasSeperator = false;
@@ -61,9 +65,10 @@ while {_index < _inputCount} do {
         };
     };
 };
-//Handle split at end:
+
+// Handle split at end
 if ((_inputCount >= _separatorCount) && _lastWasSeperator && {(_input select [(_inputCount - _separatorCount)]) isEqualTo _separator}) then {
     _split pushBack "";
 };
 
-_split
+_split // return

--- a/addons/strings/fnc_split.sqf
+++ b/addons/strings/fnc_split.sqf
@@ -29,46 +29,26 @@ SCRIPT(split);
 
 params [["_input", ""], ["_separator", ""]];
 
+// Corner cases
+if (_separator isEqualTo "") exitWith {_input splitString ""};
+if (_input isEqualTo "") exitWith {[]};
+
 private _split = [];
 private _index = 0;
-private _inputCount = count _input;
 private _separatorCount = count _separator;
 
-// Corner cases
-if (_separatorCount == 0 && {_inputCount == 0}) exitWith {[]};
-if (_separatorCount == 0) exitWith {_input splitString ""};
-if (_inputCount > 0 && {_separatorCount > _inputCount}) exitWith {[_input]};
-if (_input == _separator) exitWith {["", ""]};
+// find searches from an index without copying the rest of the string first, so
+// what is left between two separators is the only thing that gets cut out
+while {true} do {
+    private _found = _input find [_separator, _index];
 
-private _lastWasSeperator = true;
-
-while {_index < _inputCount} do {
-    private _find = (_input select [_index]) find _separator;
-
-    if (_find == 0) then {
-        _index = _index + _separatorCount;
-
-        if (_lastWasSeperator) then {
-            _split pushBack "";
-        };
-
-        _lastWasSeperator = true;
-    } else {
-        _lastWasSeperator = false;
-
-        if (_find == -1) then {
-            _split pushBack (_input select [_index]);
-            _index = _inputCount;
-        } else {
-            _split pushBack (_input select [_index, _find]);
-            _index = _index + _find;
-        };
+    if (_found == -1) exitWith {
+        _split pushBack (_input select [_index]);
     };
-};
 
-// Handle split at end
-if ((_inputCount >= _separatorCount) && _lastWasSeperator && {(_input select [(_inputCount - _separatorCount)]) isEqualTo _separator}) then {
-    _split pushBack "";
+    _split pushBack (_input select [_index, _found - _index]);
+
+    _index = _found + _separatorCount;
 };
 
 _split // return

--- a/addons/strings/fnc_strLen.sqf
+++ b/addons/strings/fnc_strLen.sqf
@@ -4,12 +4,13 @@ Function: CBA_fnc_strLen
 
 Description:
     Counts the number of characters in a string.
+    Reliably supports strings with ANSI characters only.
 
 Parameters:
-    _string - String to measure [String]
+    _string - String to measure <STRING>
 
 Returns:
-    Number of characters in string [Number]
+    Number of characters in string <SCALAR>
 
 Examples:
     (begin example)

--- a/addons/strings/fnc_substr.sqf
+++ b/addons/strings/fnc_substr.sqf
@@ -30,7 +30,9 @@ SCRIPT(substr);
 params ["_string", "_startIndex", ["_length", 0]];
 
 // Check if _length is set else extract string to end
-if (_length <= 0) exitWith {_string select [_startIndex]};
+if (_length <= 0) exitWith {
+    _string select [_startIndex] // return
+};
 
 // Cut out string
 _string select [_startIndex, _length] // return

--- a/addons/strings/fnc_substr.sqf
+++ b/addons/strings/fnc_substr.sqf
@@ -4,16 +4,17 @@ Function: CBA_fnc_substr
 
 Description:
     Retrieves a substring of this instance.
-
     The substring starts at a specified character position and has a specified length.
 
+    Reliably supports strings with ANSI characters only.
+
 Parameters:
-    _string - String to extract from [String]
-    _startIndex - Index to start the substring extraction [Number]
-    _length - length of the extracted substring [Number](Optional) if is not set than from _startIndex to end
+    _string     - String to extract from <STRING>
+    _startIndex - Index to start the substring extraction <SCALAR>
+    _length     - Length of the extracted substring, <= 0 means whole string is selected (optional, default: 0) <SCALAR>
 
 Returns:
-    String extracted [String]
+    Extracted string <STRING>
 
 Example:
     (begin example)
@@ -26,10 +27,10 @@ Author:
 --------------------------------------------------------------------------- */
 SCRIPT(substr);
 
-params ["_string", "_startIndex", "_length"];
+params ["_string", "_startIndex", ["_length", 0]];
 
 // Check if _length is set else extract string to end
-if (isNil "_length" || {_length <= 0}) exitWith {_string select [_startIndex];};
+if (_length <= 0) exitWith {_string select [_startIndex]};
 
-// Cut out String
+// Cut out string
 _string select [_startIndex, _length] // return

--- a/addons/strings/fnc_substring.sqf
+++ b/addons/strings/fnc_substring.sqf
@@ -4,14 +4,15 @@ Function: CBA_fnc_substring
 
 Description:
     Extracts the index-based substring from a string.
+    Reliably supports strings with ANSI characters only.
 
 Parameters:
-    _string - String to extract from [String]
-    _startIndex - Index to start the substring extraction [Number]
-    _endIndex - Index to end the substring extraction [Number]
+    _string     - String to extract from <STRING>
+    _startIndex - Index to start the substring extraction <SCALAR>
+    _endIndex   - Index to end the substring extraction <SCALAR>
 
 Returns:
-    String extracted [String]
+    Extracted string <STRING>
 
 Example:
     (begin example)
@@ -26,11 +27,11 @@ SCRIPT(substring);
 
 params ["_string", "_startIndex", "_endIndex"];
 
-// Check if _start is Larger than _endIndex to Prevent Issues
+// Check if _start is larger than _endIndex to prevent issues
 if (_startIndex > _endIndex) exitWith {""};
 
-// Calculate Differenz between _start and _end for select lenth value
+// Calculate difference between _start and _end for select length value
 _endIndex = _endIndex + 1 - _startIndex;
 
-// Cut out String
+// Cut out string
 _string select [_startIndex, _endIndex] // return

--- a/addons/strings/fnc_trim.sqf
+++ b/addons/strings/fnc_trim.sqf
@@ -8,11 +8,11 @@ Description:
     See <CBA_fnc_leftTrim> and <CBA_fnc_rightTrim>.
 
 Parameters:
-    _string - String to trim [String]
-    _trim - Characters to trim [String] (default: "")
+    _string - String to trim <STRING>
+    _trim   - Characters to trim (optional, default: "") <STRING>
 
 Returns:
-    Trimmed string [String]
+    Trimmed string <STRING>
 
 Example:
     (begin example)
@@ -25,8 +25,13 @@ Author:
 ---------------------------------------------------------------------------- */
 SCRIPT(trim);
 
+forceUnicode 0;
+
 params ["_string", ["_trim", "", [""]]];
 
-_string = [_string, _trim] call CBA_fnc_rightTrim;
+// Trim all whitespace characters by default
+if (_trim == "") exitWith {
+    trim _string // return
+};
 
-[_string, _trim] call CBA_fnc_leftTrim
+_string trim [_trim, 0] // return

--- a/addons/strings/fnc_trim.sqf
+++ b/addons/strings/fnc_trim.sqf
@@ -25,8 +25,6 @@ Author:
 ---------------------------------------------------------------------------- */
 SCRIPT(trim);
 
-forceUnicode 0;
-
 params ["_string", ["_trim", "", [""]]];
 
 // Trim all whitespace characters by default

--- a/addons/strings/test_strings.sqf
+++ b/addons/strings/test_strings.sqf
@@ -115,6 +115,27 @@ TEST_OP(_str,==,"Teast",_fn);
 _str = ["Mörser", "ö", "oe"] call CBA_fnc_replace;
 TEST_OP(_str,==,"Moerser",_fn);
 
+// What is searched for is a literal, not a pattern
+_str = ["a.b.c", ".", "-"] call CBA_fnc_replace;
+TEST_OP(_str,==,"a-b-c",_fn);
+
+_str = ["a|b", "|", "-"] call CBA_fnc_replace;
+TEST_OP(_str,==,"a-b",_fn);
+
+// And so is what it is replaced with
+_str = ["aaa", "a", "$&"] call CBA_fnc_replace;
+TEST_OP(_str,==,"$&$&$&",_fn);
+
+_str = ["cost 5", "5", "$5"] call CBA_fnc_replace;
+TEST_OP(_str,==,"cost $5",_fn);
+
+_str = ["path", "path", "C:\dir\file"] call CBA_fnc_replace;
+TEST_OP(_str,==,"C:\dir\file",_fn);
+
+// Case-dependent
+_str = ["Fish FRO frog", "fro", "pi"] call CBA_fnc_replace;
+TEST_OP(_str,==,"Fish FRO pig",_fn);
+
 // ----------------------------------------------------------------------------
 // UNIT TESTS (leftTrim)
 _fn = "CBA_fnc_leftTrim";


### PR DESCRIPTION
**When merged this pull request will:**
- Replace https://github.com/CBATeam/CBA_A3/pull/1592

All tests passing. Modified implementations (replace and split) are faster. 2.2x on split, replace speed improvements scale with length/matches. sanitizeHTML and decodeURL get faster due to using replace in implementation.

Probably add HEMTT lints for below eventually as they can be trivially replaced by engine commands?

| CBA function | engine equivalent | fires when |
|---|---|---|
| `CBA_fnc_strLen` | `count _string` | always — body is `count (_this select 0)` |
| `CBA_fnc_trim` | `trim _string` | no trim pattern passed, or `""` |
| `CBA_fnc_trim` | `_string trim [_chars, 0]` | trim pattern passed |
| `CBA_fnc_leftTrim` | `_string trim [_chars, 1]` | trim pattern passed (default is whitespace) |
| `CBA_fnc_rightTrim` | `_string trim [_chars, 2]` | trim pattern passed (default is whitespace) |
| `CBA_fnc_find` | `_haystack find [_needle, _index]` | both args are known strings — CBA's only extra is returning -1 for non-string input |
| `CBA_fnc_substr` | `_string select [_start]` | no length, or length <= 0 |
| `CBA_fnc_substr` | `_string select [_start, _length]` | length > 0 |
| `CBA_fnc_substring` | `_string select [_start, _end + 1 - _start]` | always — CBA takes an inclusive end index, `select` takes a length |
| `CBA_fnc_floatToString` | `toFixed` | always — the function's own header already says DEPRECATED |