### PR TITLE
Common - Add alive check to `turretDir`

### DIFF
--- a/addons/common/fnc_turretDir.sqf
+++ b/addons/common/fnc_turretDir.sqf
@@ -27,6 +27,8 @@ SCRIPT(turretDir);
 
 params [["_vehicle", objNull, [objNull]], ["_turret", [-1], [[]]], ["_relativeToModel", false, [false]]];
 
+if (!alive _vehicle) exitWith {};
+
 private _turretConfig = [_vehicle, _turret] call CBA_fnc_getTurret;
 
 private _gunBeg = _vehicle selectionPosition getText (_turretConfig >> "gunBeg");

--- a/addons/common/fnc_turretDir.sqf
+++ b/addons/common/fnc_turretDir.sqf
@@ -27,7 +27,7 @@ SCRIPT(turretDir);
 
 params [["_vehicle", objNull, [objNull]], ["_turret", [-1], [[]]], ["_relativeToModel", false, [false]]];
 
-if (!alive _vehicle) exitWith {};
+if (!alive _vehicle) exitWith { [0,0] };
 
 private _turretConfig = [_vehicle, _turret] call CBA_fnc_getTurret;
 


### PR DESCRIPTION
**When merged this pull request will:**
- When using OCAP, it runs `CBA_fnc_turretDir` on a loop using `vehicles` as it's forEach, the function works fine for alive vehicles, but with dead it will always return:
> [CBA] (common) WARNING: Vehicle I_APC_Wheeled_03_cannon_F has invalid gun configs on turret [0]