### PR TITLE
Events - Guard raises made before the events addon preInit

### DIFF
--- a/addons/keybinding/fnc_addKeybind.sqf
+++ b/addons/keybinding/fnc_addKeybind.sqf
@@ -194,6 +194,7 @@ GVAR(actions) setVariable [_action, [_displayName, _tooltip, _keybinds, _default
 // this can run before the events addon preInit has made the registry; no handler can be
 // listening yet either, so the raise is a no-op
 if (!isNil QEGVAR(events,eventNamespace)) then {
+    // Emit an event that a key has been registered.
     [QGVAR(registerKeybind), _this] call CBA_fnc_localEvent;
 };
 

--- a/addons/keybinding/fnc_addKeybind.sqf
+++ b/addons/keybinding/fnc_addKeybind.sqf
@@ -191,7 +191,10 @@ GVAR(actions) setVariable [_action, [_displayName, _tooltip, _keybinds, _default
     };
 } forEach _keybinds;
 
-// Emit an event that a key has been registered.
-[QGVAR(registerKeybind), _this] call CBA_fnc_localEvent;
+// this can run before the events addon preInit has made the registry; no handler can be
+// listening yet either, so the raise is a no-op
+if (!isNil QEGVAR(events,eventNamespace)) then {
+    [QGVAR(registerKeybind), _this] call CBA_fnc_localEvent;
+};
 
 _keybind // only return the last keybind for bwc

--- a/addons/settings/fnc_init.sqf
+++ b/addons/settings/fnc_init.sqf
@@ -241,10 +241,14 @@ if (!isNil "_settingInfo") then {
 };
 
 // --- refresh
-if (isServer) then {
-    [QGVAR(refreshSetting), _setting] call CBA_fnc_globalEvent;
-} else {
-    [QGVAR(refreshSetting), _setting] call CBA_fnc_localEvent;
+// this can run before the events addon preInit has made the registry; no handler can be
+// listening yet either, so the raise is a no-op
+if (!isNil QEGVAR(events,eventNamespace)) then {
+    if (isServer) then {
+        [QGVAR(refreshSetting), _setting] call CBA_fnc_globalEvent;
+    } else {
+        [QGVAR(refreshSetting), _setting] call CBA_fnc_localEvent;
+    };
 };
 
 if (_needRestart) then {


### PR DESCRIPTION
CBA_fnc_addKeybind and CBA_fnc_addSetting can both be called from another addon's own preInit, which is not guaranteed to run after the events addon's preInit has created the event registry. When that registry is nil, CALL_EVENT's forEach +(getVariable [event, []]) does not fall back to [] (the default only applies when the variable is missing, not when the namespace itself is nil), and the raise crashes with a 'Not a Number, expected Array,HashMap' error.

Guard both raises the same way the three existing early-raise sites already do.
